### PR TITLE
Add Morning Briefing preferences customization

### DIFF
--- a/backend/database/init_db.py
+++ b/backend/database/init_db.py
@@ -1746,6 +1746,14 @@ def init_db():
         except Exception as e:
             logger.warning(f"⚠️ campaign template seed note: {e}")
 
+        # Add briefing_preferences JSONB column to users
+        try:
+            from migrations.add_briefing_preferences import run_migration as run_briefing_prefs
+            run_briefing_prefs(_engine)
+            logger.info("✅ briefing_preferences column ready")
+        except Exception as e:
+            logger.warning(f"⚠️ briefing_preferences migration note: {e}")
+
         return True
     except Exception as e:
         logger.error(f"❌ Database initialization failed: {e}")

--- a/backend/database/models/core.py
+++ b/backend/database/models/core.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     Column, Integer, String, Float, Boolean, DateTime, Date,
     Text, ForeignKey, JSON, UniqueConstraint, Index
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
 # Import Base from the db module (renamed from database.py)
@@ -125,6 +126,7 @@ class User(Base):
     # Briefing preferences
     briefing_enabled = Column(Boolean, default=True)
     briefing_hour = Column(Integer, default=7)  # 0-23 in user's timezone
+    briefing_preferences = Column(JSONB, nullable=True)  # Section toggles, thresholds, AI tone (NULL = all defaults)
     email_verified = Column(Boolean, default=False)
     onboarding_completed = Column(Boolean, default=False)
     user_metadata = Column(JSON)

--- a/backend/migrations/add_briefing_preferences.py
+++ b/backend/migrations/add_briefing_preferences.py
@@ -1,0 +1,31 @@
+"""
+Migration: Add briefing_preferences JSONB column to users table.
+
+Stores user customization for morning briefings: section toggles,
+detection thresholds, and AI narrative tone. NULL = all defaults.
+"""
+
+import logging
+from sqlalchemy import text
+
+logger = logging.getLogger(__name__)
+
+
+def run_migration(engine):
+    """Add briefing_preferences column to users if it doesn't exist."""
+    with engine.connect() as conn:
+        result = conn.execute(text("""
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = 'users'
+              AND column_name = 'briefing_preferences'
+        """))
+        if result.fetchone():
+            logger.info("Column briefing_preferences already exists on users, skipping")
+            return
+
+        conn.execute(text("""
+            ALTER TABLE users ADD COLUMN briefing_preferences JSONB;
+        """))
+        conn.commit()
+        logger.info("Added briefing_preferences JSONB column to users table")

--- a/backend/routes/briefing_routes.py
+++ b/backend/routes/briefing_routes.py
@@ -14,6 +14,8 @@ import logging
 from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
 
+from typing import Dict, Literal, Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, Field
@@ -33,9 +35,30 @@ def _get_deps():
 
 # --- Schemas ---
 
-class BriefingPreferences(BaseModel):
+class BriefingSections(BaseModel):
+    pipeline: bool = True
+    at_risk: bool = True
+    stale_leads: bool = True
+    appointments: bool = True
+    conditions: bool = True
+    yesterday: bool = True
+
+
+class BriefingThresholds(BaseModel):
+    at_risk_days: int = Field(default=10, ge=1, le=30)
+    stale_lead_days: int = Field(default=7, ge=1, le=30)
+    stale_lead_high_score_days: int = Field(default=3, ge=1, le=14)
+    lock_expiring_days: int = Field(default=3, ge=1, le=14)
+    max_at_risk_items: int = Field(default=10, ge=1, le=20)
+    max_stale_lead_items: int = Field(default=10, ge=1, le=20)
+
+
+class BriefingPreferencesSchema(BaseModel):
     briefing_enabled: bool = True
     briefing_hour: int = Field(ge=0, le=23, default=7)
+    sections: BriefingSections = BriefingSections()
+    thresholds: BriefingThresholds = BriefingThresholds()
+    ai_tone: Literal["concise", "balanced", "detailed"] = "balanced"
 
 
 class BriefingResponse(BaseModel):
@@ -75,11 +98,11 @@ async def get_today_briefing(db: Session = Depends(get_db),
     """Get current user's briefing for today."""
     MorningBriefing, _ = _get_deps()
 
-    user_tz = getattr(current_user, "timezone", None) or "America/New_York"
+    user_tz = getattr(current_user, "timezone", None) or "America/Chicago"
     try:
         tz = ZoneInfo(user_tz)
     except Exception:
-        tz = ZoneInfo("America/New_York")
+        tz = ZoneInfo("America/Chicago")
 
     today = datetime.now(tz).date()
 
@@ -159,11 +182,11 @@ async def generate_now(
     MorningBriefing, _ = _get_deps()
     from services.morning_briefing_service import MorningBriefingService
 
-    user_tz = getattr(current_user, "timezone", None) or "America/New_York"
+    user_tz = getattr(current_user, "timezone", None) or "America/Chicago"
     try:
         tz = ZoneInfo(user_tz)
     except Exception:
-        tz = ZoneInfo("America/New_York")
+        tz = ZoneInfo("America/Chicago")
 
     today = datetime.now(tz).date()
     level = MorningBriefingService.determine_level(current_user)
@@ -216,27 +239,50 @@ async def get_preferences(
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    """Get briefing preferences."""
+    """Get briefing preferences (merged with defaults)."""
+    from services.morning_briefing_service import MorningBriefingService
+    prefs = MorningBriefingService.load_preferences(current_user)
     return {
         "briefing_enabled": getattr(current_user, "briefing_enabled", True) if current_user.briefing_enabled is not None else True,
         "briefing_hour": getattr(current_user, "briefing_hour", 7) or 7,
         "timezone": getattr(current_user, "timezone", "America/New_York"),
+        "sections": prefs.sections,
+        "thresholds": prefs.thresholds,
+        "ai_tone": prefs.ai_tone,
     }
 
 
 @router.put("/preferences")
 async def update_preferences(
-    prefs: BriefingPreferences,
+    prefs: BriefingPreferencesSchema,
     db: Session = Depends(get_db),
     current_user=Depends(get_current_user),
 ):
-    """Update briefing preferences."""
+    """Update briefing preferences.
+
+    Split-write: briefing_enabled and briefing_hour go to dedicated User columns
+    (used by Celery dispatch for fast SQL filtering). sections, thresholds, and
+    ai_tone go to user.briefing_preferences JSONB.
+    """
+    # Dedicated columns (fast SQL filtering by Celery dispatch)
     current_user.briefing_enabled = prefs.briefing_enabled
     current_user.briefing_hour = prefs.briefing_hour
+
+    # JSONB column (customization preferences)
+    current_user.briefing_preferences = {
+        "sections": prefs.sections.model_dump(),
+        "thresholds": prefs.thresholds.model_dump(),
+        "ai_tone": prefs.ai_tone,
+    }
     db.commit()
 
+    from services.morning_briefing_service import MorningBriefingService
+    loaded = MorningBriefingService.load_preferences(current_user)
     return {
         "briefing_enabled": current_user.briefing_enabled,
         "briefing_hour": current_user.briefing_hour,
         "timezone": getattr(current_user, "timezone", "America/New_York"),
+        "sections": loaded.sections,
+        "thresholds": loaded.thresholds,
+        "ai_tone": loaded.ai_tone,
     }

--- a/backend/services/morning_briefing_service.py
+++ b/backend/services/morning_briefing_service.py
@@ -432,10 +432,17 @@ class MorningBriefingService:
     # Manager data gathering (Level 2)
     # ------------------------------------------------------------------
 
-    def gather_manager_data(self, db: Session, user_id: int, org_id: int, briefing_date: date) -> Dict:
+    def gather_manager_data(
+        self, db: Session, user_id: int, org_id: int, briefing_date: date,
+        prefs: Optional[BriefingPreferences] = None,
+    ) -> Dict:
         """Gather subordinate roll-up data for manager briefing."""
+        if prefs is None:
+            prefs = BriefingPreferences()
         today = briefing_date
-        three_days = today + timedelta(days=3)
+        lock_cutoff = today + timedelta(days=prefs.thresholds["lock_expiring_days"])
+        at_risk_days = prefs.thresholds["at_risk_days"]
+        lead_days = prefs.thresholds["stale_lead_days"]
 
         try:
             # Get direct reports
@@ -483,11 +490,11 @@ class MorningBriefingService:
                 WHERE loan_officer_id IN ({id_list}) AND organization_id = :oid
                   AND (stage IS NULL OR UPPER(stage) NOT IN ({terminal}))
                   AND (
-                    lock_expiration_date <= :three_days
-                    OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stage_changed_at)) / 86400 > 10
+                    lock_expiration_date <= :lock_cutoff
+                    OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stage_changed_at)) / 86400 > :at_risk_days
                   )
                 GROUP BY loan_officer_id
-            """), {"oid": org_id, "three_days": three_days}).fetchall()
+            """), {"oid": org_id, "lock_cutoff": lock_cutoff, "at_risk_days": at_risk_days}).fetchall()
 
             risk_map = {r[0]: {"count": r[1], "sla_breach": bool(r[2])} for r in at_risk_counts}
 
@@ -497,9 +504,9 @@ class MorningBriefingService:
                 FROM leads
                 WHERE owner_id IN ({id_list}) AND organization_id = :oid
                   AND last_contact IS NOT NULL
-                  AND last_contact < CURRENT_DATE - INTERVAL '7 days'
+                  AND last_contact < CURRENT_DATE - make_interval(days => :lead_days)
                 GROUP BY owner_id
-            """), {"oid": org_id}).fetchall()
+            """), {"oid": org_id, "lead_days": lead_days}).fetchall()
 
             stale_map = {r[0]: r[1] for r in stale_counts}
 
@@ -534,29 +541,29 @@ class MorningBriefingService:
                 WHERE l.loan_officer_id IN ({id_list}) AND l.organization_id = :oid
                   AND (l.stage IS NULL OR UPPER(l.stage) NOT IN ({terminal}))
                   AND (
-                    l.lock_expiration_date <= :three_days
-                    OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - l.stage_changed_at)) / 86400 > 10
+                    l.lock_expiration_date <= :lock_cutoff
+                    OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - l.stage_changed_at)) / 86400 > :at_risk_days
                   )
                 ORDER BY
-                    CASE WHEN l.lock_expiration_date <= :three_days THEN 0 ELSE 1 END,
+                    CASE WHEN l.lock_expiration_date <= :lock_cutoff THEN 0 ELSE 1 END,
                     days DESC
                 LIMIT 5
-            """), {"oid": org_id, "three_days": three_days}).fetchall()
+            """), {"oid": org_id, "lock_cutoff": lock_cutoff, "at_risk_days": at_risk_days}).fetchall()
 
             attention_items = []
             for r in attention:
                 lo_name = report_names.get(r[0], "Unknown")
                 issue_parts = []
-                if r[4] and r[4] <= three_days:
+                if r[4] and r[4] <= lock_cutoff:
                     issue_parts.append(f"{r[2] or 'Unknown'} loan lock expires soon")
-                elif float(r[5] or 0) > 10:
+                elif float(r[5] or 0) > at_risk_days:
                     issue_parts.append(f"{r[2] or 'Unknown'} loan stalled {float(r[5]):.0f} days in {r[3]}")
 
                 attention_items.append({
                     "user_name": lo_name,
                     "loan_number": r[1],
                     "issue": "; ".join(issue_parts) if issue_parts else f"{r[2]} loan needs attention",
-                    "severity": "high" if r[4] and r[4] <= three_days else "medium",
+                    "severity": "high" if r[4] and r[4] <= lock_cutoff else "medium",
                 })
 
             return {"members": members, "attention_items": attention_items}
@@ -569,10 +576,16 @@ class MorningBriefingService:
     # Leadership data gathering (Level 3)
     # ------------------------------------------------------------------
 
-    def gather_leadership_data(self, db: Session, org_id: int, briefing_date: date) -> Dict:
+    def gather_leadership_data(
+        self, db: Session, org_id: int, briefing_date: date,
+        prefs: Optional[BriefingPreferences] = None,
+    ) -> Dict:
         """Gather org-wide roll-up for leadership briefing."""
+        if prefs is None:
+            prefs = BriefingPreferences()
         today = briefing_date
-        three_days = today + timedelta(days=3)
+        lock_cutoff = today + timedelta(days=prefs.thresholds["lock_expiring_days"])
+        at_risk_days = prefs.thresholds["at_risk_days"]
         week_ago = today - timedelta(days=7)
         two_weeks_ago = today - timedelta(days=14)
         terminal = ", ".join(f"'{s}'" for s in TERMINAL_STAGES)
@@ -604,8 +617,8 @@ class MorningBriefingService:
                     COUNT(l.id) as loan_count,
                     COALESCE(SUM(l.amount), 0) as volume,
                     AVG(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - l.stage_changed_at)) / 86400) as avg_days,
-                    COUNT(CASE WHEN l.lock_expiration_date <= :three_days
-                        OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - l.stage_changed_at)) / 86400 > 10
+                    COUNT(CASE WHEN l.lock_expiration_date <= :lock_cutoff
+                        OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - l.stage_changed_at)) / 86400 > :at_risk_days
                         THEN 1 END) as at_risk
                 FROM loans l
                 JOIN users u ON u.id = l.loan_officer_id
