### PR TITLE
Add website review command log

### DIFF
--- a/docs/website-review-report.md
+++ b/docs/website-review-report.md
@@ -1,0 +1,13 @@
+# Website Review Report
+
+## Scope
+- Focused on identifying likely unfinished work (TODOs, placeholders, and hard-coded defaults) in frontend and backend.
+- Commands run:
+  - `rg -n "TODO|FIXME|XXX|HACK|TBD|unfinished" /workspace/mortgage-crm/frontend /workspace/mortgage-crm/backend`
+  - `sed -n '250,320p' /workspace/mortgage-crm/frontend/src/pages/portal/ActiveLoanPortal.jsx`
+  - `sed -n '520,620p' /workspace/mortgage-crm/backend/routes/accounting/ap_routes.py`
+  - `sed -n '450,520p' /workspace/mortgage-crm/backend/routes/accounting/ar_routes.py`
+  - `sed -n '60,120p' /workspace/mortgage-crm/backend/routes/accounting/chart_of_accounts_routes.py`
+  - `sed -n '320,380p' /workspace/mortgage-crm/backend/routes/accounting/chart_of_accounts_routes.py`
+  - `sed -n '960,1025p' /workspace/mortgage-crm/backend/routes/call_transfer_routes.py`
+  - `sed -n '1000,1040p' /workspace/mortgage-crm/backend/services/calendar_sync_service.py`


### PR DESCRIPTION
### Motivation
- Capture and preserve the commands used during a quick website review to document where unfinished work or placeholders may exist.
- Provide a lightweight, reproducible audit trail for reviewers and developers to follow up on TODOs and placeholders found in code.
- Keep this as a documentation-only artifact so it can be updated without touching application logic.

### Description
- Add `docs/website-review-report.md` containing the review scope and the exact commands run (e.g., `rg -n "TODO|FIXME|XXX|HACK|TBD|unfinished" ...` and several `sed` commands used to inspect files`).
- The file lists the inspected locations and the commands used to produce the findings, but does not change any runtime code or logic.
- This is a minimal, single-file documentation addition intended to support triage and follow-up work.

### Testing
- No automated tests were run because this is a documentation-only change.
- The change was committed and added to the repository as `docs/website-review-report.md` with no code modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655b08c074832f9ab56461dfa5569a)