### PR TITLE
Add employer address and phone fields to employment forms

### DIFF
--- a/frontend/src/pages/PurchaseApplication.js
+++ b/frontend/src/pages/PurchaseApplication.js
@@ -3503,6 +3503,26 @@ export default function PurchaseApplication() {
               placeholder="Start typing company name..."
               className="fun-input-wrapper"
             />
+            <div className="form-group">
+              <label>Employer Address</label>
+              <input
+                type="text"
+                value={currentIncomeDataState.employerAddress || ''}
+                onChange={(e) => setCurrentIncomeData(prev => ({ ...prev, employerAddress: e.target.value }))}
+                className="fun-input"
+                placeholder="Auto-filled from employer selection"
+              />
+            </div>
+            <div className="form-group">
+              <label>Employer Phone</label>
+              <input
+                type="tel"
+                value={currentIncomeDataState.employerPhone || ''}
+                onChange={(e) => setCurrentIncomeData(prev => ({ ...prev, employerPhone: e.target.value }))}
+                className="fun-input"
+                placeholder="Auto-filled from employer selection"
+              />
+            </div>
             <div className="form-row">
               <div className="form-group">
                 <label>Job Title</label>

--- a/frontend/src/pages/RefinanceApplication.js
+++ b/frontend/src/pages/RefinanceApplication.js
@@ -2285,6 +2285,26 @@ export default function RefinanceApplication() {
               placeholder="Start typing company name..."
               className="fun-input-wrapper"
             />
+            <div className="form-group">
+              <label>Employer Address</label>
+              <input
+                type="text"
+                value={incomeData.employerAddress || ''}
+                onChange={(e) => setIncomeData(prev => ({ ...prev, employerAddress: e.target.value }))}
+                className="fun-input"
+                placeholder="Auto-filled from employer selection"
+              />
+            </div>
+            <div className="form-group">
+              <label>Employer Phone</label>
+              <input
+                type="tel"
+                value={incomeData.employerPhone || ''}
+                onChange={(e) => setIncomeData(prev => ({ ...prev, employerPhone: e.target.value }))}
+                className="fun-input"
+                placeholder="Auto-filled from employer selection"
+              />
+            </div>
             <div className="form-row">
               <div className="form-group">
                 <label>Job Title</label>


### PR DESCRIPTION
Both Purchase and Refinance application forms now display employer address and phone number fields that are auto-filled when the user selects an employer from the Google Places autocomplete dropdown. Fields remain editable for manual entry or corrections.