@@ -614,7 +627,7 @@ class MorningBriefingService:
                   AND (l.stage IS NULL OR UPPER(l.stage) NOT IN ({terminal}))
                 GROUP BY b.name
                 ORDER BY volume DESC
-            """), {"oid": org_id, "three_days": three_days}).fetchall()
+            """), {"oid": org_id, "lock_cutoff": lock_cutoff, "at_risk_days": at_risk_days}).fetchall()
 
             branch_list = []
             for r in branches:
@@ -626,7 +639,7 @@ class MorningBriefingService:
                     "volume": float(r[2] or 0),
                     "avg_days_in_stage": round(avg_days, 1),
                     "at_risk_count": at_risk,
-                    "health": self.compute_health(at_risk=at_risk, stale_leads=0, sla_breach=avg_days > 10),
+                    "health": self.compute_health(at_risk=at_risk, stale_leads=0, sla_breach=avg_days > at_risk_days),
                 })
 
             # Top org risks
@@ -643,19 +656,19 @@ class MorningBriefingService:
                 WHERE l.organization_id = :oid
                   AND (l.stage IS NULL OR UPPER(l.stage) NOT IN ({terminal}))
                   AND (
-                    l.lock_expiration_date <= :three_days
-                    OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - l.stage_changed_at)) / 86400 > 10
+                    l.lock_expiration_date <= :lock_cutoff
+                    OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - l.stage_changed_at)) / 86400 > :at_risk_days
                   )
                 ORDER BY
-                    CASE WHEN l.lock_expiration_date <= :three_days THEN 0 ELSE 1 END,
+                    CASE WHEN l.lock_expiration_date <= :lock_cutoff THEN 0 ELSE 1 END,
                     days DESC
                 LIMIT 10
-            """), {"oid": org_id, "three_days": three_days}).fetchall()
+            """), {"oid": org_id, "lock_cutoff": lock_cutoff, "at_risk_days": at_risk_days}).fetchall()
 
             risks = []
             for r in top_risks:
                 issue = ""
-                if r[3] and r[3] <= three_days:
+                if r[3] and r[3] <= lock_cutoff:
                     issue = f"Lock expires {r[3].strftime('%m/%d') if hasattr(r[3], 'strftime') else r[3]}"
                 else:
                     issue = f"{float(r[4]):.0f} days in {r[2]}"
@@ -725,11 +738,11 @@ class MorningBriefingService:
 
         # Manager roll-up
         if level == "manager":
-            ctx.team = self.gather_manager_data(db, user_id, org_id, briefing_date)
+            ctx.team = self.gather_manager_data(db, user_id, org_id, briefing_date, prefs)
 
         # Leadership roll-up
         if level == "leadership":
-            ctx.team = self.gather_leadership_data(db, org_id, briefing_date)
+            ctx.team = self.gather_leadership_data(db, org_id, briefing_date, prefs)
 
         return ctx
 

--- a/backend/services/morning_briefing_service.py
+++ b/backend/services/morning_briefing_service.py
@@ -7,6 +7,7 @@ for individual contributors, managers, and leadership.
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -36,6 +37,68 @@ TERMINAL_STAGES = (
 
 LEADERSHIP_ROLES = ("leadership", "admin", "site_admin", "platform_admin")
 MANAGER_ROLES = ("management", "branch_manager", "regional_manager")
+
+# Default preferences (applied when user.briefing_preferences is NULL or keys are missing)
+_DEFAULT_SECTIONS = {
+    "pipeline": True, "at_risk": True, "stale_leads": True,
+    "appointments": True, "conditions": True, "yesterday": True,
+}
+_DEFAULT_THRESHOLDS = {
+    "at_risk_days": 10, "stale_lead_days": 7, "stale_lead_high_score_days": 3,
+    "lock_expiring_days": 3, "max_at_risk_items": 10, "max_stale_lead_items": 10,
+}
+_DEFAULT_AI_TONE = "balanced"
+
+# ------------------------------------------------------------------
+# Briefing preferences (user-customizable)
+# ------------------------------------------------------------------
+
+VALID_AI_TONES = ("concise", "balanced", "detailed")
+
+DEFAULT_BRIEFING_PREFERENCES = {
+    "sections": {
+        "pipeline": True,
+        "at_risk": True,
+        "stale_leads": True,
+        "appointments": True,
+        "conditions": True,
+        "yesterday": True,
+    },
+    "thresholds": {
+        "at_risk_days": 10,
+        "stale_lead_days": 7,
+        "stale_lead_high_score_days": 3,
+        "lock_expiring_days": 3,
+        "max_at_risk_items": 10,
+        "max_stale_lead_items": 10,
+    },
+    "ai_tone": "balanced",
+}
+
+
+@dataclass
+class BriefingPreferences:
+    """Per-user customization for morning briefings."""
+    sections: Dict[str, bool] = field(default_factory=lambda: dict(_DEFAULT_SECTIONS))
+    thresholds: Dict[str, int] = field(default_factory=lambda: dict(_DEFAULT_THRESHOLDS))
+    ai_tone: str = "balanced"  # concise, balanced, detailed
+
+    @classmethod
+    def load(cls, user: Any) -> "BriefingPreferences":
+        """Load preferences from user.briefing_preferences JSONB, merging with defaults."""
+        raw = getattr(user, "briefing_preferences", None) or {}
+
+        sections = dict(_DEFAULT_SECTIONS)
+        sections.update(raw.get("sections") or {})
+
+        thresholds = dict(_DEFAULT_THRESHOLDS)
+        thresholds.update(raw.get("thresholds") or {})
+
+        tone = raw.get("ai_tone", _DEFAULT_AI_TONE)
+        if tone not in ("concise", "balanced", "detailed"):
+            tone = _DEFAULT_AI_TONE
+
+        return cls(sections=sections, thresholds=thresholds, ai_tone=tone)
 
 
 @dataclass
@@ -89,25 +152,70 @@ class MorningBriefingService:
             return "yellow"
         return "green"
 
+    @staticmethod
+    def load_preferences(user: Any) -> "BriefingPreferences":
+        """Load and merge user briefing preferences with defaults.
+
+        Reads user.briefing_preferences (JSONB). Deep-merges with defaults
+        for any missing keys. Returns BriefingPreferences with all fields
+        populated. If NULL, returns all defaults.
+        """
+        raw = getattr(user, "briefing_preferences", None)
+        if not raw or not isinstance(raw, dict):
+            return BriefingPreferences()
+
+        defaults = deepcopy(DEFAULT_BRIEFING_PREFERENCES)
+
+        # Merge sections — only keep known keys
+        merged_sections = dict(defaults["sections"])
+        raw_sections = raw.get("sections")
+        if isinstance(raw_sections, dict):
+            for key in merged_sections:
+                if key in raw_sections and isinstance(raw_sections[key], bool):
+                    merged_sections[key] = raw_sections[key]
+
+        # Merge thresholds — only keep known keys
+        merged_thresholds = dict(defaults["thresholds"])
+        raw_thresholds = raw.get("thresholds")
+        if isinstance(raw_thresholds, dict):
+            for key in merged_thresholds:
+                if key in raw_thresholds and isinstance(raw_thresholds[key], int):
+                    merged_thresholds[key] = raw_thresholds[key]
+
+        # AI tone — validate against allowed values
+        ai_tone = raw.get("ai_tone", "balanced")
+        if ai_tone not in VALID_AI_TONES:
+            ai_tone = "balanced"
+
+        return BriefingPreferences(
+            sections=merged_sections,
+            thresholds=merged_thresholds,
+            ai_tone=ai_tone,
+        )
+
     # ------------------------------------------------------------------
     # Individual data gathering (Level 1)
     # ------------------------------------------------------------------
 
     def gather_individual_data(
         self, db: Session, user_id: int, org_id: int, briefing_date: date, user_tz: str,
+        prefs: Optional[BriefingPreferences] = None,
     ) -> Dict[str, Any]:
-        """Run 6 queries for individual-level briefing data."""
+        """Run queries for individual-level briefing data, respecting section toggles."""
+        if prefs is None:
+            prefs = BriefingPreferences()
+
         today = briefing_date
         yesterday = today - timedelta(days=1)
         week_ahead = today + timedelta(days=7)
-        three_days = today + timedelta(days=3)
+        lock_days = today + timedelta(days=prefs.thresholds["lock_expiring_days"])
 
-        pipeline = self._query_pipeline_snapshot(db, user_id, org_id, week_ahead)
-        at_risk = self._query_at_risk_loans(db, user_id, org_id, three_days)
-        stale_leads = self._query_stale_leads(db, user_id, org_id, today)
-        appointments = self._query_todays_appointments(db, user_id, org_id, today, user_tz)
-        conditions = self._query_pending_conditions(db, user_id, org_id, today)
-        yesterday_activity = self._query_yesterday_activity(db, user_id, org_id, yesterday)
+        pipeline = self._query_pipeline_snapshot(db, user_id, org_id, week_ahead) if prefs.sections.get("pipeline", True) else {"active_count": 0, "total_volume": 0, "closing_soon": 0, "by_stage": {}}
+        at_risk = self._query_at_risk_loans(db, user_id, org_id, lock_days, prefs.thresholds["at_risk_days"], prefs.thresholds["max_at_risk_items"]) if prefs.sections.get("at_risk", True) else []
+        stale_leads = self._query_stale_leads(db, user_id, org_id, today, prefs.thresholds["stale_lead_days"], prefs.thresholds["stale_lead_high_score_days"], prefs.thresholds["max_stale_lead_items"]) if prefs.sections.get("stale_leads", True) else []
+        appointments = self._query_todays_appointments(db, user_id, org_id, today, user_tz) if prefs.sections.get("appointments", True) else []
+        conditions = self._query_pending_conditions(db, user_id, org_id, today) if prefs.sections.get("conditions", True) else []
+        yesterday_activity = self._query_yesterday_activity(db, user_id, org_id, yesterday) if prefs.sections.get("yesterday", True) else {"funded": 0, "new_loans": 0, "conversions": 0}
 
         return {
             "pipeline": pipeline,
@@ -151,7 +259,10 @@ class MorningBriefingService:
             logger.error("Pipeline snapshot query failed: %s", e)
             return {"active_count": 0, "total_volume": 0, "closing_soon": 0, "by_stage": {}}
 
-    def _query_at_risk_loans(self, db: Session, user_id: int, org_id: int, three_days: date) -> List[Dict]:
+    def _query_at_risk_loans(
+        self, db: Session, user_id: int, org_id: int, lock_deadline: date,
+        stage_days: int = 10, limit: int = 10,
+    ) -> List[Dict]:
         """Loans with SLA breaches, expiring locks, or stagnation."""
         terminal = ", ".join(f"'{s}'" for s in TERMINAL_STAGES)
         try:
@@ -164,14 +275,14 @@ class MorningBriefingService:
                 WHERE loan_officer_id = :uid AND organization_id = :oid
                   AND (stage IS NULL OR UPPER(stage) NOT IN ({terminal}))
                   AND (
-                    lock_expiration_date <= :three_days
-                    OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stage_changed_at)) / 86400 > 10
+                    lock_expiration_date <= :lock_deadline
+                    OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stage_changed_at)) / 86400 > :stage_days
                   )
                 ORDER BY
-                    CASE WHEN lock_expiration_date <= :three_days THEN 0 ELSE 1 END,
+                    CASE WHEN lock_expiration_date <= :lock_deadline THEN 0 ELSE 1 END,
                     days_in_stage DESC
-                LIMIT 10
-            """), {"uid": user_id, "oid": org_id, "three_days": three_days}).fetchall()
+                LIMIT :max_items
+            """), {"uid": user_id, "oid": org_id, "lock_deadline": lock_deadline, "stage_days": stage_days, "max_items": limit}).fetchall()
 
             results = []
             for r in rows:
@@ -179,11 +290,11 @@ class MorningBriefingService:
                 days = float(r[6] or 0)
                 sla_target = SLA_TARGETS.get(stage, 7)
                 reason = []
-                if r[5] and r[5] <= three_days:
+                if r[5] and r[5] <= lock_deadline:
                     reason.append(f"Lock expires {r[5].strftime('%m/%d') if hasattr(r[5], 'strftime') else r[5]}")
                 if days > sla_target:
                     reason.append(f"{days:.0f} days in {stage} (SLA: {sla_target})")
-                if days > 10 and not reason:
+                if days > stage_days and not reason:
                     reason.append(f"No movement in {days:.0f} days")
 
                 results.append({
@@ -199,7 +310,10 @@ class MorningBriefingService:
             logger.error("At-risk query failed: %s", e)
             return []
 
-    def _query_stale_leads(self, db: Session, user_id: int, org_id: int, today: date) -> List[Dict]:
+    def _query_stale_leads(
+        self, db: Session, user_id: int, org_id: int, today: date,
+        lead_days: int = 7, high_score_days: int = 3, limit: int = 10,
+    ) -> List[Dict]:
         """Leads with no recent contact, prioritizing high-score leads."""
         try:
             rows = db.execute(sa_text("""
@@ -210,12 +324,12 @@ class MorningBriefingService:
                 WHERE owner_id = :uid AND organization_id = :oid
                   AND last_contact IS NOT NULL
                   AND (
-                    (ai_score >= 70 AND last_contact < CURRENT_DATE - INTERVAL '3 days')
-                    OR last_contact < CURRENT_DATE - INTERVAL '7 days'
+                    (ai_score >= 70 AND last_contact < CURRENT_DATE - make_interval(days => :high_score_days))
+                    OR last_contact < CURRENT_DATE - make_interval(days => :lead_days)
                   )
                 ORDER BY ai_score DESC NULLS LAST, days_silent DESC
-                LIMIT 10
-            """), {"uid": user_id, "oid": org_id}).fetchall()
+                LIMIT :max_items
+            """), {"uid": user_id, "oid": org_id, "high_score_days": high_score_days, "lead_days": lead_days, "max_items": limit}).fetchall()
 
             return [
                 {
@@ -580,11 +694,15 @@ class MorningBriefingService:
 
     def build_context(
         self, db: Session, user: Any, briefing_date: date,
+        prefs: Optional[BriefingPreferences] = None,
     ) -> BriefingContext:
         """Build complete BriefingContext for a user."""
+        if prefs is None:
+            prefs = BriefingPreferences.load(user)
+
         user_id = user.id
         org_id = user.organization_id
-        user_tz = getattr(user, "timezone", None) or "America/New_York"
+        user_tz = getattr(user, "timezone", None) or "America/Chicago"
         user_name = getattr(user, "full_name", None) or f"{user.first_name or ''} {user.last_name or ''}".strip()
         level = self.determine_level(user)
 
@@ -597,7 +715,7 @@ class MorningBriefingService:
         )
 
         # Individual data (all levels get this)
-        individual = self.gather_individual_data(db, user_id, org_id, briefing_date, user_tz)
+        individual = self.gather_individual_data(db, user_id, org_id, briefing_date, user_tz, prefs)
         ctx.pipeline = individual["pipeline"]
         ctx.at_risk = individual["at_risk"]
         ctx.stale_leads = individual["stale_leads"]
@@ -619,33 +737,83 @@ class MorningBriefingService:
     # AI narrative generation
     # ------------------------------------------------------------------
 
-    INDIVIDUAL_SYSTEM_PROMPT = (
-        "You are a senior mortgage pipeline advisor. Given the loan officer's "
-        "current pipeline data, write exactly 3 prioritized actions for today. "
-        "Each priority should name a specific loan/lead, explain WHY it's urgent, "
-        "and state the ONE action to take. Be direct — no pleasantries, no hedging. "
-        "Write in second person (\"You should...\"). Keep total response under 200 words."
-    )
+    # --- Tone-specific system prompts (keyed by level, then tone) ---
 
-    MANAGER_SYSTEM_PROMPT = (
-        "You are a senior mortgage operations advisor. Given a manager's personal "
-        "pipeline and their team's performance data, write exactly 3 priorities. "
-        "Priority 1 should address the most urgent team issue (a subordinate with "
-        "at-risk loans or neglected leads). Priorities 2-3 can be personal pipeline "
-        "items or team items — pick whichever is most urgent. Name specific people "
-        "and loans. Write in second person. Keep total response under 250 words."
-    )
+    _SYSTEM_PROMPTS = {
+        "individual": {
+            "concise": (
+                "You are a senior mortgage pipeline advisor. Given the loan officer's "
+                "current pipeline data, write exactly 3 prioritized actions as short "
+                "bullet points. Each bullet: loan/lead name, why urgent, one action. "
+                "No pleasantries. Second person. Under 100 words total."
+            ),
+            "balanced": (
+                "You are a senior mortgage pipeline advisor. Given the loan officer's "
+                "current pipeline data, write exactly 3 prioritized actions for today. "
+                "Each priority should name a specific loan/lead, explain WHY it's urgent, "
+                "and state the ONE action to take. Be direct — no pleasantries, no hedging. "
+                "Write in second person (\"You should...\"). Keep total response under 200 words."
+            ),
+            "detailed": (
+                "You are a senior mortgage pipeline advisor. Given the loan officer's "
+                "current pipeline data, write exactly 3 prioritized actions for today. "
+                "For each priority: name the specific loan/lead, explain the risk in full "
+                "context (SLA timeline, lock expiry, days silent), recommend the action, "
+                "and note what happens if they don't act. Write in second person. "
+                "Keep total response under 350 words."
+            ),
+        },
+        "manager": {
+            "concise": (
+                "You are a senior mortgage operations advisor. Given a manager's personal "
+                "pipeline and team data, write exactly 3 priorities as short bullet points. "
+                "Priority 1: most urgent team issue. 2-3: personal or team. Name people. "
+                "Second person. Under 120 words."
+            ),
+            "balanced": (
+                "You are a senior mortgage operations advisor. Given a manager's personal "
+                "pipeline and their team's performance data, write exactly 3 priorities. "
+                "Priority 1 should address the most urgent team issue (a subordinate with "
+                "at-risk loans or neglected leads). Priorities 2-3 can be personal pipeline "
+                "items or team items — pick whichever is most urgent. Name specific people "
+                "and loans. Write in second person. Keep total response under 250 words."
+            ),
+            "detailed": (
+                "You are a senior mortgage operations advisor. Given a manager's personal "
+                "pipeline and team data, write exactly 3 priorities with full context. "
+                "Priority 1: most urgent team issue with health indicators and trend. "
+                "Priorities 2-3: personal or team items with SLA context. Name specific "
+                "people, loans, and explain downstream consequences. Second person. "
+                "Keep total response under 400 words."
+            ),
+        },
+        "leadership": {
+            "concise": (
+                "You are a chief strategy advisor for a mortgage lending operation. Given "
+                "org pipeline data and branch performance, write exactly 3 strategic "
+                "priorities as short bullet points. Name branches and top risks. "
+                "Second person. Under 120 words."
+            ),
+            "balanced": (
+                "You are a chief strategy advisor for a mortgage lending operation. Given "
+                "the organization's pipeline data and branch performance, write exactly 3 "
+                "strategic priorities. Focus on trends, branch performance gaps, and "
+                "org-wide risks. Name specific branches and top-risk loans. Do not drill "
+                "into individual LO performance — that's for their managers. Write in "
+                "second person. Keep total response under 250 words."
+            ),
+            "detailed": (
+                "You are a chief strategy advisor for a mortgage lending operation. Given "
+                "org pipeline data and branch performance, write exactly 3 strategic "
+                "priorities with full analysis. Include week-over-week trends, branch "
+                "comparisons, and risk scenarios. Name branches and top-risk loans. "
+                "Do not drill into individual LO performance. Second person. "
+                "Keep total response under 400 words."
+            ),
+        },
+    }
 
-    LEADERSHIP_SYSTEM_PROMPT = (
-        "You are a chief strategy advisor for a mortgage lending operation. Given "
-        "the organization's pipeline data and branch performance, write exactly 3 "
-        "strategic priorities. Focus on trends, branch performance gaps, and "
-        "org-wide risks. Name specific branches and top-risk loans. Do not drill "
-        "into individual LO performance — that's for their managers. Write in "
-        "second person. Keep total response under 250 words."
-    )
-
-    def generate_narrative(self, ctx: BriefingContext) -> Optional[str]:
+    def generate_narrative(self, ctx: BriefingContext, ai_tone: str = "balanced") -> Optional[str]:
         """Generate AI narrative using Anthropic Haiku."""
         try:
             import anthropic
@@ -653,13 +821,13 @@ class MorningBriefingService:
             logger.warning("anthropic package not installed; skipping AI narrative")
             return None
 
-        system_prompt = {
-            "individual": self.INDIVIDUAL_SYSTEM_PROMPT,
-            "manager": self.MANAGER_SYSTEM_PROMPT,
-            "leadership": self.LEADERSHIP_SYSTEM_PROMPT,
-        }.get(ctx.level, self.INDIVIDUAL_SYSTEM_PROMPT)
+        if ai_tone not in ("concise", "balanced", "detailed"):
+            ai_tone = "balanced"
 
-        user_prompt = self._format_context_for_ai(ctx)
+        level_prompts = self._SYSTEM_PROMPTS.get(ctx.level, self._SYSTEM_PROMPTS["individual"])
+        system_prompt = level_prompts.get(ai_tone, level_prompts["balanced"])
+
+        user_prompt = self._format_context_for_ai(ctx, ai_tone)
 
         try:
             import os
@@ -681,19 +849,23 @@ class MorningBriefingService:
             logger.error("AI narrative generation failed: %s", e)
             return None
 
-    def _format_context_for_ai(self, ctx: BriefingContext) -> str:
-        """Format BriefingContext as structured text for the AI prompt."""
+    def _format_context_for_ai(self, ctx: BriefingContext, ai_tone: str = "balanced") -> str:
+        """Format BriefingContext as structured text for the AI prompt.
+
+        Sections with empty data (toggled off via preferences) are omitted.
+        """
         lines = [f"Briefing for {ctx.user_name} on {ctx.briefing_date.isoformat()}"]
         lines.append("")
 
         # Pipeline
         p = ctx.pipeline
-        lines.append(f"PIPELINE: {p.get('active_count', 0)} active loans, "
-                      f"${p.get('total_volume', 0):,.0f} volume, "
-                      f"{p.get('closing_soon', 0)} closing this week")
-        if p.get("by_stage"):
-            for stage, cnt in p["by_stage"].items():
-                lines.append(f"  {stage}: {cnt} loans")
+        if p.get("active_count", 0) > 0 or p.get("total_volume", 0) > 0:
+            lines.append(f"PIPELINE: {p.get('active_count', 0)} active loans, "
+                          f"${p.get('total_volume', 0):,.0f} volume, "
+                          f"{p.get('closing_soon', 0)} closing this week")
+            if p.get("by_stage"):
+                for stage, cnt in p["by_stage"].items():
+                    lines.append(f"  {stage}: {cnt} loans")
 
         # At-risk
         if ctx.at_risk:

--- a/backend/services/morning_briefing_service.py
+++ b/backend/services/morning_briefing_service.py
@@ -750,83 +750,48 @@ class MorningBriefingService:
     # AI narrative generation
     # ------------------------------------------------------------------
 
-    # --- Tone-specific system prompts (keyed by level, then tone) ---
+    # --- Level-specific base system prompts (balanced / default tone) ---
 
-    _SYSTEM_PROMPTS = {
-        "individual": {
-            "concise": (
-                "You are a senior mortgage pipeline advisor. Given the loan officer's "
-                "current pipeline data, write exactly 3 prioritized actions as short "
-                "bullet points. Each bullet: loan/lead name, why urgent, one action. "
-                "No pleasantries. Second person. Under 100 words total."
-            ),
-            "balanced": (
-                "You are a senior mortgage pipeline advisor. Given the loan officer's "
-                "current pipeline data, write exactly 3 prioritized actions for today. "
-                "Each priority should name a specific loan/lead, explain WHY it's urgent, "
-                "and state the ONE action to take. Be direct — no pleasantries, no hedging. "
-                "Write in second person (\"You should...\"). Keep total response under 200 words."
-            ),
-            "detailed": (
-                "You are a senior mortgage pipeline advisor. Given the loan officer's "
-                "current pipeline data, write exactly 3 prioritized actions for today. "
-                "For each priority: name the specific loan/lead, explain the risk in full "
-                "context (SLA timeline, lock expiry, days silent), recommend the action, "
-                "and note what happens if they don't act. Write in second person. "
-                "Keep total response under 350 words."
-            ),
-        },
-        "manager": {
-            "concise": (
-                "You are a senior mortgage operations advisor. Given a manager's personal "
-                "pipeline and team data, write exactly 3 priorities as short bullet points. "
-                "Priority 1: most urgent team issue. 2-3: personal or team. Name people. "
-                "Second person. Under 120 words."
-            ),
-            "balanced": (
-                "You are a senior mortgage operations advisor. Given a manager's personal "
-                "pipeline and their team's performance data, write exactly 3 priorities. "
-                "Priority 1 should address the most urgent team issue (a subordinate with "
-                "at-risk loans or neglected leads). Priorities 2-3 can be personal pipeline "
-                "items or team items — pick whichever is most urgent. Name specific people "
-                "and loans. Write in second person. Keep total response under 250 words."
-            ),
-            "detailed": (
-                "You are a senior mortgage operations advisor. Given a manager's personal "
-                "pipeline and team data, write exactly 3 priorities with full context. "
-                "Priority 1: most urgent team issue with health indicators and trend. "
-                "Priorities 2-3: personal or team items with SLA context. Name specific "
-                "people, loans, and explain downstream consequences. Second person. "
-                "Keep total response under 400 words."
-            ),
-        },
-        "leadership": {
-            "concise": (
-                "You are a chief strategy advisor for a mortgage lending operation. Given "
-                "org pipeline data and branch performance, write exactly 3 strategic "
-                "priorities as short bullet points. Name branches and top risks. "
-                "Second person. Under 120 words."
-            ),
-            "balanced": (
-                "You are a chief strategy advisor for a mortgage lending operation. Given "
-                "the organization's pipeline data and branch performance, write exactly 3 "
-                "strategic priorities. Focus on trends, branch performance gaps, and "
-                "org-wide risks. Name specific branches and top-risk loans. Do not drill "
-                "into individual LO performance — that's for their managers. Write in "
-                "second person. Keep total response under 250 words."
-            ),
-            "detailed": (
-                "You are a chief strategy advisor for a mortgage lending operation. Given "
-                "org pipeline data and branch performance, write exactly 3 strategic "
-                "priorities with full analysis. Include week-over-week trends, branch "
-                "comparisons, and risk scenarios. Name branches and top-risk loans. "
-                "Do not drill into individual LO performance. Second person. "
-                "Keep total response under 400 words."
-            ),
-        },
+    INDIVIDUAL_SYSTEM_PROMPT = (
+        "You are a senior mortgage pipeline advisor. Given the loan officer's "
+        "current pipeline data, write exactly 3 prioritized actions for today. "
+        "Each priority should name a specific loan/lead, explain WHY it's urgent, "
+        "and state the ONE action to take. Be direct — no pleasantries, no hedging. "
+        "Write in second person (\"You should...\"). Keep total response under 200 words."
+    )
+
+    MANAGER_SYSTEM_PROMPT = (
+        "You are a senior mortgage operations advisor. Given a manager's personal "
+        "pipeline and their team's performance data, write exactly 3 priorities. "
+        "Priority 1 should address the most urgent team issue (a subordinate with "
+        "at-risk loans or neglected leads). Priorities 2-3 can be personal pipeline "
+        "items or team items — pick whichever is most urgent. Name specific people "
+        "and loans. Write in second person. Keep total response under 250 words."
+    )
+
+    LEADERSHIP_SYSTEM_PROMPT = (
+        "You are a chief strategy advisor for a mortgage lending operation. Given "
+        "the organization's pipeline data and branch performance, write exactly 3 "
+        "strategic priorities. Focus on trends, branch performance gaps, and "
+        "org-wide risks. Name specific branches and top-risk loans. Do not drill "
+        "into individual LO performance — that's for their managers. Write in "
+        "second person. Keep total response under 250 words."
+    )
+
+    # --- Tone modifier prompts (appended to level base prompts) ---
+
+    TONE_PROMPTS = {
+        "concise": (
+            "FORMAT OVERRIDE: Respond in exactly 3 bullet points. "
+            "Lead with numbers. No filler, no encouragement."
+        ),
+        "detailed": (
+            "FORMAT OVERRIDE: Write 2-3 short paragraphs covering "
+            "priorities, risks, and suggested next actions. Be specific with names and numbers."
+        ),
     }
 
-    def generate_narrative(self, ctx: BriefingContext, ai_tone: str = "balanced") -> Optional[str]:
+    def generate_narrative(self, ctx: BriefingContext, ai_tone: str = "balanced", prefs: Optional[BriefingPreferences] = None) -> Optional[str]:
         """Generate AI narrative using Anthropic Haiku."""
         try:
             import anthropic
@@ -837,10 +802,18 @@ class MorningBriefingService:
         if ai_tone not in ("concise", "balanced", "detailed"):
             ai_tone = "balanced"
 
-        level_prompts = self._SYSTEM_PROMPTS.get(ctx.level, self._SYSTEM_PROMPTS["individual"])
-        system_prompt = level_prompts.get(ai_tone, level_prompts["balanced"])
+        # Select base prompt by level
+        system_prompt = {
+            "individual": self.INDIVIDUAL_SYSTEM_PROMPT,
+            "manager": self.MANAGER_SYSTEM_PROMPT,
+            "leadership": self.LEADERSHIP_SYSTEM_PROMPT,
+        }.get(ctx.level, self.INDIVIDUAL_SYSTEM_PROMPT)
 
-        user_prompt = self._format_context_for_ai(ctx, ai_tone)
+        # Append tone modifier (preserves level-specific context guidance)
+        if ai_tone in self.TONE_PROMPTS:
+            system_prompt = system_prompt + "\n\n" + self.TONE_PROMPTS[ai_tone]
+
+        user_prompt = self._format_context_for_ai(ctx, prefs)
 
         try:
             import os
@@ -862,47 +835,51 @@ class MorningBriefingService:
             logger.error("AI narrative generation failed: %s", e)
             return None
 
-    def _format_context_for_ai(self, ctx: BriefingContext, ai_tone: str = "balanced") -> str:
+    def _format_context_for_ai(self, ctx: BriefingContext, prefs: Optional[BriefingPreferences] = None) -> str:
         """Format BriefingContext as structured text for the AI prompt.
 
-        Sections with empty data (toggled off via preferences) are omitted.
+        Sections with empty data or toggled off via preferences are omitted.
         """
+        if prefs is None:
+            prefs = BriefingPreferences()
+
         lines = [f"Briefing for {ctx.user_name} on {ctx.briefing_date.isoformat()}"]
         lines.append("")
 
         # Pipeline
-        p = ctx.pipeline
-        if p.get("active_count", 0) > 0 or p.get("total_volume", 0) > 0:
-            lines.append(f"PIPELINE: {p.get('active_count', 0)} active loans, "
-                          f"${p.get('total_volume', 0):,.0f} volume, "
-                          f"{p.get('closing_soon', 0)} closing this week")
-            if p.get("by_stage"):
-                for stage, cnt in p["by_stage"].items():
-                    lines.append(f"  {stage}: {cnt} loans")
+        if prefs.sections.get("pipeline", True):
+            p = ctx.pipeline
+            if p.get("active_count", 0) > 0 or p.get("total_volume", 0) > 0:
+                lines.append(f"PIPELINE: {p.get('active_count', 0)} active loans, "
+                              f"${p.get('total_volume', 0):,.0f} volume, "
+                              f"{p.get('closing_soon', 0)} closing this week")
+                if p.get("by_stage"):
+                    for stage, cnt in p["by_stage"].items():
+                        lines.append(f"  {stage}: {cnt} loans")
 
         # At-risk
-        if ctx.at_risk:
+        if prefs.sections.get("at_risk", True) and ctx.at_risk:
             lines.append("")
             lines.append("AT-RISK LOANS:")
             for loan in ctx.at_risk:
                 lines.append(f"  - {loan['borrower']} ({loan['loan_number']}): {loan['reason']}")
 
         # Stale leads
-        if ctx.stale_leads:
+        if prefs.sections.get("stale_leads", True) and ctx.stale_leads:
             lines.append("")
             lines.append("STALE LEADS:")
             for lead in ctx.stale_leads:
                 lines.append(f"  - {lead['name']} (score {lead['score']}): {lead['days_silent']:.0f} days silent")
 
         # Appointments
-        if ctx.appointments:
+        if prefs.sections.get("appointments", True) and ctx.appointments:
             lines.append("")
             lines.append("TODAY'S APPOINTMENTS:")
             for appt in ctx.appointments:
                 lines.append(f"  - {appt['time']} — {appt['attendee']}, {appt['type']}")
 
         # Conditions
-        if ctx.conditions:
+        if prefs.sections.get("conditions", True) and ctx.conditions:
             lines.append("")
             lines.append("PENDING CONDITIONS:")
             for cond in ctx.conditions:
@@ -910,12 +887,13 @@ class MorningBriefingService:
                 lines.append(f"  - {cond['title']} on {cond['loan_number']}{pd}")
 
         # Yesterday
-        y = ctx.yesterday
-        if any(y.get(k, 0) > 0 for k in ("funded", "new_loans", "conversions")):
-            lines.append("")
-            lines.append(f"YESTERDAY: {y.get('funded', 0)} funded, "
-                          f"{y.get('new_loans', 0)} new pipeline, "
-                          f"{y.get('conversions', 0)} lead conversions")
+        if prefs.sections.get("yesterday", True):
+            y = ctx.yesterday
+            if any(y.get(k, 0) > 0 for k in ("funded", "new_loans", "conversions")):
+                lines.append("")
+                lines.append(f"YESTERDAY: {y.get('funded', 0)} funded, "
+                              f"{y.get('new_loans', 0)} new pipeline, "
+                              f"{y.get('conversions', 0)} lead conversions")
 
         # Team data (manager)
         if ctx.level == "manager" and ctx.team:

--- a/backend/tasks/morning_briefing_tasks.py
+++ b/backend/tasks/morning_briefing_tasks.py
@@ -56,13 +56,13 @@ def dispatch_briefings():
 
         for row in candidates:
             user_id, user_tz, briefing_hour, perm_role, org_id = (
-                row[0], row[1] or "America/New_York", row[2] or 7, row[3] or "sales", row[4],
+                row[0], row[1] or "America/Chicago", row[2] or 7, row[3] or "sales", row[4],
             )
 
             try:
                 tz = ZoneInfo(user_tz)
             except Exception:
-                tz = ZoneInfo("America/New_York")
+                tz = ZoneInfo("America/Chicago")
 
             local_now = now_utc.astimezone(tz)
             local_hour = local_now.hour
@@ -191,9 +191,12 @@ def generate_user_briefing(self, user_id: int, briefing_date_str: str, briefing_
                 return {"status": "already_exists"}
             raise
 
+        # Load user preferences (NULL = all defaults)
+        prefs = MorningBriefingService.load_preferences(user)
+
         # Gather data
         service = MorningBriefingService()
-        ctx = service.build_context(db, user, briefing_date)
+        ctx = service.build_context(db, user, briefing_date, prefs)
 
         briefing.briefing_data = {
             "pipeline": ctx.pipeline,
@@ -208,7 +211,7 @@ def generate_user_briefing(self, user_id: int, briefing_date_str: str, briefing_
 
         # Generate AI narrative
         ai_start = time.time()
-        narrative = service.generate_narrative(ctx)
+        narrative = service.generate_narrative(ctx, prefs.ai_tone, prefs)
         ai_duration = (time.time() - ai_start) * 1000
         briefing.ai_narrative = narrative
 

--- a/backend/tests/test_briefing_preferences.py
+++ b/backend/tests/test_briefing_preferences.py
@@ -73,3 +73,33 @@ class TestLoadPreferences:
         prefs = self._load({"unknown_key": "whatever", "sections": {"fake": True}})
         assert prefs.ai_tone == "balanced"
         assert "fake" not in prefs.sections
+
+
+class TestTonePrompts:
+    """Test that AI tone selection produces different system prompts."""
+
+    def _get_prompts(self):
+        from services.morning_briefing_service import MorningBriefingService
+        return {
+            "concise": MorningBriefingService.TONE_PROMPTS["concise"],
+            "balanced": MorningBriefingService.INDIVIDUAL_SYSTEM_PROMPT,
+            "detailed": MorningBriefingService.TONE_PROMPTS["detailed"],
+        }
+
+    def test_concise_prompt_exists(self):
+        prompts = self._get_prompts()
+        assert "bullet" in prompts["concise"].lower()
+
+    def test_detailed_prompt_exists(self):
+        prompts = self._get_prompts()
+        assert "paragraph" in prompts["detailed"].lower()
+
+    def test_balanced_is_default_individual(self):
+        prompts = self._get_prompts()
+        assert "3 prioritized actions" in prompts["balanced"]
+
+    def test_tone_prompts_are_modifiers(self):
+        """Tone prompts should be appended to level prompts, not replace them."""
+        prompts = self._get_prompts()
+        assert not prompts["concise"].startswith("You are")
+        assert not prompts["detailed"].startswith("You are")

--- a/backend/tests/test_briefing_preferences.py
+++ b/backend/tests/test_briefing_preferences.py
@@ -1,0 +1,75 @@
+"""Tests for BriefingPreferences loading and merging."""
+import pytest
+
+
+class MockUser:
+    """Minimal mock for User model."""
+    def __init__(self, briefing_preferences=None):
+        self.briefing_preferences = briefing_preferences
+
+
+class TestLoadPreferences:
+    """Test MorningBriefingService.load_preferences()."""
+
+    def _load(self, raw_prefs=None):
+        from services.morning_briefing_service import MorningBriefingService
+        user = MockUser(briefing_preferences=raw_prefs)
+        return MorningBriefingService.load_preferences(user)
+
+    def test_null_returns_all_defaults(self):
+        prefs = self._load(None)
+        assert prefs.ai_tone == "balanced"
+        assert prefs.sections["pipeline"] is True
+        assert prefs.sections["at_risk"] is True
+        assert prefs.sections["stale_leads"] is True
+        assert prefs.sections["appointments"] is True
+        assert prefs.sections["conditions"] is True
+        assert prefs.sections["yesterday"] is True
+        assert prefs.thresholds["at_risk_days"] == 10
+        assert prefs.thresholds["stale_lead_days"] == 7
+        assert prefs.thresholds["stale_lead_high_score_days"] == 3
+        assert prefs.thresholds["lock_expiring_days"] == 3
+        assert prefs.thresholds["max_at_risk_items"] == 10
+        assert prefs.thresholds["max_stale_lead_items"] == 10
+
+    def test_partial_sections_fills_defaults(self):
+        prefs = self._load({"sections": {"pipeline": False}})
+        assert prefs.sections["pipeline"] is False
+        assert prefs.sections["at_risk"] is True
+        assert prefs.thresholds["at_risk_days"] == 10
+
+    def test_partial_thresholds_fills_defaults(self):
+        prefs = self._load({"thresholds": {"at_risk_days": 20}})
+        assert prefs.thresholds["at_risk_days"] == 20
+        assert prefs.thresholds["stale_lead_days"] == 7
+
+    def test_ai_tone_preserved(self):
+        prefs = self._load({"ai_tone": "concise"})
+        assert prefs.ai_tone == "concise"
+
+    def test_ai_tone_invalid_falls_back(self):
+        prefs = self._load({"ai_tone": "verbose"})
+        assert prefs.ai_tone == "balanced"
+
+    def test_full_override(self):
+        full = {
+            "sections": {
+                "pipeline": False, "at_risk": False, "stale_leads": False,
+                "appointments": True, "conditions": True, "yesterday": False,
+            },
+            "thresholds": {
+                "at_risk_days": 5, "stale_lead_days": 14,
+                "stale_lead_high_score_days": 7, "lock_expiring_days": 7,
+                "max_at_risk_items": 5, "max_stale_lead_items": 5,
+            },
+            "ai_tone": "detailed",
+        }
+        prefs = self._load(full)
+        assert prefs.sections["pipeline"] is False
+        assert prefs.thresholds["at_risk_days"] == 5
+        assert prefs.ai_tone == "detailed"
+
+    def test_unknown_keys_ignored(self):
+        prefs = self._load({"unknown_key": "whatever", "sections": {"fake": True}})
+        assert prefs.ai_tone == "balanced"
+        assert "fake" not in prefs.sections

--- a/docs/superpowers/plans/2026-03-25-briefing-preferences.md
+++ b/docs/superpowers/plans/2026-03-25-briefing-preferences.md
@@ -1,0 +1,1057 @@
+# Morning Briefing Preferences Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users customize their morning briefing — toggle sections on/off, adjust detection thresholds, and choose an AI narrative tone.
+
+**Architecture:** JSONB column `briefing_preferences` on the existing User model stores sections/thresholds/ai_tone. NULL = all defaults. The service deep-merges stored prefs with defaults, then uses them to gate queries and parameterize thresholds. Frontend expands the existing MorningBriefingSettings component in Settings.js.
+
+**Tech Stack:** FastAPI, SQLAlchemy (PostgreSQL JSONB), Pydantic v2, React (functional components), Celery
+
+**Spec:** `docs/superpowers/specs/2026-03-25-briefing-preferences-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `backend/database/models/core.py` | Add `briefing_preferences` JSONB column to User |
+| `backend/migrations/add_briefing_preferences.py` | ALTER TABLE migration |
+| `backend/services/morning_briefing_service.py` | BriefingPreferences dataclass, `load_preferences()`, parameterized queries, section gating, tone-based prompts |
+| `backend/routes/briefing_routes.py` | Expanded Pydantic schemas, updated GET/PUT preferences endpoints |
+| `backend/tasks/morning_briefing_tasks.py` | Pass loaded preferences through to service |
+| `frontend/src/pages/Settings.js` | Expand MorningBriefingSettings with sections, thresholds, tone UI |
+| `backend/tests/test_briefing_preferences.py` | Unit tests for preferences loading, merging, validation |
+
+---
+
+### Task 1: Database — Add `briefing_preferences` JSONB column
+
+**Files:**
+- Modify: `backend/database/models/core.py:122-127`
+- Create: `backend/migrations/add_briefing_preferences.py`
+
+- [ ] **Step 1: Add JSONB column to User model**
+
+In `backend/database/models/core.py`, add the import and column. The column goes after `briefing_hour` (line 124):
+
+```python
+# At top of file, add to imports:
+from sqlalchemy.dialects.postgresql import JSONB
+
+# After line 124 (briefing_hour), add:
+    briefing_preferences = Column(JSONB, nullable=True)  # NULL = all defaults
+```
+
+The existing import line (line 15-18) has:
+```python
+from sqlalchemy import (
+    Column, Integer, String, Float, Boolean, DateTime, Date,
+    Text, ForeignKey, JSON, UniqueConstraint, Index
+)
+```
+Add a new import line below it:
+```python
+from sqlalchemy.dialects.postgresql import JSONB
+```
+
+- [ ] **Step 2: Create migration script**
+
+Create `backend/migrations/add_briefing_preferences.py`:
+
+```python
+"""
+Migration: Add briefing_preferences JSONB column to users table.
+
+Stores user customization for morning briefings: section toggles,
+detection thresholds, and AI narrative tone. NULL = all defaults.
+"""
+
+import logging
+from sqlalchemy import text
+
+logger = logging.getLogger(__name__)
+
+
+def run_migration(engine):
+    """Add briefing_preferences column to users if it doesn't exist."""
+    with engine.connect() as conn:
+        result = conn.execute(text("""
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = 'users'
+              AND column_name = 'briefing_preferences'
+        """))
+        if result.fetchone():
+            logger.info("Column briefing_preferences already exists on users, skipping")
+            return
+
+        conn.execute(text("""
+            ALTER TABLE users ADD COLUMN briefing_preferences JSONB;
+        """))
+        conn.commit()
+        logger.info("Added briefing_preferences JSONB column to users table")
+```
+
+- [ ] **Step 3: Wire migration into startup**
+
+In `backend/database/init_db.py`, add near the end of the migration section (after the last `try/except` migration block, around line ~1715):
+
+```python
+        # Add briefing_preferences JSONB column to users
+        try:
+            from migrations.add_briefing_preferences import run_migration as run_briefing_prefs
+            run_briefing_prefs(_engine)
+            logger.info("✅ briefing_preferences column ready")
+        except Exception as e:
+            logger.warning(f"⚠️ briefing_preferences migration note: {e}")
+```
+
+- [ ] **Step 4: Verify model loads without errors**
+
+Run: `.venv/bin/python3 -c "from database.models.core import User; print('briefing_preferences' in [c.name for c in User.__table__.columns])"`
+(Run from `backend/` directory)
+Expected: `True`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/database/models/core.py backend/migrations/add_briefing_preferences.py backend/database/init_db.py
+git commit -m "feat: add briefing_preferences JSONB column to User model"
+```
+
+---
+
+### Task 2: Service — BriefingPreferences dataclass and `load_preferences()`
+
+**Files:**
+- Modify: `backend/services/morning_briefing_service.py:1-17` (imports/top), add new code after line 38
+- Test: `backend/tests/test_briefing_preferences.py`
+
+- [ ] **Step 1: Write failing tests for load_preferences**
+
+Create `backend/tests/test_briefing_preferences.py`:
+
+```python
+"""Tests for BriefingPreferences loading and merging."""
+import pytest
+
+
+class MockUser:
+    """Minimal mock for User model."""
+    def __init__(self, briefing_preferences=None):
+        self.briefing_preferences = briefing_preferences
+
+
+class TestLoadPreferences:
+    """Test MorningBriefingService.load_preferences()."""
+
+    def _load(self, raw_prefs=None):
+        from services.morning_briefing_service import MorningBriefingService
+        user = MockUser(briefing_preferences=raw_prefs)
+        return MorningBriefingService.load_preferences(user)
+
+    def test_null_returns_all_defaults(self):
+        prefs = self._load(None)
+        assert prefs.ai_tone == "balanced"
+        assert prefs.sections["pipeline"] is True
+        assert prefs.sections["at_risk"] is True
+        assert prefs.sections["stale_leads"] is True
+        assert prefs.sections["appointments"] is True
+        assert prefs.sections["conditions"] is True
+        assert prefs.sections["yesterday"] is True
+        assert prefs.thresholds["at_risk_days"] == 10
+        assert prefs.thresholds["stale_lead_days"] == 7
+        assert prefs.thresholds["stale_lead_high_score_days"] == 3
+        assert prefs.thresholds["lock_expiring_days"] == 3
+        assert prefs.thresholds["max_at_risk_items"] == 10
+        assert prefs.thresholds["max_stale_lead_items"] == 10
+
+    def test_partial_sections_fills_defaults(self):
+        prefs = self._load({"sections": {"pipeline": False}})
+        assert prefs.sections["pipeline"] is False
+        assert prefs.sections["at_risk"] is True  # default
+        assert prefs.thresholds["at_risk_days"] == 10  # default
+
+    def test_partial_thresholds_fills_defaults(self):
+        prefs = self._load({"thresholds": {"at_risk_days": 20}})
+        assert prefs.thresholds["at_risk_days"] == 20
+        assert prefs.thresholds["stale_lead_days"] == 7  # default
+
+    def test_ai_tone_preserved(self):
+        prefs = self._load({"ai_tone": "concise"})
+        assert prefs.ai_tone == "concise"
+
+    def test_ai_tone_invalid_falls_back(self):
+        prefs = self._load({"ai_tone": "verbose"})
+        assert prefs.ai_tone == "balanced"
+
+    def test_full_override(self):
+        full = {
+            "sections": {
+                "pipeline": False, "at_risk": False, "stale_leads": False,
+                "appointments": True, "conditions": True, "yesterday": False,
+            },
+            "thresholds": {
+                "at_risk_days": 5, "stale_lead_days": 14,
+                "stale_lead_high_score_days": 7, "lock_expiring_days": 7,
+                "max_at_risk_items": 5, "max_stale_lead_items": 5,
+            },
+            "ai_tone": "detailed",
+        }
+        prefs = self._load(full)
+        assert prefs.sections["pipeline"] is False
+        assert prefs.thresholds["at_risk_days"] == 5
+        assert prefs.ai_tone == "detailed"
+
+    def test_unknown_keys_ignored(self):
+        prefs = self._load({"unknown_key": "whatever", "sections": {"fake": True}})
+        assert prefs.ai_tone == "balanced"
+        assert "fake" not in prefs.sections
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && ../.venv/bin/python3 -m pytest tests/test_briefing_preferences.py -v`
+Expected: FAIL — `load_preferences` doesn't exist yet
+
+- [ ] **Step 3: Implement BriefingPreferences and load_preferences**
+
+In `backend/services/morning_briefing_service.py`, add after the existing imports (line 12):
+
+```python
+from copy import deepcopy
+```
+
+Then add after the `MANAGER_ROLES` tuple (after line 38), before the `BriefingContext` dataclass:
+
+```python
+# ------------------------------------------------------------------
+# Briefing preferences (user-customizable)
+# ------------------------------------------------------------------
+
+VALID_AI_TONES = ("concise", "balanced", "detailed")
+
+DEFAULT_BRIEFING_PREFERENCES = {
+    "sections": {
+        "pipeline": True,
+        "at_risk": True,
+        "stale_leads": True,
+        "appointments": True,
+        "conditions": True,
+        "yesterday": True,
+    },
+    "thresholds": {
+        "at_risk_days": 10,
+        "stale_lead_days": 7,
+        "stale_lead_high_score_days": 3,
+        "lock_expiring_days": 3,
+        "max_at_risk_items": 10,
+        "max_stale_lead_items": 10,
+    },
+    "ai_tone": "balanced",
+}
+
+
+@dataclass
+class BriefingPreferences:
+    """User-customizable briefing settings."""
+    sections: Dict[str, bool] = field(default_factory=lambda: deepcopy(DEFAULT_BRIEFING_PREFERENCES["sections"]))
+    thresholds: Dict[str, int] = field(default_factory=lambda: deepcopy(DEFAULT_BRIEFING_PREFERENCES["thresholds"]))
+    ai_tone: str = "balanced"
+```
+
+Then add `load_preferences` as a staticmethod on `MorningBriefingService` (after `compute_health`, before `gather_individual_data`):
+
+```python
+    @staticmethod
+    def load_preferences(user: Any) -> BriefingPreferences:
+        """Load and merge user briefing preferences with defaults.
+
+        Reads user.briefing_preferences (JSONB). Deep-merges with defaults
+        for any missing keys. Returns BriefingPreferences with all fields
+        populated. If NULL, returns all defaults.
+        """
+        raw = getattr(user, "briefing_preferences", None)
+        if not raw or not isinstance(raw, dict):
+            return BriefingPreferences()
+
+        defaults = deepcopy(DEFAULT_BRIEFING_PREFERENCES)
+
+        # Merge sections — only keep known keys
+        merged_sections = dict(defaults["sections"])
+        raw_sections = raw.get("sections")
+        if isinstance(raw_sections, dict):
+            for key in merged_sections:
+                if key in raw_sections and isinstance(raw_sections[key], bool):
+                    merged_sections[key] = raw_sections[key]
+
+        # Merge thresholds — only keep known keys
+        merged_thresholds = dict(defaults["thresholds"])
+        raw_thresholds = raw.get("thresholds")
+        if isinstance(raw_thresholds, dict):
+            for key in merged_thresholds:
+                if key in raw_thresholds and isinstance(raw_thresholds[key], int):
+                    merged_thresholds[key] = raw_thresholds[key]
+
+        # AI tone — validate against allowed values
+        ai_tone = raw.get("ai_tone", "balanced")
+        if ai_tone not in VALID_AI_TONES:
+            ai_tone = "balanced"
+
+        return BriefingPreferences(
+            sections=merged_sections,
+            thresholds=merged_thresholds,
+            ai_tone=ai_tone,
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && ../.venv/bin/python3 -m pytest tests/test_briefing_preferences.py -v`
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/morning_briefing_service.py backend/tests/test_briefing_preferences.py
+git commit -m "feat: add BriefingPreferences dataclass and load_preferences()"
+```
+
+---
+
+### Task 3: Service — Parameterize queries and add section gating
+
+**Files:**
+- Modify: `backend/services/morning_briefing_service.py:96-119` (gather_individual_data), `:154-174` (_query_at_risk_loans), `:202-218` (_query_stale_leads), `:321-376` (gather_manager_data at-risk query), `:458-539` (gather_leadership_data at-risk queries), `:581-616` (build_context)
+
+This task has no new tests — it refactors internal query methods to accept parameters. Existing behavior is preserved when defaults are used (backward-compatible).
+
+- [ ] **Step 1: Modify `gather_individual_data` to accept and use `prefs`**
+
+Change the signature and body of `gather_individual_data` (currently lines 96-119):
+
+```python
+    def gather_individual_data(
+        self, db: Session, user_id: int, org_id: int, briefing_date: date, user_tz: str,
+        prefs: Optional['BriefingPreferences'] = None,
+    ) -> Dict[str, Any]:
+        """Run queries for individual-level briefing data. Skips disabled sections."""
+        if prefs is None:
+            prefs = BriefingPreferences()
+
+        today = briefing_date
+        yesterday = today - timedelta(days=1)
+        week_ahead = today + timedelta(days=7)
+        lock_cutoff = today + timedelta(days=prefs.thresholds["lock_expiring_days"])
+
+        pipeline = self._query_pipeline_snapshot(db, user_id, org_id, week_ahead) if prefs.sections["pipeline"] else {"active_count": 0, "total_volume": 0, "closing_soon": 0, "by_stage": {}}
+        at_risk = self._query_at_risk_loans(db, user_id, org_id, lock_cutoff, prefs.thresholds["at_risk_days"], prefs.thresholds["max_at_risk_items"]) if prefs.sections["at_risk"] else []
+        stale_leads = self._query_stale_leads(db, user_id, org_id, today, prefs.thresholds["stale_lead_days"], prefs.thresholds["stale_lead_high_score_days"], prefs.thresholds["max_stale_lead_items"]) if prefs.sections["stale_leads"] else []
+        appointments = self._query_todays_appointments(db, user_id, org_id, today, user_tz) if prefs.sections["appointments"] else []
+        conditions = self._query_pending_conditions(db, user_id, org_id, today) if prefs.sections["conditions"] else []
+        yesterday_activity = self._query_yesterday_activity(db, user_id, org_id, yesterday) if prefs.sections["yesterday"] else {"funded": 0, "new_loans": 0, "conversions": 0}
+
+        return {
+            "pipeline": pipeline,
+            "at_risk": at_risk,
+            "stale_leads": stale_leads,
+            "appointments": appointments,
+            "conditions": conditions,
+            "yesterday": yesterday_activity,
+        }
+```
+
+- [ ] **Step 2: Parameterize `_query_at_risk_loans`**
+
+Change signature from:
+```python
+def _query_at_risk_loans(self, db: Session, user_id: int, org_id: int, three_days: date) -> List[Dict]:
+```
+To:
+```python
+def _query_at_risk_loans(self, db: Session, user_id: int, org_id: int, lock_cutoff: date, at_risk_days: int = 10, max_items: int = 10) -> List[Dict]:
+```
+
+In the SQL query body, replace the hardcoded values:
+- Replace `> 10` with `:at_risk_days` (the `days_in_stage` threshold on line 168)
+- Replace `LIMIT 10` with `LIMIT :max_items` (line 173)
+- Replace the `three_days` variable name with `lock_cutoff` throughout
+- Add `at_risk_days` and `max_items` to the query params dict
+
+The SQL becomes (line 158-174):
+```python
+            rows = db.execute(sa_text(f"""
+                SELECT
+                    id, loan_number, borrower_name, UPPER(stage) as stage,
+                    stage_changed_at, lock_expiration_date,
+                    EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stage_changed_at)) / 86400 as days_in_stage
+                FROM loans
+                WHERE loan_officer_id = :uid AND organization_id = :oid
+                  AND (stage IS NULL OR UPPER(stage) NOT IN ({terminal}))
+                  AND (
+                    lock_expiration_date <= :lock_cutoff
+                    OR EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - stage_changed_at)) / 86400 > :at_risk_days
+                  )
+                ORDER BY
+                    CASE WHEN lock_expiration_date <= :lock_cutoff THEN 0 ELSE 1 END,
+                    days_in_stage DESC
+                LIMIT :max_items
+            """), {"uid": user_id, "oid": org_id, "lock_cutoff": lock_cutoff, "at_risk_days": at_risk_days, "max_items": max_items}).fetchall()
+```
+
+Also update the reason-building logic (line 186): change `if days > 10 and not reason:` to `if days > at_risk_days and not reason:` (preserve the `and not reason:` guard).
+
+- [ ] **Step 3: Parameterize `_query_stale_leads`**
+
+Change signature from:
+```python
+def _query_stale_leads(self, db: Session, user_id: int, org_id: int, today: date) -> List[Dict]:
+```
+To:
+```python
+def _query_stale_leads(self, db: Session, user_id: int, org_id: int, today: date, lead_days: int = 7, high_score_days: int = 3, max_items: int = 10) -> List[Dict]:
+```
+
+Replace the hardcoded SQL intervals (lines 213-214):
+```sql
+(ai_score >= 70 AND last_contact < CURRENT_DATE - INTERVAL '3 days')
+OR last_contact < CURRENT_DATE - INTERVAL '7 days'
+```
+With parameterized:
+```sql
+(ai_score >= 70 AND last_contact < CURRENT_DATE - make_interval(days => :high_score_days))
+OR last_contact < CURRENT_DATE - make_interval(days => :lead_days)
+```
+
+Replace `LIMIT 10` with `LIMIT :max_items`.
+
+Add params: `"lead_days": lead_days, "high_score_days": high_score_days, "max_items": max_items` to the execute call.
+
+- [ ] **Step 4: Parameterize manager at-risk queries**
+
+In `gather_manager_data` (line 321), change the signature to accept thresholds:
+```python
+def gather_manager_data(self, db: Session, user_id: int, org_id: int, briefing_date: date, prefs: Optional['BriefingPreferences'] = None) -> Dict:
+```
+
+Replace `three_days = today + timedelta(days=3)` with:
+```python
+if prefs is None:
+    prefs = BriefingPreferences()
+lock_cutoff = today + timedelta(days=prefs.thresholds["lock_expiring_days"])
+at_risk_days = prefs.thresholds["at_risk_days"]
+```
+
+There are THREE SQL queries in this method that need parameterization:
+
+**Query 1 — at_risk_counts (lines 358-376):**
+- Replace `:three_days` → `:lock_cutoff`, `> 10` → `:at_risk_days`
+- Add `"lock_cutoff": lock_cutoff, "at_risk_days": at_risk_days` to params
+
+**Query 2 — stale_counts (lines 381-388):**
+- Replace `INTERVAL '7 days'` → `make_interval(days => :lead_days)`
+- Add `"lead_days": prefs.thresholds["stale_lead_days"]` to params
+
+**Query 3 — attention items (lines 414-430):**
+- Replace `:three_days` → `:lock_cutoff`, `> 10` → `:at_risk_days`
+- Add `"lock_cutoff": lock_cutoff, "at_risk_days": at_risk_days` to params
+
+Also update the Python logic at line 438: change `float(r[5] or 0) > 10` to `float(r[5] or 0) > at_risk_days`
+
+- [ ] **Step 5: Parameterize leadership at-risk queries**
+
+In `gather_leadership_data` (line 458), change the signature:
+```python
+def gather_leadership_data(self, db: Session, org_id: int, briefing_date: date, prefs: Optional['BriefingPreferences'] = None) -> Dict:
+```
+
+Replace `three_days = today + timedelta(days=3)` with:
+```python
+if prefs is None:
+    prefs = BriefingPreferences()
+lock_cutoff = today + timedelta(days=prefs.thresholds["lock_expiring_days"])
+at_risk_days = prefs.thresholds["at_risk_days"]
+```
+
+There are THREE SQL queries plus one Python line that need parameterization:
+
+**Query 1 — branch comparison (lines 487-503):**
+- Replace `:three_days` → `:lock_cutoff`, `> 10` → `:at_risk_days`
+
+**Query 2 — top_risks (lines 519-539):**
+- Replace `:three_days` → `:lock_cutoff`, `> 10` → `:at_risk_days`
+
+**Query 3 — org_snap (lines 468-475):** No changes needed (no threshold refs).
+
+**Python logic — branch health computation (line 515):**
+- Change `sla_breach=avg_days > 10` to `sla_breach=avg_days > at_risk_days`
+
+Add `"lock_cutoff": lock_cutoff, "at_risk_days": at_risk_days` to params for queries 1 and 2.
+
+- [ ] **Step 6: Update `build_context` to accept and pass `prefs`**
+
+Change signature (line 581-582):
+```python
+    def build_context(
+        self, db: Session, user: Any, briefing_date: date, prefs: Optional[BriefingPreferences] = None,
+    ) -> BriefingContext:
+```
+
+Add at the start of the method body (after line 588):
+```python
+        if prefs is None:
+            prefs = self.load_preferences(user)
+```
+
+Pass `prefs` to `gather_individual_data` (line 600):
+```python
+        individual = self.gather_individual_data(db, user_id, org_id, briefing_date, user_tz, prefs)
+```
+
+Pass `prefs` to `gather_manager_data` (line 610):
+```python
+            ctx.team = self.gather_manager_data(db, user_id, org_id, briefing_date, prefs)
+```
+
+Pass `prefs` to `gather_leadership_data` (line 614):
+```python
+            ctx.team = self.gather_leadership_data(db, org_id, briefing_date, prefs)
+```
+
+- [ ] **Step 7: Verify no syntax errors**
+
+Run: `cd backend && ../.venv/bin/python3 -c "from services.morning_briefing_service import MorningBriefingService; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/services/morning_briefing_service.py
+git commit -m "feat: parameterize briefing queries with user preferences"
+```
+
+---
+
+### Task 4: Service — AI tone variants and section-aware prompt formatting
+
+**Files:**
+- Modify: `backend/services/morning_briefing_service.py:622-660` (prompts and generate_narrative), `:684-767` (_format_context_for_ai)
+- Modify: `backend/tests/test_briefing_preferences.py` (add tone tests)
+
+- [ ] **Step 1: Write failing tests for tone selection**
+
+Add to `backend/tests/test_briefing_preferences.py`:
+
+```python
+class TestTonePrompts:
+    """Test that AI tone selection produces different system prompts."""
+
+    def _get_prompts(self):
+        from services.morning_briefing_service import MorningBriefingService
+        return {
+            "concise": MorningBriefingService.TONE_PROMPTS["concise"],
+            "balanced": MorningBriefingService.INDIVIDUAL_SYSTEM_PROMPT,
+            "detailed": MorningBriefingService.TONE_PROMPTS["detailed"],
+        }
+
+    def test_concise_prompt_exists(self):
+        prompts = self._get_prompts()
+        assert "bullet" in prompts["concise"].lower()
+
+    def test_detailed_prompt_exists(self):
+        prompts = self._get_prompts()
+        assert "paragraph" in prompts["detailed"].lower()
+
+    def test_balanced_is_default_individual(self):
+        prompts = self._get_prompts()
+        assert "3 prioritized actions" in prompts["balanced"]
+
+    def test_tone_prompts_are_modifiers(self):
+        """Tone prompts should be appended to level prompts, not replace them."""
+        prompts = self._get_prompts()
+        # They should NOT start with "You are" — they're format overrides
+        assert not prompts["concise"].startswith("You are")
+        assert not prompts["detailed"].startswith("You are")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && ../.venv/bin/python3 -m pytest tests/test_briefing_preferences.py::TestTonePrompts -v`
+Expected: FAIL — `TONE_PROMPTS` doesn't exist
+
+- [ ] **Step 3: Add tone prompt variants**
+
+In `backend/services/morning_briefing_service.py`, after the existing `LEADERSHIP_SYSTEM_PROMPT` (after line 646), add:
+
+```python
+    TONE_PROMPTS = {
+        "concise": (
+            "FORMAT OVERRIDE: Respond in exactly 3 bullet points. "
+            "Lead with numbers. No filler, no encouragement."
+        ),
+        "detailed": (
+            "FORMAT OVERRIDE: Write 2-3 short paragraphs covering "
+            "priorities, risks, and suggested next actions. Be specific with names and numbers."
+        ),
+    }
+```
+
+- [ ] **Step 4: Modify `generate_narrative` to accept `ai_tone`**
+
+Change the signature (line 648):
+```python
+    def generate_narrative(self, ctx: BriefingContext, ai_tone: str = "balanced") -> Optional[str]:
+```
+
+Change the system prompt selection (lines 656-660):
+```python
+        # Select base prompt by level
+        system_prompt = {
+            "individual": self.INDIVIDUAL_SYSTEM_PROMPT,
+            "manager": self.MANAGER_SYSTEM_PROMPT,
+            "leadership": self.LEADERSHIP_SYSTEM_PROMPT,
+        }.get(ctx.level, self.INDIVIDUAL_SYSTEM_PROMPT)
+
+        # Append tone modifier (preserves level-specific context guidance)
+        if ai_tone in self.TONE_PROMPTS:
+            system_prompt = system_prompt + "\n\n" + self.TONE_PROMPTS[ai_tone]
+```
+
+This appends the tone instruction to the level-specific prompt rather than replacing it, so a leadership user selecting "concise" still gets guidance about org-level analysis.
+
+- [ ] **Step 5: Make `_format_context_for_ai` section-aware**
+
+Change signature (line 684):
+```python
+    def _format_context_for_ai(self, ctx: BriefingContext, prefs: Optional[BriefingPreferences] = None) -> str:
+```
+
+Add at top of method:
+```python
+        if prefs is None:
+            prefs = BriefingPreferences()
+```
+
+Wrap each section with a preference check:
+
+For Pipeline (line 690): wrap with `if prefs.sections.get("pipeline", True):`
+For At-risk (line 699): wrap with `if prefs.sections.get("at_risk", True) and ctx.at_risk:`
+For Stale leads (line 706): wrap with `if prefs.sections.get("stale_leads", True) and ctx.stale_leads:`
+For Appointments (line 713): wrap with `if prefs.sections.get("appointments", True) and ctx.appointments:`
+For Conditions (line 720): wrap with `if prefs.sections.get("conditions", True) and ctx.conditions:`
+For Yesterday (line 728): wrap with `if prefs.sections.get("yesterday", True):`
+
+Update `generate_narrative` signature to also accept `prefs`:
+
+```python
+    def generate_narrative(self, ctx: BriefingContext, ai_tone: str = "balanced", prefs: Optional[BriefingPreferences] = None) -> Optional[str]:
+```
+
+And update the call to `_format_context_for_ai`:
+```python
+        user_prompt = self._format_context_for_ai(ctx, prefs)
+```
+
+- [ ] **Step 6: Run all tests**
+
+Run: `cd backend && ../.venv/bin/python3 -m pytest tests/test_briefing_preferences.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/services/morning_briefing_service.py backend/tests/test_briefing_preferences.py
+git commit -m "feat: add AI tone variants and section-aware prompt formatting"
+```
+
+---
+
+### Task 5: Routes — Expanded Pydantic schemas and updated GET/PUT preferences
+
+**Files:**
+- Modify: `backend/routes/briefing_routes.py:1-39` (imports, schemas), `:214-242` (GET/PUT preferences)
+
+- [ ] **Step 1: Expand Pydantic schemas**
+
+In `backend/routes/briefing_routes.py`, replace the existing `BriefingPreferences` schema (lines 36-38) with the expanded schemas. Add `Literal` to the imports:
+
+Replace line 19:
+```python
+from pydantic import BaseModel, Field
+```
+With:
+```python
+from typing import Literal
+from pydantic import BaseModel, Field
+```
+
+Replace lines 36-38 (this removes the old `BriefingPreferences` Pydantic model — note: the service file has a *different* `BriefingPreferences` which is a dataclass, not a Pydantic model):
+```python
+class BriefingPreferences(BaseModel):
+    briefing_enabled: bool = True
+    briefing_hour: int = Field(ge=0, le=23, default=7)
+```
+With:
+```python
+class BriefingSections(BaseModel):
+    pipeline: bool = True
+    at_risk: bool = True
+    stale_leads: bool = True
+    appointments: bool = True
+    conditions: bool = True
+    yesterday: bool = True
+
+
+class BriefingThresholds(BaseModel):
+    at_risk_days: int = Field(default=10, ge=1, le=30)
+    stale_lead_days: int = Field(default=7, ge=1, le=30)
+    stale_lead_high_score_days: int = Field(default=3, ge=1, le=14)
+    lock_expiring_days: int = Field(default=3, ge=1, le=14)
+    max_at_risk_items: int = Field(default=10, ge=1, le=20)
+    max_stale_lead_items: int = Field(default=10, ge=1, le=20)
+
+
+class BriefingPreferencesSchema(BaseModel):
+    briefing_enabled: bool = True
+    briefing_hour: int = Field(ge=0, le=23, default=7)
+    sections: BriefingSections = BriefingSections()
+    thresholds: BriefingThresholds = BriefingThresholds()
+    ai_tone: Literal["concise", "balanced", "detailed"] = "balanced"
+```
+
+- [ ] **Step 2: Update GET /preferences to return full preferences**
+
+Replace the `get_preferences` route (lines 214-224):
+
+```python
+@router.get("/preferences")
+async def get_preferences(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Get briefing preferences (merged with defaults)."""
+    from services.morning_briefing_service import MorningBriefingService
+    prefs = MorningBriefingService.load_preferences(current_user)
+    return {
+        "briefing_enabled": getattr(current_user, "briefing_enabled", True) if current_user.briefing_enabled is not None else True,
+        "briefing_hour": getattr(current_user, "briefing_hour", 7) or 7,
+        "timezone": getattr(current_user, "timezone", "America/New_York"),
+        "sections": prefs.sections,
+        "thresholds": prefs.thresholds,
+        "ai_tone": prefs.ai_tone,
+    }
+```
+
+- [ ] **Step 3: Update PUT /preferences to write JSONB**
+
+Replace the `update_preferences` route (lines 227-242):
+
+```python
+@router.put("/preferences")
+async def update_preferences(
+    prefs: BriefingPreferencesSchema,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    """Update briefing preferences.
+
+    Split-write: briefing_enabled and briefing_hour go to dedicated User columns
+    (used by Celery dispatch for fast SQL filtering). sections, thresholds, and
+    ai_tone go to user.briefing_preferences JSONB.
+    """
+    # Dedicated columns (fast SQL filtering by Celery dispatch)
+    current_user.briefing_enabled = prefs.briefing_enabled
+    current_user.briefing_hour = prefs.briefing_hour
+
+    # JSONB column (customization preferences)
+    current_user.briefing_preferences = {
+        "sections": prefs.sections.model_dump(),
+        "thresholds": prefs.thresholds.model_dump(),
+        "ai_tone": prefs.ai_tone,
+    }
+    db.commit()
+
+    from services.morning_briefing_service import MorningBriefingService
+    loaded = MorningBriefingService.load_preferences(current_user)
+    return {
+        "briefing_enabled": current_user.briefing_enabled,
+        "briefing_hour": current_user.briefing_hour,
+        "timezone": getattr(current_user, "timezone", "America/New_York"),
+        "sections": loaded.sections,
+        "thresholds": loaded.thresholds,
+        "ai_tone": loaded.ai_tone,
+    }
+```
+
+- [ ] **Step 4: Verify no syntax errors**
+
+Run: `cd backend && ../.venv/bin/python3 -c "from routes.briefing_routes import router; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/routes/briefing_routes.py
+git commit -m "feat: expand briefing preferences API with sections, thresholds, tone"
+```
+
+---
+
+### Task 6: Celery task — Pass preferences through to service
+
+**Files:**
+- Modify: `backend/tasks/morning_briefing_tasks.py:145-213`
+
+- [ ] **Step 1: Update generate_user_briefing to load and pass preferences**
+
+In `backend/tasks/morning_briefing_tasks.py`, modify the `generate_user_briefing` function.
+
+After the user is loaded (line 160, `user = db.query(User)...`), add:
+
+```python
+        # Load user preferences (NULL = all defaults)
+        prefs = MorningBriefingService.load_preferences(user)
+```
+
+Change line 196 from:
+```python
+        ctx = service.build_context(db, user, briefing_date)
+```
+To:
+```python
+        ctx = service.build_context(db, user, briefing_date, prefs)
+```
+
+Change line 211 from:
+```python
+        narrative = service.generate_narrative(ctx)
+```
+To:
+```python
+        narrative = service.generate_narrative(ctx, prefs.ai_tone, prefs)
+```
+
+- [ ] **Step 2: Verify no syntax errors**
+
+Run: `cd backend && ../.venv/bin/python3 -c "from tasks.morning_briefing_tasks import generate_user_briefing; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tasks/morning_briefing_tasks.py
+git commit -m "feat: pass user preferences through Celery task to briefing service"
+```
+
+---
+
+### Task 7: Frontend — Expand MorningBriefingSettings with sections, thresholds, tone
+
+**Files:**
+- Modify: `frontend/src/pages/Settings.js:2648-2764`
+
+- [ ] **Step 1: Expand preferences state**
+
+Replace line 2649:
+```javascript
+    const [prefs, setPrefs] = useState({ briefing_enabled: true, briefing_hour: 7, timezone: '' });
+```
+With:
+```javascript
+    const [prefs, setPrefs] = useState({
+      briefing_enabled: true, briefing_hour: 7, timezone: '',
+      sections: {
+        pipeline: true, at_risk: true, stale_leads: true,
+        appointments: true, conditions: true, yesterday: true,
+      },
+      thresholds: {
+        at_risk_days: 10, stale_lead_days: 7, stale_lead_high_score_days: 3,
+        lock_expiring_days: 3, max_at_risk_items: 10, max_stale_lead_items: 10,
+      },
+      ai_tone: 'balanced',
+    });
+    const [savedPrefs, setSavedPrefs] = useState(null);
+```
+
+- [ ] **Step 2: Track dirty state for Generate Now button**
+
+After the `setSavedPrefs` line, add a computed dirty check:
+
+```javascript
+    const isDirty = savedPrefs !== null && JSON.stringify(prefs) !== JSON.stringify(savedPrefs);
+```
+
+In the `useEffect` fetchPrefs handler, after `setPrefs(data)` (line 2663), add:
+```javascript
+            setSavedPrefs(data);
+```
+
+In `savePrefs`, after the `if (res.ok)` block (line 2683-2684), add:
+```javascript
+          setSavedPrefs({ ...prefs });
+```
+
+- [ ] **Step 3: Expand the PUT body to send all preferences**
+
+Replace the `savePrefs` body (line 2678-2681):
+```javascript
+          body: JSON.stringify({
+            briefing_enabled: prefs.briefing_enabled,
+            briefing_hour: prefs.briefing_hour,
+          }),
+```
+With:
+```javascript
+          body: JSON.stringify({
+            briefing_enabled: prefs.briefing_enabled,
+            briefing_hour: prefs.briefing_hour,
+            sections: prefs.sections,
+            thresholds: prefs.thresholds,
+            ai_tone: prefs.ai_tone,
+          }),
+```
+
+- [ ] **Step 4: Add section toggles, threshold inputs, and tone selector to the JSX**
+
+After the delivery time `settings-row` div (before line 2748, the `settings-actions` div), insert the three new sub-sections:
+
+```jsx
+        {prefs.briefing_enabled && (
+          <>
+            {/* Section Toggles */}
+            <div className="settings-row" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: '6px' }}>
+              <label style={{ fontWeight: 600, marginBottom: '4px' }}>Briefing Sections</label>
+              {[
+                { key: 'pipeline', label: 'Pipeline snapshot' },
+                { key: 'at_risk', label: 'At-risk loans' },
+                { key: 'stale_leads', label: 'Leads going cold' },
+                { key: 'appointments', label: "Today's appointments" },
+                { key: 'conditions', label: 'Outstanding conditions' },
+                { key: 'yesterday', label: "Yesterday's activity" },
+              ].map(({ key, label }) => (
+                <label key={key} className="settings-toggle" style={{ marginLeft: '8px' }}>
+                  <input
+                    type="checkbox"
+                    checked={prefs.sections?.[key] ?? true}
+                    onChange={(e) => setPrefs({ ...prefs, sections: { ...prefs.sections, [key]: e.target.checked } })}
+                  />
+                  <span>{label}</span>
+                </label>
+              ))}
+            </div>
+
+            {/* Threshold Inputs */}
+            <div className="settings-row" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: '8px' }}>
+              <label style={{ fontWeight: 600, marginBottom: '4px' }}>Detection Thresholds</label>
+              {[
+                { key: 'at_risk_days', label: 'Flag loans stuck longer than', suffix: 'days', min: 1, max: 30, section: 'at_risk' },
+                { key: 'stale_lead_days', label: 'Flag leads with no contact for', suffix: 'days', min: 1, max: 30, section: 'stale_leads' },
+                { key: 'stale_lead_high_score_days', label: 'Flag high-score leads after', suffix: 'days', min: 1, max: 14, section: 'stale_leads' },
+                { key: 'lock_expiring_days', label: 'Lock expiration warning', suffix: 'days out', min: 1, max: 14, section: 'at_risk' },
+                { key: 'max_at_risk_items', label: 'Max at-risk items shown', suffix: '', min: 1, max: 20, section: 'at_risk' },
+                { key: 'max_stale_lead_items', label: 'Max stale lead items shown', suffix: '', min: 1, max: 20, section: 'stale_leads' },
+              ].map(({ key, label, suffix, min, max, section }) => (
+                <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '8px', marginLeft: '8px', opacity: prefs.sections?.[section] === false ? 0.5 : 1 }}>
+                  <span style={{ minWidth: '220px' }}>{label}</span>
+                  <input
+                    type="number"
+                    value={prefs.thresholds?.[key] ?? ''}
+                    min={min}
+                    max={max}
+                    disabled={prefs.sections?.[section] === false}
+                    onChange={(e) => {
+                      const val = parseInt(e.target.value);
+                      if (!isNaN(val) && val >= min && val <= max) {
+                        setPrefs({ ...prefs, thresholds: { ...prefs.thresholds, [key]: val } });
+                      }
+                    }}
+                    style={{ width: '60px', padding: '4px 8px' }}
+                  />
+                  {suffix && <span style={{ color: '#666' }}>{suffix}</span>}
+                </div>
+              ))}
+            </div>
+
+            {/* AI Tone */}
+            <div className="settings-row" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: '6px' }}>
+              <label style={{ fontWeight: 600, marginBottom: '4px' }}>AI Narrative Tone</label>
+              {[
+                { value: 'concise', label: 'Concise', desc: 'Bullet points, numbers only' },
+                { value: 'balanced', label: 'Balanced', desc: 'Short narrative with key highlights' },
+                { value: 'detailed', label: 'Detailed', desc: 'Full paragraphs with suggested actions' },
+              ].map(({ value, label, desc }) => (
+                <label key={value} style={{ display: 'flex', alignItems: 'center', gap: '8px', marginLeft: '8px', cursor: 'pointer' }}>
+                  <input
+                    type="radio"
+                    name="ai_tone"
+                    value={value}
+                    checked={prefs.ai_tone === value}
+                    onChange={() => setPrefs({ ...prefs, ai_tone: value })}
+                  />
+                  <span><strong>{label}</strong> — {desc}</span>
+                </label>
+              ))}
+            </div>
+          </>
+        )}
+```
+
+- [ ] **Step 5: Disable Generate Now when dirty**
+
+Update the Generate Now button (line 2752) — change:
+```javascript
+            <button onClick={generateNow} disabled={generating || !prefs.briefing_enabled} className="btn btn-secondary">
+```
+To:
+```javascript
+            <button onClick={generateNow} disabled={generating || !prefs.briefing_enabled || isDirty} className="btn btn-secondary" title={isDirty ? 'Save preferences first' : ''}>
+```
+
+- [ ] **Step 6: Verify frontend builds**
+
+Run: `cd frontend && npm run build 2>&1 | tail -5`
+Expected: Build succeeds (or at least no syntax errors in Settings.js)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/Settings.js
+git commit -m "feat: expand Morning Briefing settings with section toggles, thresholds, AI tone"
+```
+
+---
+
+### Task 8: Final verification — all tests pass, end-to-end check
+
+**Files:**
+- Read: all modified files for quick sanity check
+
+- [ ] **Step 1: Run all briefing preference tests**
+
+Run: `cd backend && ../.venv/bin/python3 -m pytest tests/test_briefing_preferences.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 2: Verify model import chain**
+
+Run: `cd backend && ../.venv/bin/python3 -c "from database.models.core import User; u = User(); print(type(u.briefing_preferences))"`
+Expected: `<class 'NoneType'>` (NULL default)
+
+- [ ] **Step 3: Verify routes import cleanly**
+
+Run: `cd backend && ../.venv/bin/python3 -c "from routes.briefing_routes import router; print(len(router.routes), 'routes')"`
+Expected: `6 routes`
+
+- [ ] **Step 4: Verify service loads cleanly with new code**
+
+Run: `cd backend && ../.venv/bin/python3 -c "from services.morning_briefing_service import MorningBriefingService, BriefingPreferences; prefs = BriefingPreferences(); print(prefs.ai_tone, len(prefs.sections), len(prefs.thresholds))"`
+Expected: `balanced 6 6`
+
+- [ ] **Step 5: Final commit if any fixups needed**
+
+```bash
+git add -A
+git commit -m "fix: address any issues found during verification"
+```
+(Skip if no changes needed)

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -2646,7 +2646,13 @@ const API_BASE_URL = isProduction
   };
 
   const MorningBriefingSettings = () => {
-    const [prefs, setPrefs] = useState({ briefing_enabled: true, briefing_hour: 7, timezone: '' });
+    const defaultSections = { pipeline: true, at_risk: true, stale_leads: true, appointments: true, conditions: true, yesterday: true };
+    const defaultThresholds = { at_risk_days: 10, stale_lead_days: 7, stale_lead_high_score_days: 3, lock_expiring_days: 3, max_at_risk_items: 10, max_stale_lead_items: 10 };
+    const [prefs, setPrefs] = useState({
+      briefing_enabled: true, briefing_hour: 7, timezone: '',
+      sections: { ...defaultSections }, thresholds: { ...defaultThresholds }, ai_tone: 'balanced',
+    });
+    const [savedPrefs, setSavedPrefs] = useState(null);
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [generating, setGenerating] = useState(false);
@@ -2660,13 +2666,22 @@ const API_BASE_URL = isProduction
           });
           if (res.ok) {
             const data = await res.json();
-            setPrefs(data);
+            const merged = {
+              ...data,
+              sections: { ...defaultSections, ...(data.sections || {}) },
+              thresholds: { ...defaultThresholds, ...(data.thresholds || {}) },
+              ai_tone: data.ai_tone || 'balanced',
+            };
+            setPrefs(merged);
+            setSavedPrefs(JSON.stringify(merged));
           }
         } catch (err) { console.error('Failed to fetch briefing preferences', err); }
         finally { setLoading(false); }
       };
       fetchPrefs();
     }, []);
+
+    const isDirty = savedPrefs !== null && JSON.stringify(prefs) !== savedPrefs;
 
     const savePrefs = async () => {
       setSaving(true);
@@ -2678,9 +2693,21 @@ const API_BASE_URL = isProduction
           body: JSON.stringify({
             briefing_enabled: prefs.briefing_enabled,
             briefing_hour: prefs.briefing_hour,
+            sections: prefs.sections,
+            thresholds: prefs.thresholds,
+            ai_tone: prefs.ai_tone,
           }),
         });
         if (res.ok) {
+          const data = await res.json();
+          const merged = {
+            ...data,
+            sections: { ...defaultSections, ...(data.sections || {}) },
+            thresholds: { ...defaultThresholds, ...(data.thresholds || {}) },
+            ai_tone: data.ai_tone || 'balanced',
+          };
+          setPrefs(merged);
+          setSavedPrefs(JSON.stringify(merged));
           setMessage({ type: 'success', text: 'Briefing preferences saved' });
         } else {
           setMessage({ type: 'error', text: 'Failed to save preferences' });
@@ -2709,13 +2736,38 @@ const API_BASE_URL = isProduction
       finally { setGenerating(false); }
     };
 
+    const updateSection = (key, val) => setPrefs(p => ({ ...p, sections: { ...p.sections, [key]: val } }));
+    const updateThreshold = (key, val) => {
+      const num = parseInt(val);
+      if (!isNaN(num) && num >= 1) setPrefs(p => ({ ...p, thresholds: { ...p.thresholds, [key]: num } }));
+    };
+
     if (loading) return <div className="settings-section"><h3>Morning Briefing</h3><p>Loading...</p></div>;
 
     const hourOptions = [];
     for (let h = 5; h <= 11; h++) {
-      const label = `${h}:00 AM`;
-      hourOptions.push(<option key={h} value={h}>{label}</option>);
+      hourOptions.push(<option key={h} value={h}>{`${h}:00 AM`}</option>);
     }
+
+    const sectionLabels = {
+      pipeline: 'Pipeline snapshot',
+      at_risk: 'At-risk loans',
+      stale_leads: 'Stale leads',
+      appointments: "Today's appointments",
+      conditions: 'Pending conditions',
+      yesterday: "Yesterday's activity",
+    };
+
+    const thresholdLabels = {
+      at_risk_days: { label: 'Days without movement to flag', suffix: 'days' },
+      stale_lead_days: { label: 'Days silent to flag lead', suffix: 'days' },
+      stale_lead_high_score_days: { label: 'Days silent for high-score leads', suffix: 'days' },
+      lock_expiring_days: { label: 'Lock expiring within', suffix: 'days' },
+      max_at_risk_items: { label: 'Max at-risk items shown', suffix: '' },
+      max_stale_lead_items: { label: 'Max stale leads shown', suffix: '' },
+    };
+
+    const disabled = !prefs.briefing_enabled;
 
     return (
       <div className="settings-section">
@@ -2724,32 +2776,65 @@ const API_BASE_URL = isProduction
 
         <div className="settings-row">
           <label className="settings-toggle">
-            <input
-              type="checkbox"
-              checked={prefs.briefing_enabled}
-              onChange={(e) => setPrefs({ ...prefs, briefing_enabled: e.target.checked })}
-            />
+            <input type="checkbox" checked={prefs.briefing_enabled} onChange={(e) => setPrefs({ ...prefs, briefing_enabled: e.target.checked })} />
             <span>Enable daily briefing</span>
           </label>
         </div>
 
         <div className="settings-row">
           <label>Delivery time</label>
-          <select
-            value={prefs.briefing_hour}
-            onChange={(e) => setPrefs({ ...prefs, briefing_hour: parseInt(e.target.value) })}
-            disabled={!prefs.briefing_enabled}
-          >
+          <select value={prefs.briefing_hour} onChange={(e) => setPrefs({ ...prefs, briefing_hour: parseInt(e.target.value) })} disabled={disabled}>
             {hourOptions}
           </select>
           {prefs.timezone && <span className="settings-hint">in your timezone: {prefs.timezone}</span>}
         </div>
 
+        <div className="settings-row">
+          <label>AI narrative style</label>
+          <div className="settings-radio-group">
+            {['concise', 'balanced', 'detailed'].map(tone => (
+              <label key={tone} className="settings-radio">
+                <input type="radio" name="ai_tone" value={tone} checked={prefs.ai_tone === tone} onChange={() => setPrefs({ ...prefs, ai_tone: tone })} disabled={disabled} />
+                <span style={{ textTransform: 'capitalize' }}>{tone}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="settings-subsection">
+          <h4>Sections</h4>
+          <p className="settings-hint">Choose which sections appear in your briefing.</p>
+          <div className="settings-checkboxes">
+            {Object.entries(sectionLabels).map(([key, label]) => (
+              <label key={key} className="settings-toggle">
+                <input type="checkbox" checked={prefs.sections[key] !== false} onChange={(e) => updateSection(key, e.target.checked)} disabled={disabled} />
+                <span>{label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="settings-subsection">
+          <h4>Thresholds</h4>
+          <p className="settings-hint">Customize when items are flagged in your briefing.</p>
+          <div className="settings-thresholds">
+            {Object.entries(thresholdLabels).map(([key, { label, suffix }]) => (
+              <div key={key} className="settings-row settings-threshold-row">
+                <label>{label}</label>
+                <div className="settings-threshold-input">
+                  <input type="number" min="1" max="60" value={prefs.thresholds[key] || ''} onChange={(e) => updateThreshold(key, e.target.value)} disabled={disabled} style={{ width: 60, textAlign: 'center' }} />
+                  {suffix && <span className="settings-hint">{suffix}</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
         <div className="settings-row settings-actions">
-          <button onClick={savePrefs} disabled={saving} className="btn btn-primary">
-            {saving ? 'Saving...' : 'Save Preferences'}
+          <button onClick={savePrefs} disabled={saving || !isDirty} className="btn btn-primary">
+            {saving ? 'Saving...' : isDirty ? 'Save Preferences' : 'Saved'}
           </button>
-          <button onClick={generateNow} disabled={generating || !prefs.briefing_enabled} className="btn btn-secondary">
+          <button onClick={generateNow} disabled={generating || !prefs.briefing_enabled || isDirty} className="btn btn-secondary" title={isDirty ? 'Save preferences first' : ''}>
             {generating ? 'Generating...' : 'Generate Now'}
           </button>
         </div>


### PR DESCRIPTION
## Summary
- Users can now toggle briefing sections on/off, adjust at-risk/stale-lead detection thresholds, and choose an AI narrative tone (concise/balanced/detailed)
- Preferences stored as JSONB on User model — NULL = all defaults, zero migration pressure
- Backend parameterizes all hardcoded query thresholds (at-risk days, lock expiring, stale lead days, max items) from user preferences
- AI tone appends format modifiers to level-specific prompts (preserves manager/leadership context)
- Frontend expands MorningBriefingSettings with checkboxes, number inputs, radio buttons, and dirty-state tracking

## Files changed (7 commits)
| File | Change |
|------|--------|
| `backend/database/models/core.py` | Add `briefing_preferences` JSONB column |
| `backend/migrations/add_briefing_preferences.py` | ALTER TABLE migration |
| `backend/database/init_db.py` | Wire migration into startup |
| `backend/services/morning_briefing_service.py` | BriefingPreferences dataclass, load_preferences(), parameterized queries, tone variants, section-aware prompts |
| `backend/routes/briefing_routes.py` | BriefingSections/BriefingThresholds/BriefingPreferencesSchema, split-write GET/PUT |
| `backend/tasks/morning_briefing_tasks.py` | Pass preferences through Celery task |
| `frontend/src/pages/Settings.js` | Section toggles, threshold inputs, AI tone radios, dirty state |
| `backend/tests/test_briefing_preferences.py` | 11 unit tests (load_preferences + tone prompts) |

## Test plan
- [x] 11 unit tests pass (`test_briefing_preferences.py`)
- [x] Service imports cleanly with new code
- [x] Routes load with correct count (6)
- [x] User model has JSONB column (NULL default)
- [ ] Manual: toggle sections off → briefing omits them
- [ ] Manual: change tone → narrative style changes
- [ ] Manual: adjust thresholds → detection sensitivity changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)