### PR TITLE
feat: Smart Docs enterprise features + platform completion (P1-P3)

### DIFF
--- a/backend/agents/tools/compliance.py
+++ b/backend/agents/tools/compliance.py
@@ -691,13 +691,12 @@ def get_state_requirements(
     state: Optional[str] = None,
     loan_id: Optional[int] = None,
 ) -> ToolResult:
-    """Get state-specific requirements."""
+    """Get state-specific requirements. Queries the state_disclosures DB table first;
+    falls back to the hardcoded dict for the original 4 states if the table is
+    empty or unavailable."""
     try:
         if loan_id and not state:
-            # Get state from loan
-            loan_query = """
-                SELECT property_state FROM loans WHERE id = :loan_id
-            """
+            loan_query = "SELECT property_state FROM loans WHERE id = :loan_id"
             loan = execute_single(loan_query, {"loan_id": loan_id})
             if loan:
                 state = loan.get("property_state")
@@ -707,7 +706,51 @@ def get_state_requirements(
 
         state = state.upper()
 
-        # State requirements database (simplified)
+        # ------------------------------------------------------------------
+        # 1. Try the database-backed state_disclosures table first
+        # ------------------------------------------------------------------
+        try:
+            db_results = execute_query(
+                "SELECT state_name, category, requirement, applies_to_loan_types, regulatory_reference "
+                "FROM state_disclosures WHERE state_code = :state ORDER BY category, id",
+                {"state": state},
+            )
+        except Exception:
+            db_results = []
+
+        if db_results:
+            state_name = db_results[0]["state_name"]
+            by_category: dict = {}
+            for row in db_results:
+                cat = row["category"]
+                if cat not in by_category:
+                    by_category[cat] = []
+                entry: dict = {"requirement": row["requirement"]}
+                if row["regulatory_reference"]:
+                    entry["reference"] = row["regulatory_reference"]
+                if row["applies_to_loan_types"]:
+                    entry["applies_to"] = row["applies_to_loan_types"]
+                by_category[cat].append(entry)
+
+            data = {
+                "state": state,
+                "state_name": state_name,
+                "source": "database",
+                "has_specific_requirements": True,
+                "categories": by_category,
+                "total_requirements": len(db_results),
+            }
+            return ToolResult.success(
+                data=data,
+                message=(
+                    f"{state_name}: {len(db_results)} requirements "
+                    f"across {len(by_category)} categories"
+                ),
+            )
+
+        # ------------------------------------------------------------------
+        # 2. Fallback: original hardcoded dict for CA / TX / FL / NY
+        # ------------------------------------------------------------------
         state_requirements = {
             "CA": {
                 "name": "California",
@@ -775,9 +818,9 @@ def get_state_requirements(
         requirements = state_requirements.get(state)
 
         if not requirements:
-            # Return generic federal requirements
             return ToolResult.success({
                 "state": state,
+                "source": "fallback",
                 "has_specific_requirements": False,
                 "message": f"No state-specific requirements on file for {state}. Federal requirements apply.",
                 "federal_requirements": [
@@ -791,6 +834,7 @@ def get_state_requirements(
         return ToolResult.success({
             "state": state,
             "state_name": requirements["name"],
+            "source": "fallback",
             "has_specific_requirements": True,
             "disclosures": requirements["disclosures"],
             "waiting_periods": requirements["waiting_periods"],

--- a/backend/database/models/__init__.py
+++ b/backend/database/models/__init__.py
@@ -298,6 +298,9 @@ from .compliance import (
     AdverseActionReason,
 )
 
+# 50-state disclosure requirements
+from .state_disclosure import StateDisclosure
+
 # AI Prospect Re-Engagement models
 from .ai_prospect_conversation import (
     AIProspectConversation,
@@ -885,6 +888,11 @@ __all__ = [
     "ToleranceCategory",
     "DisclosureType",
     "AdverseActionReason",
+
+    # =====================
+    # State Disclosures (50-state)
+    # =====================
+    "StateDisclosure",
 
     # =====================
     # AI Prospect Re-Engagement

--- a/backend/database/models/state_disclosure.py
+++ b/backend/database/models/state_disclosure.py
@@ -1,0 +1,22 @@
+"""State-specific mortgage disclosure requirements — database-backed."""
+
+from sqlalchemy import Column, Integer, String, Text, Date, DateTime, func
+from sqlalchemy.dialects.postgresql import ARRAY
+
+from database import Base
+
+
+class StateDisclosure(Base):
+    __tablename__ = "state_disclosures"
+
+    id = Column(Integer, primary_key=True)
+    state_code = Column(String(2), nullable=False, index=True)
+    state_name = Column(String(50), nullable=False)
+    # licensing, disclosure, fee_limit, prepayment, cooling_off, special_rule, recording_consent
+    category = Column(String(50), nullable=False, index=True)
+    requirement = Column(Text, nullable=False)
+    applies_to_loan_types = Column(ARRAY(String), nullable=True)  # null = all types
+    regulatory_reference = Column(String(255), nullable=True)
+    effective_date = Column(Date, nullable=True)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())

--- a/backend/database/seed_state_disclosures.py
+++ b/backend/database/seed_state_disclosures.py
@@ -1,0 +1,941 @@
+"""
+Seed script for 50-state + DC mortgage disclosure requirements.
+
+Covers all 51 jurisdictions. Top 20 states by mortgage volume have full
+multi-category entries; remaining 31 have licensing, key disclosure, and
+recording consent as a minimum baseline.
+
+Usage:
+    python seed_state_disclosures.py
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Seed data
+# ---------------------------------------------------------------------------
+
+_DISCLOSURES: List[Dict[str, Any]] = [
+    # =========================================================================
+    # CALIFORNIA
+    # =========================================================================
+    {"state_code": "CA", "state_name": "California", "category": "licensing",
+     "requirement": "DRE or DFPI (formerly DBO) license required. NMLS registration mandatory for all MLOs.",
+     "regulatory_reference": "Cal. Fin. Code § 50000; Cal. Bus. & Prof. Code § 10166"},
+    {"state_code": "CA", "state_name": "California", "category": "disclosure",
+     "requirement": "Mortgage Loan Disclosure Statement (MLDS) required within 3 business days of application.",
+     "regulatory_reference": "Cal. Bus. & Prof. Code § 10240"},
+    {"state_code": "CA", "state_name": "California", "category": "disclosure",
+     "requirement": "Agency disclosure required prior to accepting deposit or executing purchase agreement.",
+     "regulatory_reference": "Cal. Civ. Code § 2079.16"},
+    {"state_code": "CA", "state_name": "California", "category": "disclosure",
+     "requirement": "Transfer Disclosure Statement (TDS) required in residential sales of 1–4 units.",
+     "regulatory_reference": "Cal. Civ. Code § 1102"},
+    {"state_code": "CA", "state_name": "California", "category": "fee_limit",
+     "requirement": "Origination fees limited to 3% on loans > $30,000. Total points and fees capped at 5%.",
+     "regulatory_reference": "Cal. Fin. Code § 50204"},
+    {"state_code": "CA", "state_name": "California", "category": "fee_limit",
+     "requirement": "APR threshold for high-cost loans: 6.5% above APOR for first lien; 8.5% for subordinate.",
+     "regulatory_reference": "Cal. Fin. Code § 4970"},
+    {"state_code": "CA", "state_name": "California", "category": "prepayment",
+     "requirement": "No prepayment penalties allowed on primary residence loans. Restriction applies to refinances and purchase loans.",
+     "regulatory_reference": "Cal. Civ. Code § 2954.9"},
+    {"state_code": "CA", "state_name": "California", "category": "cooling_off",
+     "requirement": "3-day right of rescission on refinances of primary residence (federal) plus California-specific HELOC rescission.",
+     "regulatory_reference": "15 U.S.C. § 1635; Cal. Civ. Code § 1689.5"},
+    {"state_code": "CA", "state_name": "California", "category": "special_rule",
+     "requirement": "Foreclosure consultant regulations impose strict disclosure and contract requirements when assisting distressed homeowners.",
+     "regulatory_reference": "Cal. Civ. Code § 2945"},
+    {"state_code": "CA", "state_name": "California", "category": "special_rule",
+     "requirement": "One-action rule: lender may pursue only one remedy (foreclosure or deficiency judgment) against defaulting borrower.",
+     "regulatory_reference": "Cal. Code Civ. Proc. § 726"},
+    {"state_code": "CA", "state_name": "California", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "Cal. Penal Code § 632"},
+
+    # =========================================================================
+    # TEXAS
+    # =========================================================================
+    {"state_code": "TX", "state_name": "Texas", "category": "licensing",
+     "requirement": "SML (Savings & Mortgage Lending) license required. NMLS registration mandatory.",
+     "regulatory_reference": "Tex. Fin. Code § 156.201"},
+    {"state_code": "TX", "state_name": "Texas", "category": "disclosure",
+     "requirement": "Texas Section 50(a)(6) Home Equity Disclosure required at application for cash-out refinances.",
+     "regulatory_reference": "Tex. Const. art. XVI § 50(a)(6)"},
+    {"state_code": "TX", "state_name": "Texas", "category": "disclosure",
+     "requirement": "12-Day Letter must be provided at least 12 days before closing for home equity loans.",
+     "regulatory_reference": "7 Tex. Admin. Code § 153.14"},
+    {"state_code": "TX", "state_name": "Texas", "category": "fee_limit",
+     "requirement": "Total fees on home equity loans capped at 3% of loan amount. Excludes bona fide third-party charges.",
+     "regulatory_reference": "Tex. Const. art. XVI § 50(a)(6)(E)"},
+    {"state_code": "TX", "state_name": "Texas", "category": "prepayment",
+     "requirement": "No prepayment penalties on home equity loans secured by homestead. Conventional loans: state law silent, contractual terms govern.",
+     "regulatory_reference": "Tex. Const. art. XVI § 50(a)(6)(G)"},
+    {"state_code": "TX", "state_name": "Texas", "category": "cooling_off",
+     "requirement": "12-day waiting period from date of application or 12-day disclosure (whichever is later) before home equity loan can close.",
+     "regulatory_reference": "Tex. Const. art. XVI § 50(a)(6)(M)(ii)"},
+    {"state_code": "TX", "state_name": "Texas", "category": "cooling_off",
+     "requirement": "3-business-day right of rescission after closing on home equity loans.",
+     "regulatory_reference": "Tex. Const. art. XVI § 50(a)(6)(Q)(viii)"},
+    {"state_code": "TX", "state_name": "Texas", "category": "special_rule",
+     "requirement": "Maximum LTV of 80% for cash-out refinances on homestead property.",
+     "regulatory_reference": "Tex. Const. art. XVI § 50(a)(6)(B)"},
+    {"state_code": "TX", "state_name": "Texas", "category": "special_rule",
+     "requirement": "Once-a-year rule: a homestead property may have only one home equity loan per 12-month period.",
+     "regulatory_reference": "Tex. Const. art. XVI § 50(a)(6)(M)(iii)"},
+    {"state_code": "TX", "state_name": "Texas", "category": "special_rule",
+     "requirement": "Home equity loans must close at the office of the lender, a title company, or an attorney's office.",
+     "regulatory_reference": "Tex. Const. art. XVI § 50(a)(6)(N)"},
+    {"state_code": "TX", "state_name": "Texas", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls (Texas is a one-party consent state).",
+     "regulatory_reference": "Tex. Penal Code § 16.02"},
+
+    # =========================================================================
+    # FLORIDA
+    # =========================================================================
+    {"state_code": "FL", "state_name": "Florida", "category": "licensing",
+     "requirement": "OFR (Office of Financial Regulation) Mortgage Loan Originator license required. NMLS registration mandatory.",
+     "regulatory_reference": "Fla. Stat. § 494.00312"},
+    {"state_code": "FL", "state_name": "Florida", "category": "disclosure",
+     "requirement": "Radon gas disclosure required in all residential sales and leases.",
+     "regulatory_reference": "Fla. Stat. § 404.056(5)"},
+    {"state_code": "FL", "state_name": "Florida", "category": "disclosure",
+     "requirement": "Seller's real property disclosure form required for residential sales of 1–4 units.",
+     "regulatory_reference": "Fla. Stat. § 689.261"},
+    {"state_code": "FL", "state_name": "Florida", "category": "disclosure",
+     "requirement": "Energy efficiency rating disclosure required for new construction.",
+     "regulatory_reference": "Fla. Stat. § 553.996"},
+    {"state_code": "FL", "state_name": "Florida", "category": "fee_limit",
+     "requirement": "High-cost loan threshold: APR exceeds APOR by 6.5% (first lien) or 8.5% (subordinate). Additional restrictions apply.",
+     "regulatory_reference": "Fla. Stat. § 494.0079"},
+    {"state_code": "FL", "state_name": "Florida", "category": "special_rule",
+     "requirement": "Documentary stamp tax: $0.35 per $100 of consideration on deed; $0.35 per $100 on mortgage note (Miami-Dade: $0.60 on deed).",
+     "regulatory_reference": "Fla. Stat. §§ 201.02, 201.08"},
+    {"state_code": "FL", "state_name": "Florida", "category": "special_rule",
+     "requirement": "Florida homestead exemption provides strong anti-deficiency protection; forced sale of homestead is narrowly restricted.",
+     "regulatory_reference": "Fla. Const. art. X § 4"},
+    {"state_code": "FL", "state_name": "Florida", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "Fla. Stat. § 934.03"},
+
+    # =========================================================================
+    # NEW YORK
+    # =========================================================================
+    {"state_code": "NY", "state_name": "New York", "category": "licensing",
+     "requirement": "NYDFS Mortgage Loan Originator license required. NMLS registration mandatory.",
+     "regulatory_reference": "N.Y. Banking Law § 590-b"},
+    {"state_code": "NY", "state_name": "New York", "category": "disclosure",
+     "requirement": "Subprime/High-Cost Loan Disclosure (NYCRR) required 3 business days before closing.",
+     "regulatory_reference": "3 N.Y.C.R.R. Part 41"},
+    {"state_code": "NY", "state_name": "New York", "category": "disclosure",
+     "requirement": "Mortgage Recording Tax Disclosure required at application. Tax: 1.05% on mortgages ≤ $500K; 1.3% on mortgages > $500K in NYC.",
+     "regulatory_reference": "N.Y. Tax Law § 253"},
+    {"state_code": "NY", "state_name": "New York", "category": "disclosure",
+     "requirement": "Predatory lending disclosure required for high-cost loans (SONYMA definition applies).",
+     "regulatory_reference": "N.Y. Banking Law § 6-l"},
+    {"state_code": "NY", "state_name": "New York", "category": "fee_limit",
+     "requirement": "Points and fees cap: 5% on high-cost loans. Origination fee limits apply under Banking Law § 6-l.",
+     "regulatory_reference": "N.Y. Banking Law § 6-l(2)(d)"},
+    {"state_code": "NY", "state_name": "New York", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on high-cost loans. Conventional loans: 3-year limitation on prepayment penalty terms.",
+     "regulatory_reference": "N.Y. Banking Law § 6-l(2)(c)"},
+    {"state_code": "NY", "state_name": "New York", "category": "cooling_off",
+     "requirement": "3-business-day waiting period after receipt of high-cost loan disclosure before closing.",
+     "regulatory_reference": "N.Y. Banking Law § 6-l(2)(b)"},
+    {"state_code": "NY", "state_name": "New York", "category": "special_rule",
+     "requirement": "Mansion tax: 1% surcharge on residential purchases ≥ $1M; progressive rate up to 3.9% over $25M.",
+     "regulatory_reference": "N.Y. Tax Law § 1402-a"},
+    {"state_code": "NY", "state_name": "New York", "category": "special_rule",
+     "requirement": "CEMA (Consolidation, Extension and Modification Agreement) allows borrowers to avoid mortgage recording tax on refinances.",
+     "regulatory_reference": "N.Y. Real Prop. Law § 275"},
+    {"state_code": "NY", "state_name": "New York", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls (New York is a one-party consent state).",
+     "regulatory_reference": "N.Y. Penal Law § 250.00"},
+
+    # =========================================================================
+    # PENNSYLVANIA
+    # =========================================================================
+    {"state_code": "PA", "state_name": "Pennsylvania", "category": "licensing",
+     "requirement": "Pennsylvania Department of Banking license required under the Mortgage Licensing Act. NMLS registration mandatory.",
+     "regulatory_reference": "63 P.S. § 456.1 et seq."},
+    {"state_code": "PA", "state_name": "Pennsylvania", "category": "disclosure",
+     "requirement": "Homeowner's Emergency Mortgage Assistance Program (HEMAP) disclosure required at loan origination.",
+     "regulatory_reference": "35 P.S. § 1680.401 et seq."},
+    {"state_code": "PA", "state_name": "Pennsylvania", "category": "disclosure",
+     "requirement": "Seller Property Disclosure Statement required for residential sales; covers structure, mechanical systems, environmental hazards.",
+     "regulatory_reference": "68 Pa. Stat. § 1023"},
+    {"state_code": "PA", "state_name": "Pennsylvania", "category": "fee_limit",
+     "requirement": "High-cost home loan: APR threshold 8% above TBMR for first liens. Points and fees > 4% triggers high-cost designation.",
+     "regulatory_reference": "41 P.S. § 101 (Loan Interest and Protection Law)"},
+    {"state_code": "PA", "state_name": "Pennsylvania", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on high-cost home loans.",
+     "regulatory_reference": "41 P.S. § 101"},
+    {"state_code": "PA", "state_name": "Pennsylvania", "category": "special_rule",
+     "requirement": "Act 91 Notice: lenders must send prescribed notice before initiating foreclosure, giving borrower access to HEMAP counseling.",
+     "regulatory_reference": "35 P.S. § 1680.403c"},
+    {"state_code": "PA", "state_name": "Pennsylvania", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "18 Pa. Cons. Stat. § 5703"},
+
+    # =========================================================================
+    # ILLINOIS
+    # =========================================================================
+    {"state_code": "IL", "state_name": "Illinois", "category": "licensing",
+     "requirement": "IDFPR Residential Mortgage License required. NMLS registration mandatory.",
+     "regulatory_reference": "205 ILCS 635/"},
+    {"state_code": "IL", "state_name": "Illinois", "category": "disclosure",
+     "requirement": "Residential Real Property Disclosure Act report required before sale of residential property.",
+     "regulatory_reference": "765 ILCS 77/"},
+    {"state_code": "IL", "state_name": "Illinois", "category": "disclosure",
+     "requirement": "Illinois Predatory Lending Database Program applies in Cook County and select collar counties; counseling certificate required.",
+     "regulatory_reference": "765 ILCS 77/70"},
+    {"state_code": "IL", "state_name": "Illinois", "category": "fee_limit",
+     "requirement": "High-risk home loan: points and fees cap at 5%. Anti-predatory lending rules impose additional restrictions in covered counties.",
+     "regulatory_reference": "815 ILCS 137/"},
+    {"state_code": "IL", "state_name": "Illinois", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on high-risk home loans.",
+     "regulatory_reference": "815 ILCS 137/35"},
+    {"state_code": "IL", "state_name": "Illinois", "category": "special_rule",
+     "requirement": "Attorneys are required to close real estate transactions in Illinois; title companies alone cannot close.",
+     "regulatory_reference": "Common practice / Illinois Supreme Court Rule 1.2"},
+    {"state_code": "IL", "state_name": "Illinois", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "720 ILCS 5/14-2"},
+
+    # =========================================================================
+    # OHIO
+    # =========================================================================
+    {"state_code": "OH", "state_name": "Ohio", "category": "licensing",
+     "requirement": "Ohio Division of Financial Institutions Mortgage Loan Originator license required. NMLS mandatory.",
+     "regulatory_reference": "Ohio Rev. Code § 1322.01 et seq."},
+    {"state_code": "OH", "state_name": "Ohio", "category": "disclosure",
+     "requirement": "Ohio Residential Property Disclosure Form required in sales of residential property (1–4 units).",
+     "regulatory_reference": "Ohio Rev. Code § 5302.30"},
+    {"state_code": "OH", "state_name": "Ohio", "category": "fee_limit",
+     "requirement": "Consumer Sales Practices Act applies; unconscionable terms or excessive fees may be challenged.",
+     "regulatory_reference": "Ohio Rev. Code § 1345.02"},
+    {"state_code": "OH", "state_name": "Ohio", "category": "prepayment",
+     "requirement": "No specific state prepayment penalty prohibition; contractual terms govern. Federal CFPB rules apply.",
+     "regulatory_reference": "Ohio Rev. Code Title XIII"},
+    {"state_code": "OH", "state_name": "Ohio", "category": "special_rule",
+     "requirement": "Ohio Anti-Predatory Lending law (OAML) imposes restrictions on high-cost loans originated in the state.",
+     "regulatory_reference": "Ohio Rev. Code § 1349.25"},
+    {"state_code": "OH", "state_name": "Ohio", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Ohio Rev. Code § 2933.52"},
+
+    # =========================================================================
+    # GEORGIA
+    # =========================================================================
+    {"state_code": "GA", "state_name": "Georgia", "category": "licensing",
+     "requirement": "Georgia Department of Banking and Finance license required. NMLS registration mandatory.",
+     "regulatory_reference": "O.C.G.A. § 7-1-1000 et seq."},
+    {"state_code": "GA", "state_name": "Georgia", "category": "disclosure",
+     "requirement": "Georgia Fair Lending Act Disclosure required for home loans. Notice of transfer of servicing required within 15 days.",
+     "regulatory_reference": "O.C.G.A. § 7-6A-1 et seq."},
+    {"state_code": "GA", "state_name": "Georgia", "category": "disclosure",
+     "requirement": "Seller's Property Disclosure Statement: required by convention in residential sales; statutory requirement for some transfers.",
+     "regulatory_reference": "O.C.G.A. § 44-1-16"},
+    {"state_code": "GA", "state_name": "Georgia", "category": "fee_limit",
+     "requirement": "High-cost home loan: points and fees > 5% of loan amount (or $800, whichever is greater) triggers GFLA restrictions.",
+     "regulatory_reference": "O.C.G.A. § 7-6A-2"},
+    {"state_code": "GA", "state_name": "Georgia", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on high-cost home loans under the Georgia Fair Lending Act.",
+     "regulatory_reference": "O.C.G.A. § 7-6A-6"},
+    {"state_code": "GA", "state_name": "Georgia", "category": "special_rule",
+     "requirement": "Georgia is a non-judicial foreclosure state; Power of Sale clauses are commonly used. 30-day notice required before foreclosure sale.",
+     "regulatory_reference": "O.C.G.A. § 44-14-162.2"},
+    {"state_code": "GA", "state_name": "Georgia", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "O.C.G.A. § 16-11-62"},
+
+    # =========================================================================
+    # NORTH CAROLINA
+    # =========================================================================
+    {"state_code": "NC", "state_name": "North Carolina", "category": "licensing",
+     "requirement": "NC Commissioner of Banks Mortgage Loan Originator license required. NMLS registration mandatory.",
+     "regulatory_reference": "N.C. Gen. Stat. § 53-244.010 et seq."},
+    {"state_code": "NC", "state_name": "North Carolina", "category": "disclosure",
+     "requirement": "NC Residential Property Disclosure Statement required in residential real estate sales.",
+     "regulatory_reference": "N.C. Gen. Stat. § 47E-4"},
+    {"state_code": "NC", "state_name": "North Carolina", "category": "fee_limit",
+     "requirement": "High-cost home loan: points and fees > 5% of loan or $1,000 (whichever is greater). APR threshold 8% above T-bond rate.",
+     "regulatory_reference": "N.C. Gen. Stat. § 24-1.1E"},
+    {"state_code": "NC", "state_name": "North Carolina", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on high-cost home loans. Conventional loans: not restricted beyond federal rules.",
+     "regulatory_reference": "N.C. Gen. Stat. § 24-1.1E(d)"},
+    {"state_code": "NC", "state_name": "North Carolina", "category": "cooling_off",
+     "requirement": "3-business-day waiting period after receipt of high-cost loan disclosures before consummation.",
+     "regulatory_reference": "N.C. Gen. Stat. § 24-1.1E(c)"},
+    {"state_code": "NC", "state_name": "North Carolina", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "N.C. Gen. Stat. § 15A-287"},
+
+    # =========================================================================
+    # MICHIGAN
+    # =========================================================================
+    {"state_code": "MI", "state_name": "Michigan", "category": "licensing",
+     "requirement": "DIFS (Department of Insurance and Financial Services) license required under MRMLA. NMLS mandatory.",
+     "regulatory_reference": "M.C.L. § 493.131 et seq."},
+    {"state_code": "MI", "state_name": "Michigan", "category": "disclosure",
+     "requirement": "Seller Disclosure Act: written disclosure statement required for residential sales of 1–4 units.",
+     "regulatory_reference": "M.C.L. § 565.951 et seq."},
+    {"state_code": "MI", "state_name": "Michigan", "category": "fee_limit",
+     "requirement": "High-cost mortgage: APR exceeds APOR by 6.5% (first lien). Points and fees > 5%. Additional MI-specific restrictions apply.",
+     "regulatory_reference": "M.C.L. § 445.1631 et seq."},
+    {"state_code": "MI", "state_name": "Michigan", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on high-cost mortgages. Otherwise governed by contractual terms.",
+     "regulatory_reference": "M.C.L. § 445.1638"},
+    {"state_code": "MI", "state_name": "Michigan", "category": "special_rule",
+     "requirement": "Michigan is a judicial foreclosure state by default but non-judicial (advertisement-based) foreclosure is available with power-of-sale clause.",
+     "regulatory_reference": "M.C.L. § 600.3101; M.C.L. § 600.3201"},
+    {"state_code": "MI", "state_name": "Michigan", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "M.C.L. § 750.539c"},
+
+    # =========================================================================
+    # NEW JERSEY
+    # =========================================================================
+    {"state_code": "NJ", "state_name": "New Jersey", "category": "licensing",
+     "requirement": "NJ Department of Banking and Insurance license required. NMLS registration mandatory.",
+     "regulatory_reference": "N.J. Stat. Ann. § 17:11C-51 et seq."},
+    {"state_code": "NJ", "state_name": "New Jersey", "category": "disclosure",
+     "requirement": "NJ Seller Property Condition Disclosure Statement required for residential sales.",
+     "regulatory_reference": "N.J. Stat. Ann. § 46:3C-1 et seq."},
+    {"state_code": "NJ", "state_name": "New Jersey", "category": "disclosure",
+     "requirement": "Lead paint disclosure required for residential housing built before 1978.",
+     "regulatory_reference": "N.J.A.C. 8:51"},
+    {"state_code": "NJ", "state_name": "New Jersey", "category": "fee_limit",
+     "requirement": "High-cost home loan: points and fees > 6% of loan amount triggers NJ Home Ownership Security Act restrictions.",
+     "regulatory_reference": "N.J. Stat. Ann. § 46:10B-22 et seq."},
+    {"state_code": "NJ", "state_name": "New Jersey", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on high-cost home loans under the NJ Home Ownership Security Act.",
+     "regulatory_reference": "N.J. Stat. Ann. § 46:10B-25(c)"},
+    {"state_code": "NJ", "state_name": "New Jersey", "category": "special_rule",
+     "requirement": "NJ is a judicial foreclosure state; foreclosure requires court filing, typically 200–400 days from default.",
+     "regulatory_reference": "N.J. Ct. R. 4:65"},
+    {"state_code": "NJ", "state_name": "New Jersey", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "N.J. Stat. Ann. § 2A:156A-4"},
+
+    # =========================================================================
+    # VIRGINIA
+    # =========================================================================
+    {"state_code": "VA", "state_name": "Virginia", "category": "licensing",
+     "requirement": "Virginia Bureau of Financial Institutions license required under the Virginia Mortgage Lender and Broker Act. NMLS mandatory.",
+     "regulatory_reference": "Va. Code Ann. § 6.2-1600 et seq."},
+    {"state_code": "VA", "state_name": "Virginia", "category": "disclosure",
+     "requirement": "Virginia Residential Property Disclosure Act: sellers must deliver disclosure or disclaimer statement.",
+     "regulatory_reference": "Va. Code Ann. § 55.1-700 et seq."},
+    {"state_code": "VA", "state_name": "Virginia", "category": "fee_limit",
+     "requirement": "Virginia Consumer Protection Act applies to mortgage transactions; unconscionable or deceptive fee arrangements are prohibited.",
+     "regulatory_reference": "Va. Code Ann. § 59.1-196 et seq."},
+    {"state_code": "VA", "state_name": "Virginia", "category": "prepayment",
+     "requirement": "No specific state prepayment penalty prohibition beyond federal rules. High-cost loan restrictions apply where triggered.",
+     "regulatory_reference": "Va. Code Ann. § 6.2-422"},
+    {"state_code": "VA", "state_name": "Virginia", "category": "special_rule",
+     "requirement": "Virginia uses non-judicial (deed of trust) foreclosure; trustee sale can proceed without court action after proper notice.",
+     "regulatory_reference": "Va. Code Ann. § 55.1-321"},
+    {"state_code": "VA", "state_name": "Virginia", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Va. Code Ann. § 19.2-62"},
+
+    # =========================================================================
+    # WASHINGTON
+    # =========================================================================
+    {"state_code": "WA", "state_name": "Washington", "category": "licensing",
+     "requirement": "Washington DFI Consumer Loan Company or Mortgage Broker license required. NMLS mandatory.",
+     "regulatory_reference": "Wash. Rev. Code § 31.04.015; § 19.146.200"},
+    {"state_code": "WA", "state_name": "Washington", "category": "disclosure",
+     "requirement": "Seller Disclosure Statement required for residential sales of real property.",
+     "regulatory_reference": "Wash. Rev. Code § 64.06.013"},
+    {"state_code": "WA", "state_name": "Washington", "category": "disclosure",
+     "requirement": "Washington's Predatory Lending Law requires good-faith estimate and closing cost disclosure consistent with TRID.",
+     "regulatory_reference": "Wash. Rev. Code § 19.146.030"},
+    {"state_code": "WA", "state_name": "Washington", "category": "fee_limit",
+     "requirement": "High-cost home loan: points and fees > 5% of loan amount or $1,000 (whichever is greater). APR threshold applies.",
+     "regulatory_reference": "Wash. Rev. Code § 19.144.020"},
+    {"state_code": "WA", "state_name": "Washington", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on high-cost home loans.",
+     "regulatory_reference": "Wash. Rev. Code § 19.144.040"},
+    {"state_code": "WA", "state_name": "Washington", "category": "special_rule",
+     "requirement": "Washington uses non-judicial (deed of trust) foreclosure with 190-day minimum process from notice of default.",
+     "regulatory_reference": "Wash. Rev. Code § 61.24.030"},
+    {"state_code": "WA", "state_name": "Washington", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "Wash. Rev. Code § 9.73.030"},
+
+    # =========================================================================
+    # ARIZONA
+    # =========================================================================
+    {"state_code": "AZ", "state_name": "Arizona", "category": "licensing",
+     "requirement": "Arizona Department of Financial Institutions Mortgage Banker/Broker license required. NMLS mandatory.",
+     "regulatory_reference": "A.R.S. § 6-901 et seq."},
+    {"state_code": "AZ", "state_name": "Arizona", "category": "disclosure",
+     "requirement": "Arizona Residential Seller Property Disclosure Statement (SPDS) required in residential resales.",
+     "regulatory_reference": "A.R.S. § 33-422"},
+    {"state_code": "AZ", "state_name": "Arizona", "category": "fee_limit",
+     "requirement": "No state-specific high-cost loan fee caps beyond federal HOEPA thresholds. Usury limits may apply to certain lenders.",
+     "regulatory_reference": "A.R.S. § 44-1201"},
+    {"state_code": "AZ", "state_name": "Arizona", "category": "prepayment",
+     "requirement": "Prepayment penalties permitted by contract on most loans; no specific state prohibition except as triggered by federal rules.",
+     "regulatory_reference": "A.R.S. § 33-806.01"},
+    {"state_code": "AZ", "state_name": "Arizona", "category": "special_rule",
+     "requirement": "Arizona is an anti-deficiency state: no deficiency judgment allowed on purchase-money mortgage on residential property (2.5 acres, single/2-family).",
+     "regulatory_reference": "A.R.S. § 33-729"},
+    {"state_code": "AZ", "state_name": "Arizona", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "A.R.S. § 13-3005"},
+
+    # =========================================================================
+    # MASSACHUSETTS
+    # =========================================================================
+    {"state_code": "MA", "state_name": "Massachusetts", "category": "licensing",
+     "requirement": "Massachusetts Division of Banks Mortgage Loan Originator license required. NMLS mandatory.",
+     "regulatory_reference": "Mass. Gen. Laws ch. 255E § 2"},
+    {"state_code": "MA", "state_name": "Massachusetts", "category": "disclosure",
+     "requirement": "Massachusetts Consumer Credit Cost Disclosure Act mandates APR disclosure in addition to TRID requirements.",
+     "regulatory_reference": "Mass. Gen. Laws ch. 140D"},
+    {"state_code": "MA", "state_name": "Massachusetts", "category": "disclosure",
+     "requirement": "Mandatory homebuyer counseling for first-time buyers using MassHousing or MHP products.",
+     "regulatory_reference": "760 C.M.R. § 56.00"},
+    {"state_code": "MA", "state_name": "Massachusetts", "category": "fee_limit",
+     "requirement": "High-cost home mortgage loan: points and fees > 5% of loan amount (or $800). APR threshold: 8% above T-bond rate.",
+     "regulatory_reference": "Mass. Gen. Laws ch. 183C"},
+    {"state_code": "MA", "state_name": "Massachusetts", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on high-cost home mortgage loans.",
+     "regulatory_reference": "Mass. Gen. Laws ch. 183C § 7"},
+    {"state_code": "MA", "state_name": "Massachusetts", "category": "special_rule",
+     "requirement": "Massachusetts uses non-judicial (power of sale) foreclosure after right to cure period (150-day notice requirement).",
+     "regulatory_reference": "Mass. Gen. Laws ch. 244 § 35A"},
+    {"state_code": "MA", "state_name": "Massachusetts", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "Mass. Gen. Laws ch. 272 § 99"},
+
+    # =========================================================================
+    # TENNESSEE
+    # =========================================================================
+    {"state_code": "TN", "state_name": "Tennessee", "category": "licensing",
+     "requirement": "Tennessee Department of Financial Institutions license required under the Tennessee Residential Lending, Brokerage and Servicing Act. NMLS mandatory.",
+     "regulatory_reference": "Tenn. Code Ann. § 45-13-101 et seq."},
+    {"state_code": "TN", "state_name": "Tennessee", "category": "disclosure",
+     "requirement": "Tennessee Residential Property Condition Disclosure required for all residential property transfers.",
+     "regulatory_reference": "Tenn. Code Ann. § 66-5-202"},
+    {"state_code": "TN", "state_name": "Tennessee", "category": "fee_limit",
+     "requirement": "Home loan high-cost thresholds follow federal HOEPA. No additional state-specific fee caps on conventional loans.",
+     "regulatory_reference": "Tenn. Code Ann. § 45-20-101"},
+    {"state_code": "TN", "state_name": "Tennessee", "category": "special_rule",
+     "requirement": "Tennessee uses non-judicial (trustee's sale) foreclosure; 20-day notice period required after advertisement.",
+     "regulatory_reference": "Tenn. Code Ann. § 35-5-101"},
+    {"state_code": "TN", "state_name": "Tennessee", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Tenn. Code Ann. § 39-13-601"},
+
+    # =========================================================================
+    # INDIANA
+    # =========================================================================
+    {"state_code": "IN", "state_name": "Indiana", "category": "licensing",
+     "requirement": "Indiana Department of Financial Institutions license required. NMLS registration mandatory.",
+     "regulatory_reference": "Ind. Code § 24-4.4-1-101 et seq."},
+    {"state_code": "IN", "state_name": "Indiana", "category": "disclosure",
+     "requirement": "Seller's Residential Real Estate Sales Disclosure required for sales of residential property (1–4 units).",
+     "regulatory_reference": "Ind. Code § 32-21-5-7"},
+    {"state_code": "IN", "state_name": "Indiana", "category": "fee_limit",
+     "requirement": "First lien home loan rates governed by Indiana Uniform Consumer Credit Code. Rate and fee ceilings apply.",
+     "regulatory_reference": "Ind. Code § 24-4.5-3-508"},
+    {"state_code": "IN", "state_name": "Indiana", "category": "special_rule",
+     "requirement": "Indiana requires judicial foreclosure; process typically takes 150–300 days.",
+     "regulatory_reference": "Ind. Code § 32-30-10-1"},
+    {"state_code": "IN", "state_name": "Indiana", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Ind. Code § 35-31.5-2-176"},
+
+    # =========================================================================
+    # MISSOURI
+    # =========================================================================
+    {"state_code": "MO", "state_name": "Missouri", "category": "licensing",
+     "requirement": "Missouri Division of Finance Mortgage Loan Originator license required. NMLS mandatory.",
+     "regulatory_reference": "Mo. Rev. Stat. § 443.800 et seq."},
+    {"state_code": "MO", "state_name": "Missouri", "category": "disclosure",
+     "requirement": "Missouri Seller Property Disclosure required in residential transactions; statutory form required.",
+     "regulatory_reference": "Mo. Rev. Stat. § 339.730"},
+    {"state_code": "MO", "state_name": "Missouri", "category": "fee_limit",
+     "requirement": "High-cost home loans follow federal HOEPA thresholds. Missouri has no additional state-specific points and fees cap.",
+     "regulatory_reference": "Mo. Rev. Stat. § 408.233"},
+    {"state_code": "MO", "state_name": "Missouri", "category": "special_rule",
+     "requirement": "Missouri allows both judicial and non-judicial (deed of trust with power of sale) foreclosure. Non-judicial takes ~60 days.",
+     "regulatory_reference": "Mo. Rev. Stat. § 443.310"},
+    {"state_code": "MO", "state_name": "Missouri", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Mo. Rev. Stat. § 542.402"},
+
+    # =========================================================================
+    # MARYLAND
+    # =========================================================================
+    {"state_code": "MD", "state_name": "Maryland", "category": "licensing",
+     "requirement": "Maryland Commissioner of Financial Regulation license required under the Maryland Mortgage Lender Law. NMLS mandatory.",
+     "regulatory_reference": "Md. Code Ann., Fin. Inst. § 11-501 et seq."},
+    {"state_code": "MD", "state_name": "Maryland", "category": "disclosure",
+     "requirement": "Maryland Residential Property Disclosure/Disclaimer Statement required in residential sales.",
+     "regulatory_reference": "Md. Code Ann., Real Prop. § 10-702"},
+    {"state_code": "MD", "state_name": "Maryland", "category": "disclosure",
+     "requirement": "Mortgage loan originator disclosures required at application under Maryland Mortgage Disclosure Act.",
+     "regulatory_reference": "Md. Code Ann., Real Prop. § 11-101"},
+    {"state_code": "MD", "state_name": "Maryland", "category": "fee_limit",
+     "requirement": "Maryland Mortgage Fraud Protection Act limits origination fees on first-time homebuyer loans to 1.5% of loan amount.",
+     "regulatory_reference": "Md. Code Ann., Real Prop. § 7-113"},
+    {"state_code": "MD", "state_name": "Maryland", "category": "prepayment",
+     "requirement": "Prepayment penalties prohibited on variable rate mortgages and certain high-cost loans.",
+     "regulatory_reference": "Md. Code Ann., Com. Law § 12-105"},
+    {"state_code": "MD", "state_name": "Maryland", "category": "special_rule",
+     "requirement": "Maryland requires judicial foreclosure (circuit court). Loss mitigation conference required before final order.",
+     "regulatory_reference": "Md. Code Ann., Real Prop. § 7-105.1"},
+    {"state_code": "MD", "state_name": "Maryland", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "Md. Code Ann., Cts. & Jud. Proc. § 10-402"},
+
+    # =========================================================================
+    # WISCONSIN
+    # =========================================================================
+    {"state_code": "WI", "state_name": "Wisconsin", "category": "licensing",
+     "requirement": "Wisconsin Department of Financial Institutions license required under the Wisconsin Mortgage Banking Act. NMLS mandatory.",
+     "regulatory_reference": "Wis. Stat. § 224.71 et seq."},
+    {"state_code": "WI", "state_name": "Wisconsin", "category": "disclosure",
+     "requirement": "Real Estate Condition Report required in residential property sales (1–4 units); seller must complete within 10 days of acceptance.",
+     "regulatory_reference": "Wis. Stat. § 709.03"},
+    {"state_code": "WI", "state_name": "Wisconsin", "category": "fee_limit",
+     "requirement": "Wisconsin high-cost home loan provisions mirror federal HOEPA thresholds. No additional state-specific points and fees cap.",
+     "regulatory_reference": "Wis. Stat. § 428.208"},
+    {"state_code": "WI", "state_name": "Wisconsin", "category": "prepayment",
+     "requirement": "Prepayment permitted on residential mortgages; no state statutory prohibition on prepayment penalties beyond federal rules.",
+     "regulatory_reference": "Wis. Stat. § 138.052"},
+    {"state_code": "WI", "state_name": "Wisconsin", "category": "special_rule",
+     "requirement": "Wisconsin uses judicial foreclosure; borrower has 12-month (or 6-month for abandoned property) right of redemption after sale.",
+     "regulatory_reference": "Wis. Stat. § 846.13"},
+    {"state_code": "WI", "state_name": "Wisconsin", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Wis. Stat. § 968.31"},
+
+    # =========================================================================
+    # REMAINING 31 STATES + DC  (licensing + key disclosure + recording consent)
+    # =========================================================================
+
+    # ALABAMA
+    {"state_code": "AL", "state_name": "Alabama", "category": "licensing",
+     "requirement": "Alabama State Banking Department license required. NMLS registration mandatory.",
+     "regulatory_reference": "Ala. Code § 5-25-1 et seq."},
+    {"state_code": "AL", "state_name": "Alabama", "category": "disclosure",
+     "requirement": "Alabama residential property disclosure recommended; not statutorily mandated statewide but often required by contract.",
+     "regulatory_reference": "Ala. Code § 6-5-102"},
+    {"state_code": "AL", "state_name": "Alabama", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Ala. Code § 13A-11-30"},
+
+    # ALASKA
+    {"state_code": "AK", "state_name": "Alaska", "category": "licensing",
+     "requirement": "Alaska Division of Banking and Securities license required. NMLS mandatory.",
+     "regulatory_reference": "Alaska Stat. § 06.60.010 et seq."},
+    {"state_code": "AK", "state_name": "Alaska", "category": "disclosure",
+     "requirement": "Alaska Residential Real Property Transfer Disclosure required for residential sales.",
+     "regulatory_reference": "Alaska Stat. § 34.70.010"},
+    {"state_code": "AK", "state_name": "Alaska", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Alaska Stat. § 42.20.310"},
+
+    # ARKANSAS
+    {"state_code": "AR", "state_name": "Arkansas", "category": "licensing",
+     "requirement": "Arkansas Securities Department license required. NMLS registration mandatory.",
+     "regulatory_reference": "Ark. Code Ann. § 23-39-501 et seq."},
+    {"state_code": "AR", "state_name": "Arkansas", "category": "disclosure",
+     "requirement": "Seller property disclosure recommended; no statewide statutory mandate, but common by contract.",
+     "regulatory_reference": "Ark. Code Ann. § 17-42-301"},
+    {"state_code": "AR", "state_name": "Arkansas", "category": "special_rule",
+     "requirement": "Arkansas usury constitution: maximum interest rate is 5% above Federal Reserve discount rate. Exemptions apply to certain institutional lenders.",
+     "regulatory_reference": "Ark. Const. Amend. 89"},
+    {"state_code": "AR", "state_name": "Arkansas", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Ark. Code Ann. § 5-60-120"},
+
+    # COLORADO
+    {"state_code": "CO", "state_name": "Colorado", "category": "licensing",
+     "requirement": "Colorado Division of Real Estate or DORA license required. NMLS registration mandatory.",
+     "regulatory_reference": "Colo. Rev. Stat. § 12-10-701 et seq."},
+    {"state_code": "CO", "state_name": "Colorado", "category": "disclosure",
+     "requirement": "Colorado Seller's Property Disclosure required in residential sales.",
+     "regulatory_reference": "Colo. Rev. Stat. § 38-35.7-101"},
+    {"state_code": "CO", "state_name": "Colorado", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Colo. Rev. Stat. § 18-9-304"},
+
+    # CONNECTICUT
+    {"state_code": "CT", "state_name": "Connecticut", "category": "licensing",
+     "requirement": "Connecticut Department of Banking license required under the Connecticut Mortgage Act. NMLS mandatory.",
+     "regulatory_reference": "Conn. Gen. Stat. § 36a-485 et seq."},
+    {"state_code": "CT", "state_name": "Connecticut", "category": "disclosure",
+     "requirement": "Connecticut Disclosure of Property Conditions required for residential sales.",
+     "regulatory_reference": "Conn. Gen. Stat. § 20-327b"},
+    {"state_code": "CT", "state_name": "Connecticut", "category": "special_rule",
+     "requirement": "Connecticut anti-predatory lending: high-cost home loan law imposes counseling requirements and prohibits balloon payments in first 7 years.",
+     "regulatory_reference": "Conn. Gen. Stat. § 36a-746a"},
+    {"state_code": "CT", "state_name": "Connecticut", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "Conn. Gen. Stat. § 52-570d"},
+
+    # DELAWARE
+    {"state_code": "DE", "state_name": "Delaware", "category": "licensing",
+     "requirement": "Delaware Office of the State Bank Commissioner license required. NMLS registration mandatory.",
+     "regulatory_reference": "Del. Code Ann. tit. 5, § 2101 et seq."},
+    {"state_code": "DE", "state_name": "Delaware", "category": "disclosure",
+     "requirement": "Delaware Seller's Disclosure of Real Property Condition required for residential sales.",
+     "regulatory_reference": "Del. Code Ann. tit. 6, § 2572"},
+    {"state_code": "DE", "state_name": "Delaware", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Del. Code Ann. tit. 11, § 2402"},
+
+    # DISTRICT OF COLUMBIA
+    {"state_code": "DC", "state_name": "District of Columbia", "category": "licensing",
+     "requirement": "DC Department of Insurance, Securities and Banking license required. NMLS registration mandatory.",
+     "regulatory_reference": "D.C. Code § 26-1101 et seq."},
+    {"state_code": "DC", "state_name": "District of Columbia", "category": "disclosure",
+     "requirement": "DC Seller Disclosure Act: written disclosure required for residential sales of 1–4 units.",
+     "regulatory_reference": "D.C. Code § 42-1302"},
+    {"state_code": "DC", "state_name": "District of Columbia", "category": "special_rule",
+     "requirement": "DC Predatory Lending Amendment Act imposes strict high-cost loan restrictions, mandatory counseling, and borrower protections.",
+     "regulatory_reference": "D.C. Code § 26-1151.01 et seq."},
+    {"state_code": "DC", "state_name": "District of Columbia", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "D.C. Code § 23-542"},
+
+    # HAWAII
+    {"state_code": "HI", "state_name": "Hawaii", "category": "licensing",
+     "requirement": "Hawaii Division of Financial Institutions license required. NMLS registration mandatory.",
+     "regulatory_reference": "Haw. Rev. Stat. § 454F-1 et seq."},
+    {"state_code": "HI", "state_name": "Hawaii", "category": "disclosure",
+     "requirement": "Hawaii Seller's Disclosure Statement required. Leasehold vs. fee simple status must be disclosed prominently.",
+     "regulatory_reference": "Haw. Rev. Stat. § 508D-4"},
+    {"state_code": "HI", "state_name": "Hawaii", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "Haw. Rev. Stat. § 803-42"},
+
+    # IDAHO
+    {"state_code": "ID", "state_name": "Idaho", "category": "licensing",
+     "requirement": "Idaho Department of Finance license required. NMLS registration mandatory.",
+     "regulatory_reference": "Idaho Code § 26-3101 et seq."},
+    {"state_code": "ID", "state_name": "Idaho", "category": "disclosure",
+     "requirement": "Seller Property Condition Disclosure Form required for residential sales in Idaho.",
+     "regulatory_reference": "Idaho Code § 55-2501 et seq."},
+    {"state_code": "ID", "state_name": "Idaho", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Idaho Code § 18-6702"},
+
+    # IOWA
+    {"state_code": "IA", "state_name": "Iowa", "category": "licensing",
+     "requirement": "Iowa Division of Banking license required. NMLS registration mandatory.",
+     "regulatory_reference": "Iowa Code § 535B.1 et seq."},
+    {"state_code": "IA", "state_name": "Iowa", "category": "disclosure",
+     "requirement": "Iowa Residential Property Seller Disclosure Statement required for residential sales.",
+     "regulatory_reference": "Iowa Code § 558A.4"},
+    {"state_code": "IA", "state_name": "Iowa", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Iowa Code § 808B.2"},
+
+    # KANSAS
+    {"state_code": "KS", "state_name": "Kansas", "category": "licensing",
+     "requirement": "Kansas Office of the State Bank Commissioner license required. NMLS mandatory.",
+     "regulatory_reference": "Kan. Stat. Ann. § 9-2201 et seq."},
+    {"state_code": "KS", "state_name": "Kansas", "category": "disclosure",
+     "requirement": "Kansas Seller's Disclosure of Property Condition required for residential sales.",
+     "regulatory_reference": "Kan. Stat. Ann. § 58-30,105"},
+    {"state_code": "KS", "state_name": "Kansas", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Kan. Stat. Ann. § 21-6101"},
+
+    # KENTUCKY
+    {"state_code": "KY", "state_name": "Kentucky", "category": "licensing",
+     "requirement": "Kentucky Department of Financial Institutions license required. NMLS registration mandatory.",
+     "regulatory_reference": "Ky. Rev. Stat. Ann. § 286.8-010 et seq."},
+    {"state_code": "KY", "state_name": "Kentucky", "category": "disclosure",
+     "requirement": "Kentucky Seller's Disclosure of Property Condition required for residential sales.",
+     "regulatory_reference": "Ky. Rev. Stat. Ann. § 324.360"},
+    {"state_code": "KY", "state_name": "Kentucky", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Ky. Rev. Stat. Ann. § 526.010"},
+
+    # LOUISIANA
+    {"state_code": "LA", "state_name": "Louisiana", "category": "licensing",
+     "requirement": "Louisiana Office of Financial Institutions license required. NMLS registration mandatory.",
+     "regulatory_reference": "La. Rev. Stat. Ann. § 6:1082 et seq."},
+    {"state_code": "LA", "state_name": "Louisiana", "category": "disclosure",
+     "requirement": "Louisiana Property Disclosure Document required for residential sales of 1–4 units.",
+     "regulatory_reference": "La. Rev. Stat. Ann. § 9:3196 et seq."},
+    {"state_code": "LA", "state_name": "Louisiana", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "La. Rev. Stat. Ann. § 15:1303"},
+
+    # MAINE
+    {"state_code": "ME", "state_name": "Maine", "category": "licensing",
+     "requirement": "Maine Bureau of Consumer Credit Protection license required. NMLS registration mandatory.",
+     "regulatory_reference": "Me. Rev. Stat. tit. 9-A, § 6-201 et seq."},
+    {"state_code": "ME", "state_name": "Maine", "category": "disclosure",
+     "requirement": "Maine Seller Disclosure of Property Condition required for residential real estate transfers.",
+     "regulatory_reference": "Me. Rev. Stat. tit. 33, § 173"},
+    {"state_code": "ME", "state_name": "Maine", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "Me. Rev. Stat. tit. 15, § 710"},
+
+    # MINNESOTA
+    {"state_code": "MN", "state_name": "Minnesota", "category": "licensing",
+     "requirement": "Minnesota Department of Commerce Residential Mortgage Originator license required. NMLS mandatory.",
+     "regulatory_reference": "Minn. Stat. § 58A.04 et seq."},
+    {"state_code": "MN", "state_name": "Minnesota", "category": "disclosure",
+     "requirement": "Minnesota Seller's Property Disclosure required for residential property sales.",
+     "regulatory_reference": "Minn. Stat. § 513.55"},
+    {"state_code": "MN", "state_name": "Minnesota", "category": "special_rule",
+     "requirement": "Minnesota Residential Mortgage Originator and Servicer Licensing Act imposes specific borrower notice requirements for servicing transfers.",
+     "regulatory_reference": "Minn. Stat. § 58A.14"},
+    {"state_code": "MN", "state_name": "Minnesota", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Minn. Stat. § 626A.02"},
+
+    # MISSISSIPPI
+    {"state_code": "MS", "state_name": "Mississippi", "category": "licensing",
+     "requirement": "Mississippi Department of Banking and Consumer Finance license required. NMLS mandatory.",
+     "regulatory_reference": "Miss. Code Ann. § 81-18-1 et seq."},
+    {"state_code": "MS", "state_name": "Mississippi", "category": "disclosure",
+     "requirement": "Seller disclosure of property condition required; statutory form promulgated by Mississippi Real Estate Commission.",
+     "regulatory_reference": "Miss. Code Ann. § 89-1-501 et seq."},
+    {"state_code": "MS", "state_name": "Mississippi", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Miss. Code Ann. § 41-29-531"},
+
+    # MONTANA
+    {"state_code": "MT", "state_name": "Montana", "category": "licensing",
+     "requirement": "Montana Division of Banking and Financial Institutions license required. NMLS registration mandatory.",
+     "regulatory_reference": "Mont. Code Ann. § 32-9-101 et seq."},
+    {"state_code": "MT", "state_name": "Montana", "category": "disclosure",
+     "requirement": "Montana Seller Disclosure Act requires written disclosure of known defects in residential property.",
+     "regulatory_reference": "Mont. Code Ann. § 37-51-209"},
+    {"state_code": "MT", "state_name": "Montana", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Mont. Code Ann. § 45-8-213"},
+
+    # NEBRASKA
+    {"state_code": "NE", "state_name": "Nebraska", "category": "licensing",
+     "requirement": "Nebraska Department of Banking and Finance license required. NMLS mandatory.",
+     "regulatory_reference": "Neb. Rev. Stat. § 45-725 et seq."},
+    {"state_code": "NE", "state_name": "Nebraska", "category": "disclosure",
+     "requirement": "Nebraska Seller Property Condition Disclosure Statement required for residential sales.",
+     "regulatory_reference": "Neb. Rev. Stat. § 76-2,120"},
+    {"state_code": "NE", "state_name": "Nebraska", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Neb. Rev. Stat. § 86-290"},
+
+    # NEVADA
+    {"state_code": "NV", "state_name": "Nevada", "category": "licensing",
+     "requirement": "Nevada Division of Mortgage Lending license required. NMLS registration mandatory.",
+     "regulatory_reference": "Nev. Rev. Stat. § 645B.010 et seq."},
+    {"state_code": "NV", "state_name": "Nevada", "category": "disclosure",
+     "requirement": "Nevada Seller's Real Property Disclosure Form (SRPD) required in residential sales.",
+     "regulatory_reference": "Nev. Rev. Stat. § 113.130"},
+    {"state_code": "NV", "state_name": "Nevada", "category": "special_rule",
+     "requirement": "Nevada is an anti-deficiency state for purchase-money mortgages on single-family residences; lender cannot pursue deficiency after foreclosure.",
+     "regulatory_reference": "Nev. Rev. Stat. § 40.455"},
+    {"state_code": "NV", "state_name": "Nevada", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Nev. Rev. Stat. § 200.620"},
+
+    # NEW HAMPSHIRE
+    {"state_code": "NH", "state_name": "New Hampshire", "category": "licensing",
+     "requirement": "New Hampshire Banking Department license required. NMLS registration mandatory.",
+     "regulatory_reference": "N.H. Rev. Stat. Ann. § 397-A:1 et seq."},
+    {"state_code": "NH", "state_name": "New Hampshire", "category": "disclosure",
+     "requirement": "Seller Property Disclosure Form required for residential sales; covers structural, mechanical, and environmental conditions.",
+     "regulatory_reference": "N.H. Rev. Stat. Ann. § 477:4-d"},
+    {"state_code": "NH", "state_name": "New Hampshire", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "N.H. Rev. Stat. Ann. § 570-A:2"},
+
+    # NEW MEXICO
+    {"state_code": "NM", "state_name": "New Mexico", "category": "licensing",
+     "requirement": "New Mexico Financial Institutions Division license required. NMLS mandatory.",
+     "regulatory_reference": "N.M. Stat. Ann. § 58-21A-1 et seq."},
+    {"state_code": "NM", "state_name": "New Mexico", "category": "disclosure",
+     "requirement": "New Mexico Seller Property Disclosure Statement required for residential sales.",
+     "regulatory_reference": "N.M. Stat. Ann. § 47-13-3"},
+    {"state_code": "NM", "state_name": "New Mexico", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "N.M. Stat. Ann. § 30-12-1"},
+
+    # NORTH DAKOTA
+    {"state_code": "ND", "state_name": "North Dakota", "category": "licensing",
+     "requirement": "North Dakota Department of Financial Institutions license required. NMLS mandatory.",
+     "regulatory_reference": "N.D. Cent. Code § 13-11-01 et seq."},
+    {"state_code": "ND", "state_name": "North Dakota", "category": "disclosure",
+     "requirement": "North Dakota Seller Disclosure of Property Condition required for residential real estate sales.",
+     "regulatory_reference": "N.D. Cent. Code § 47-10-02.3"},
+    {"state_code": "ND", "state_name": "North Dakota", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "N.D. Cent. Code § 12.1-15-02"},
+
+    # OKLAHOMA
+    {"state_code": "OK", "state_name": "Oklahoma", "category": "licensing",
+     "requirement": "Oklahoma Department of Consumer Credit license required. NMLS registration mandatory.",
+     "regulatory_reference": "Okla. Stat. tit. 59, § 2095 et seq."},
+    {"state_code": "OK", "state_name": "Oklahoma", "category": "disclosure",
+     "requirement": "Oklahoma Residential Property Condition Disclosure required for residential sales.",
+     "regulatory_reference": "Okla. Stat. tit. 60, § 831 et seq."},
+    {"state_code": "OK", "state_name": "Oklahoma", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Okla. Stat. tit. 13, § 176.4"},
+
+    # OREGON
+    {"state_code": "OR", "state_name": "Oregon", "category": "licensing",
+     "requirement": "Oregon Division of Financial Regulation license required. NMLS mandatory.",
+     "regulatory_reference": "Or. Rev. Stat. § 86A.100 et seq."},
+    {"state_code": "OR", "state_name": "Oregon", "category": "disclosure",
+     "requirement": "Oregon Seller's Property Disclosure Statement required for residential sales of 1–4 units.",
+     "regulatory_reference": "Or. Rev. Stat. § 105.465"},
+    {"state_code": "OR", "state_name": "Oregon", "category": "special_rule",
+     "requirement": "Oregon Home Loan Protection Act (OHLPA): high-cost home loan restrictions including mandatory counseling.",
+     "regulatory_reference": "Or. Rev. Stat. § 86A.159"},
+    {"state_code": "OR", "state_name": "Oregon", "category": "recording_consent",
+     "requirement": "Two-party (all-party) consent required for recording telephone calls.",
+     "regulatory_reference": "Or. Rev. Stat. § 165.540"},
+
+    # RHODE ISLAND
+    {"state_code": "RI", "state_name": "Rhode Island", "category": "licensing",
+     "requirement": "Rhode Island Department of Business Regulation license required. NMLS registration mandatory.",
+     "regulatory_reference": "R.I. Gen. Laws § 19-14.1-1 et seq."},
+    {"state_code": "RI", "state_name": "Rhode Island", "category": "disclosure",
+     "requirement": "Rhode Island mandatory disclosure of high-cost home loan terms; additional protections for subprime borrowers.",
+     "regulatory_reference": "R.I. Gen. Laws § 34-25.2-6"},
+    {"state_code": "RI", "state_name": "Rhode Island", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "R.I. Gen. Laws § 11-35-21"},
+
+    # SOUTH CAROLINA
+    {"state_code": "SC", "state_name": "South Carolina", "category": "licensing",
+     "requirement": "South Carolina Department of Consumer Affairs license required. NMLS registration mandatory.",
+     "regulatory_reference": "S.C. Code Ann. § 37-22-110 et seq."},
+    {"state_code": "SC", "state_name": "South Carolina", "category": "disclosure",
+     "requirement": "South Carolina Residential Property Condition Disclosure Statement required for residential sales.",
+     "regulatory_reference": "S.C. Code Ann. § 27-50-10 et seq."},
+    {"state_code": "SC", "state_name": "South Carolina", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "S.C. Code Ann. § 17-30-30"},
+
+    # SOUTH DAKOTA
+    {"state_code": "SD", "state_name": "South Dakota", "category": "licensing",
+     "requirement": "South Dakota Division of Banking license required. NMLS registration mandatory.",
+     "regulatory_reference": "S.D. Codified Laws § 36-21A-57 et seq."},
+    {"state_code": "SD", "state_name": "South Dakota", "category": "disclosure",
+     "requirement": "Seller Property Condition Disclosure required; statutory form required for residential property sales.",
+     "regulatory_reference": "S.D. Codified Laws § 43-4-44"},
+    {"state_code": "SD", "state_name": "South Dakota", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "S.D. Codified Laws § 23A-35A-20"},
+
+    # UTAH
+    {"state_code": "UT", "state_name": "Utah", "category": "licensing",
+     "requirement": "Utah Department of Financial Institutions license required. NMLS registration mandatory.",
+     "regulatory_reference": "Utah Code Ann. § 61-2c-101 et seq."},
+    {"state_code": "UT", "state_name": "Utah", "category": "disclosure",
+     "requirement": "Utah Seller Property Condition Disclosure required for residential sales of 1–5 units.",
+     "regulatory_reference": "Utah Code Ann. § 57-27-101 et seq."},
+    {"state_code": "UT", "state_name": "Utah", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Utah Code Ann. § 77-23a-4"},
+
+    # VERMONT
+    {"state_code": "VT", "state_name": "Vermont", "category": "licensing",
+     "requirement": "Vermont Department of Financial Regulation license required. NMLS registration mandatory.",
+     "regulatory_reference": "Vt. Stat. Ann. tit. 8, § 2200 et seq."},
+    {"state_code": "VT", "state_name": "Vermont", "category": "disclosure",
+     "requirement": "Vermont Seller's Property Disclosure Form required; covers structural, mechanical, environmental, and title issues.",
+     "regulatory_reference": "Vt. Stat. Ann. tit. 27, § 834"},
+    {"state_code": "VT", "state_name": "Vermont", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Vt. Stat. Ann. tit. 13, § 4601"},
+
+    # WEST VIRGINIA
+    {"state_code": "WV", "state_name": "West Virginia", "category": "licensing",
+     "requirement": "West Virginia Division of Financial Institutions license required. NMLS mandatory.",
+     "regulatory_reference": "W. Va. Code § 31-17-1 et seq."},
+    {"state_code": "WV", "state_name": "West Virginia", "category": "disclosure",
+     "requirement": "West Virginia Residential Property Disclosure required; seller must disclose known defects to buyer.",
+     "regulatory_reference": "W. Va. Code § 36B-4-102"},
+    {"state_code": "WV", "state_name": "West Virginia", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "W. Va. Code § 62-1D-3"},
+
+    # WYOMING
+    {"state_code": "WY", "state_name": "Wyoming", "category": "licensing",
+     "requirement": "Wyoming Division of Banking license required. NMLS registration mandatory.",
+     "regulatory_reference": "Wyo. Stat. Ann. § 40-23-101 et seq."},
+    {"state_code": "WY", "state_name": "Wyoming", "category": "disclosure",
+     "requirement": "Seller Property Disclosure Form required for residential sales; statutory form mandated.",
+     "regulatory_reference": "Wyo. Stat. Ann. § 33-28-303"},
+    {"state_code": "WY", "state_name": "Wyoming", "category": "recording_consent",
+     "requirement": "One-party consent for recording telephone calls.",
+     "regulatory_reference": "Wyo. Stat. Ann. § 7-3-702"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def seed_state_disclosures(db) -> int:
+    """
+    Seed the state_disclosures table.
+
+    Skips seeding if any rows already exist.
+    Returns the number of rows inserted.
+    """
+    from database.models.state_disclosure import StateDisclosure
+
+    # Ensure table exists
+    from database import Base
+    from db import engine as _engine
+    StateDisclosure.__table__.create(_engine, checkfirst=True)
+
+    existing = db.query(StateDisclosure).count()
+    if existing > 0:
+        logger.info("state_disclosures already seeded (%d rows), skipping.", existing)
+        return 0
+
+    rows = [StateDisclosure(**entry) for entry in _DISCLOSURES]
+    db.bulk_save_objects(rows)
+    logger.info("Seeded %d state disclosure entries.", len(rows))
+    return len(rows)
+
+
+def clear_state_disclosures(db) -> int:
+    """Delete all rows from state_disclosures. Returns number of deleted rows."""
+    from database.models.state_disclosure import StateDisclosure
+    deleted = db.query(StateDisclosure).delete()
+    logger.info("Cleared %d state disclosure rows.", deleted)
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# CLI runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import logging as _logging
+    _logging.basicConfig(level=_logging.INFO)
+
+    from db import SessionLocal
+    db = SessionLocal()
+    try:
+        count = seed_state_disclosures(db)
+        db.commit()
+        print(f"Done! Inserted {count} rows.")
+    finally:
+        db.close()

--- a/backend/routes/health_routes.py
+++ b/backend/routes/health_routes.py
@@ -980,6 +980,11 @@ def register_health_routes(app, get_db, **kwargs):
             content={"status": "not_ready", "checks": checks, "errors": errors}
         )
 
+    @app.get("/ready")
+    async def ready_alias():
+        """Root-level readiness alias for load balancers."""
+        return await readiness_check()
+
     # ========================================================================
     # Health live (lines ~16951-16954 in inline_legacy_routes.py)
     # ========================================================================

--- a/backend/routes/state_disclosure_routes.py
+++ b/backend/routes/state_disclosure_routes.py
@@ -1,0 +1,83 @@
+"""Admin routes for managing state disclosure requirements."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from typing import Optional
+
+router = APIRouter(prefix="/api/v1/admin/state-disclosures", tags=["State Disclosures"])
+
+
+def register_state_disclosure_routes(app, get_db):
+    """Register state disclosure admin routes."""
+
+    @router.get("")
+    async def list_state_disclosures(
+        state: Optional[str] = Query(None, description="Filter by state code (e.g., CA)"),
+        category: Optional[str] = Query(None, description="Filter by category"),
+        db: Session = Depends(get_db),
+    ):
+        from database.models.state_disclosure import StateDisclosure
+        query = db.query(StateDisclosure)
+        if state:
+            query = query.filter(StateDisclosure.state_code == state.upper())
+        if category:
+            query = query.filter(StateDisclosure.category == category)
+        results = query.order_by(StateDisclosure.state_code, StateDisclosure.category).all()
+        return {
+            "count": len(results),
+            "disclosures": [
+                {
+                    "id": r.id,
+                    "state_code": r.state_code,
+                    "state_name": r.state_name,
+                    "category": r.category,
+                    "requirement": r.requirement,
+                    "applies_to_loan_types": r.applies_to_loan_types,
+                    "regulatory_reference": r.regulatory_reference,
+                    "effective_date": r.effective_date.isoformat() if r.effective_date else None,
+                }
+                for r in results
+            ],
+        }
+
+    @router.put("/{disclosure_id}")
+    async def update_state_disclosure(
+        disclosure_id: int,
+        requirement: Optional[str] = None,
+        regulatory_reference: Optional[str] = None,
+        db: Session = Depends(get_db),
+    ):
+        from database.models.state_disclosure import StateDisclosure
+        disc = db.query(StateDisclosure).filter(StateDisclosure.id == disclosure_id).first()
+        if not disc:
+            raise HTTPException(status_code=404, detail="Disclosure not found")
+        if requirement is not None:
+            disc.requirement = requirement
+        if regulatory_reference is not None:
+            disc.regulatory_reference = regulatory_reference
+        db.commit()
+        return {"status": "updated", "id": disc.id}
+
+    @router.get("/states")
+    async def list_available_states(db: Session = Depends(get_db)):
+        from database.models.state_disclosure import StateDisclosure
+        from sqlalchemy import func as sqlfunc
+        states = (
+            db.query(
+                StateDisclosure.state_code,
+                StateDisclosure.state_name,
+                sqlfunc.count().label("count"),
+            )
+            .group_by(StateDisclosure.state_code, StateDisclosure.state_name)
+            .order_by(StateDisclosure.state_code)
+            .all()
+        )
+        return {
+            "count": len(states),
+            "states": [
+                {"code": s.state_code, "name": s.state_name, "requirements": s.count}
+                for s in states
+            ],
+        }
+
+    app.include_router(router)

--- a/backend/tasks/morning_briefing_tasks.py
+++ b/backend/tasks/morning_briefing_tasks.py
@@ -245,6 +245,26 @@ def generate_user_briefing(self, user_id: int, briefing_date_str: str, briefing_
             user_name = user.full_name if hasattr(user, "full_name") else (
                 f"{user.first_name or ''} {user.last_name or ''}".strip() or "there"
             )
+
+            # Load white-label branding (if configured)
+            branding = {}
+            wl_config = None
+            try:
+                from database.models.white_label_config import WhiteLabelConfig
+                wl_config = db.query(WhiteLabelConfig).filter(
+                    WhiteLabelConfig.organization_id == user.organization_id,
+                    WhiteLabelConfig.is_active == True,
+                ).first()
+                if wl_config:
+                    branding = {
+                        "company_name": wl_config.company_name or "Perennia AI",
+                        "logo_url": wl_config.logo_url,
+                        "primary_color": wl_config.primary_color or "#218d8d",
+                        "secondary_color": wl_config.secondary_color,
+                    }
+            except Exception as e:
+                logger.warning("Failed to load white-label config for org %s: %s", user.organization_id, e)
+
             html = render_briefing_email(
                 user_name=user_name,
                 briefing_date=briefing_date,
@@ -257,13 +277,18 @@ def generate_user_briefing(self, user_id: int, briefing_date_str: str, briefing_
                 conditions=ctx.conditions,
                 yesterday=ctx.yesterday,
                 team=ctx.team,
+                **branding,
             )
             briefing.html_content = html
 
             # Send email
             email_sent = False
             try:
-                _send_briefing_email(user.email, user_name, briefing_date, briefing_level, html, ctx.pipeline)
+                _send_briefing_email(
+                    user.email, user_name, briefing_date, briefing_level, html, ctx.pipeline,
+                    from_name_override=branding.get("company_name"),
+                    from_email_override=wl_config.email_from_address if wl_config else None,
+                )
                 briefing.email_sent_at = datetime.now(timezone.utc)
                 email_sent = True
             except Exception as e:
@@ -305,6 +330,8 @@ def generate_user_briefing(self, user_id: int, briefing_date_str: str, briefing_
 def _send_briefing_email(
     to_email: str, user_name: str, briefing_date: date,
     level: str, html: str, pipeline: dict,
+    from_name_override: str = None,
+    from_email_override: str = None,
 ):
     """Send briefing email via SendGrid / notification service."""
     import sendgrid
@@ -322,8 +349,8 @@ def _send_briefing_email(
     level_labels = {"individual": f"{active} active loans", "manager": "team briefing", "leadership": f"${volume / 1_000_000:.1f}M pipeline"}
     subject = f"Your Morning Briefing — {short_date} — {level_labels.get(level, '')}"
 
-    from_email = os.getenv("BRIEFING_FROM_EMAIL", "briefing@perenniaai.com")
-    from_name = os.getenv("SENDGRID_FROM_NAME", "Perennia AI")
+    from_email = from_email_override or os.getenv("BRIEFING_FROM_EMAIL", "briefing@perenniaai.com")
+    from_name = from_name_override or os.getenv("SENDGRID_FROM_NAME", "Perennia AI")
 
     message = Mail(
         from_email=Email(from_email, from_name),

--- a/backend/templates/morning_briefing_email.py
+++ b/backend/templates/morning_briefing_email.py
@@ -9,6 +9,17 @@ from datetime import date
 from typing import Any, Dict, List, Optional
 
 
+def _darken_hex(hex_color: str, factor: float = 0.15) -> str:
+    """Darken a hex color by a factor (0-1). Used for gradient end-stop."""
+    hex_color = hex_color.lstrip("#")
+    if len(hex_color) != 6:
+        return f"#{hex_color}"
+    r = max(0, int(int(hex_color[0:2], 16) * (1 - factor)))
+    g = max(0, int(int(hex_color[2:4], 16) * (1 - factor)))
+    b = max(0, int(int(hex_color[4:6], 16) * (1 - factor)))
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
 def render_briefing_email(
     user_name: str,
     briefing_date: date,
@@ -22,6 +33,11 @@ def render_briefing_email(
     yesterday: Dict[str, Any],
     team: Optional[Dict[str, Any]] = None,
     app_url: str = "https://app.perenniaai.com",
+    # Branding params:
+    company_name: str = "Perennia AI",
+    logo_url: Optional[str] = None,
+    primary_color: str = "#218d8d",
+    secondary_color: Optional[str] = None,
 ) -> str:
     """Render complete briefing email HTML."""
     date_str = briefing_date.strftime("%B %d, %Y")
@@ -38,19 +54,22 @@ def render_briefing_email(
     else:
         subject_detail = f"{active} active loans"
 
+    brand = primary_color
+    gradient_end = _darken_hex(primary_color)
+
     sections = []
 
     # AI narrative
     if ai_narrative:
-        sections.append(_section_priorities(ai_narrative))
+        sections.append(_section_priorities(ai_narrative, brand_color=brand))
     else:
-        sections.append(_section_priorities_unavailable())
+        sections.append(_section_priorities_unavailable(brand_color=brand))
 
     sections.append(_divider())
 
     # Personal pipeline (all levels)
     if active > 0 or level == "individual":
-        sections.append(_section_pipeline(pipeline))
+        sections.append(_section_pipeline(pipeline, brand_color=brand))
 
     # At-risk
     if at_risk:
@@ -62,7 +81,7 @@ def render_briefing_email(
 
     # Appointments
     if appointments:
-        sections.append(_section_appointments(appointments))
+        sections.append(_section_appointments(appointments, brand_color=brand))
 
     # Conditions
     if conditions:
@@ -71,14 +90,19 @@ def render_briefing_email(
     # Team section (manager)
     if level == "manager" and team:
         sections.append(_divider())
-        sections.append(_section_team(team))
+        sections.append(_section_team(team, brand_color=brand))
 
     # Org section (leadership)
     if level == "leadership" and team:
         sections.append(_divider())
-        sections.append(_section_org(team))
+        sections.append(_section_org(team, brand_color=brand))
 
     body = "\n".join(sections)
+
+    # Optional logo in header
+    logo_html = ""
+    if logo_url:
+        logo_html = f'<img src="{logo_url}" alt="{company_name}" style="max-height:40px;max-width:200px;margin-bottom:12px;display:block;">\n  '
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -89,8 +113,8 @@ def render_briefing_email(
 <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;max-width:600px;width:100%;">
 
 <!-- Header -->
-<tr><td style="background:linear-gradient(135deg,#218d8d,#1a7070);padding:28px 32px;">
-  <h1 style="margin:0;color:#ffffff;font-size:20px;font-weight:600;">Good morning, {user_name}</h1>
+<tr><td style="background:linear-gradient(135deg,{primary_color},{gradient_end});padding:28px 32px;">
+  {logo_html}<h1 style="margin:0;color:#ffffff;font-size:20px;font-weight:600;">Good morning, {user_name}</h1>
   <p style="margin:6px 0 0;color:rgba(255,255,255,0.8);font-size:13px;">{date_str}</p>
 </td></tr>
 
@@ -101,13 +125,13 @@ def render_briefing_email(
 
 <!-- CTA -->
 <tr><td style="padding:0 32px 32px;" align="center">
-  <a href="{app_url}/dashboard" style="display:inline-block;background:#218d8d;color:#ffffff;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">Open Perennia</a>
+  <a href="{app_url}/dashboard" style="display:inline-block;background:{primary_color};color:#ffffff;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">Open {company_name}</a>
 </td></tr>
 
 <!-- Footer -->
 <tr><td style="padding:16px 32px;border-top:1px solid #e8e8ed;background:#fafafa;">
   <p style="margin:0;color:#8888a0;font-size:11px;text-align:center;">
-    Adjust or disable morning briefings in <a href="{app_url}/settings" style="color:#218d8d;">Settings</a>
+    Adjust or disable morning briefings in <a href="{app_url}/settings" style="color:{primary_color};">Settings</a>
   </p>
 </td></tr>
 
@@ -118,7 +142,7 @@ def render_briefing_email(
 </html>"""
 
 
-def _section_priorities(narrative: str) -> str:
+def _section_priorities(narrative: str, brand_color: str = "#218d8d") -> str:
     # Convert numbered items to styled HTML
     lines = narrative.strip().split("\n")
     items_html = ""
@@ -128,13 +152,13 @@ def _section_priorities(narrative: str) -> str:
             items_html += f'<p style="margin:8px 0;color:#1a1a2a;font-size:14px;line-height:1.6;">{line}</p>\n'
 
     return f"""
-<h2 style="margin:0 0 12px;color:#218d8d;font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Top 3 Priorities</h2>
+<h2 style="margin:0 0 12px;color:{brand_color};font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Top 3 Priorities</h2>
 {items_html}"""
 
 
-def _section_priorities_unavailable() -> str:
-    return """
-<h2 style="margin:0 0 12px;color:#218d8d;font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Your Pipeline</h2>
+def _section_priorities_unavailable(brand_color: str = "#218d8d") -> str:
+    return f"""
+<h2 style="margin:0 0 12px;color:{brand_color};font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Your Pipeline</h2>
 <p style="margin:0;color:#8888a0;font-size:13px;font-style:italic;">AI priorities unavailable today — here's your pipeline data.</p>"""
 
 
@@ -142,7 +166,7 @@ def _divider() -> str:
     return '<hr style="border:none;border-top:1px solid #e8e8ed;margin:20px 0;">'
 
 
-def _section_pipeline(pipeline: Dict) -> str:
+def _section_pipeline(pipeline: Dict, brand_color: str = "#218d8d") -> str:
     active = pipeline.get("active_count", 0)
     volume = pipeline.get("total_volume", 0)
     closing = pipeline.get("closing_soon", 0)
@@ -153,7 +177,7 @@ def _section_pipeline(pipeline: Dict) -> str:
         stage_rows += f'<tr><td style="padding:6px 12px;border-bottom:1px solid #f0f0f4;font-size:13px;color:#4a4a5a;">{stage}</td><td style="padding:6px 12px;border-bottom:1px solid #f0f0f4;font-size:13px;color:#1a1a2a;font-weight:600;text-align:right;">{cnt}</td></tr>\n'
 
     return f"""
-<h2 style="margin:0 0 8px;color:#218d8d;font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Pipeline Snapshot</h2>
+<h2 style="margin:0 0 8px;color:{brand_color};font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Pipeline Snapshot</h2>
 <p style="margin:0 0 12px;color:#4a4a5a;font-size:14px;">{active} active loans &middot; ${volume:,.0f} volume &middot; {closing} closing this week</p>
 <table width="100%" cellpadding="0" cellspacing="0" style="background:#fafafa;border-radius:6px;overflow:hidden;">
 <tr><th style="padding:8px 12px;text-align:left;font-size:11px;color:#8888a0;text-transform:uppercase;border-bottom:1px solid #e8e8ed;">Stage</th><th style="padding:8px 12px;text-align:right;font-size:11px;color:#8888a0;text-transform:uppercase;border-bottom:1px solid #e8e8ed;">Count</th></tr>
@@ -178,12 +202,12 @@ def _section_stale_leads(items: List[Dict]) -> str:
 <ul style="margin:0;padding-left:20px;">{rows}</ul>"""
 
 
-def _section_appointments(items: List[Dict]) -> str:
+def _section_appointments(items: List[Dict], brand_color: str = "#218d8d") -> str:
     rows = ""
     for item in items:
         rows += f'<li style="margin:4px 0;font-size:13px;color:#4a4a5a;"><strong>{item["time"]}</strong> — {item["attendee"]}, {item["type"]}</li>\n'
     return f"""
-<h2 style="margin:20px 0 8px;color:#218d8d;font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">&#128197; Today's Appointments ({len(items)})</h2>
+<h2 style="margin:20px 0 8px;color:{brand_color};font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">&#128197; Today's Appointments ({len(items)})</h2>
 <ul style="margin:0;padding-left:20px;">{rows}</ul>"""
 
 
@@ -202,7 +226,7 @@ def _health_dot(health: str) -> str:
     return f'<span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:{colors.get(health, "#ccc")};"></span>'
 
 
-def _section_team(team: Dict) -> str:
+def _section_team(team: Dict, brand_color: str = "#218d8d") -> str:
     members = team.get("members", [])
     attention = team.get("attention_items", [])
 
@@ -229,7 +253,7 @@ def _section_team(team: Dict) -> str:
 <ul style="margin:0;padding-left:20px;">{items}</ul>"""
 
     return f"""
-<h2 style="margin:0 0 12px;color:#218d8d;font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Your Team</h2>
+<h2 style="margin:0 0 12px;color:{brand_color};font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Your Team</h2>
 <table width="100%" cellpadding="0" cellspacing="0" style="background:#fafafa;border-radius:6px;overflow:hidden;">
 <tr>
 <th style="padding:8px 12px;text-align:left;font-size:11px;color:#8888a0;text-transform:uppercase;border-bottom:1px solid #e8e8ed;">Name</th>
@@ -241,7 +265,7 @@ def _section_team(team: Dict) -> str:
 {attention_html}"""
 
 
-def _section_org(team: Dict) -> str:
+def _section_org(team: Dict, brand_color: str = "#218d8d") -> str:
     snap = team.get("org_snapshot", {})
     branches = team.get("branches", [])
     risks = team.get("top_risks", [])
@@ -270,7 +294,7 @@ def _section_org(team: Dict) -> str:
 <ul style="margin:0;padding-left:20px;">{risk_items}</ul>"""
 
     return f"""
-<h2 style="margin:0 0 8px;color:#218d8d;font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Organization Overview</h2>
+<h2 style="margin:0 0 8px;color:{brand_color};font-size:15px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Organization Overview</h2>
 <p style="margin:0 0 16px;color:#4a4a5a;font-size:14px;">
   ${snap.get('total_volume', 0):,.0f} pipeline &middot; {snap.get('active_count', 0)} active loans &middot;
   {snap.get('funded_this_week', 0)} funded this week {trend_arrow} vs {snap.get('funded_last_week', 0)} last week

--- a/docs/monitoring-runbook.md
+++ b/docs/monitoring-runbook.md
@@ -1,0 +1,145 @@
+# Perennia AI — Production Monitoring Runbook
+
+## Service Architecture
+
+| Component | Host | Purpose |
+|-----------|------|---------|
+| Backend API | Railway (api.perenniaai.com) | FastAPI application |
+| Frontend SPA | Vercel (app.perenniaai.com) | React 18 application |
+| Database | Railway PostgreSQL | Primary data store |
+| Cache | Railway Redis | Session cache, rate limiting, Celery broker |
+| Workers | Railway (Celery) | Background tasks, briefing generation |
+
+## Monitoring Stack
+
+### DataDog APM
+- **Env vars**: `DD_API_KEY`, `DD_APP_KEY`, `DD_SERVICE=mortgage-crm`, `DD_ENV`
+- **Init**: `backend/datadog_monitoring.py` → `setup_datadog_monitoring(app)`
+- **Traces**: All FastAPI endpoints auto-instrumented via ddtrace
+- **Custom metrics**: `business_metrics` module for pipeline/agent tracking
+
+### Sentry Error Tracking
+- **Env var**: `SENTRY_DSN`
+- **Init**: `backend/production_hardening.py` → `sentry_sdk.init()`
+- **Integrations**: FastAPI, SQLAlchemy, Logging (errors auto-captured)
+- **PII**: `send_default_pii=False` — no PII sent to Sentry
+- **Sampling**: 10% traces in production, 100% in development
+
+## Health Endpoints
+
+| Endpoint | Purpose | Expected Response |
+|----------|---------|-------------------|
+| `GET /` | Root info | `{"status": "operational"}` |
+| `GET /health` | Basic health (DB check) | `{"status": "healthy"}` or 503 |
+| `GET /health/ready` | Readiness probe (DB + Redis) | `{"status": "ready"}` or 503 |
+| `GET /ready` | Alias for `/health/ready` | Same as above |
+| `GET /health/detailed` | Full system status | Detailed component health |
+
+## Key Metrics to Monitor
+
+### API Performance
+| Metric | Warning | Critical | Action |
+|--------|---------|----------|--------|
+| p95 latency | > 500ms | > 2000ms | Check slow queries, N+1 patterns |
+| p99 latency | > 2000ms | > 5000ms | Scale workers, check connection pool |
+| Error rate (5xx) | > 0.5% | > 2% | Check Sentry, review recent deploys |
+| Request throughput | < 10 RPS | < 5 RPS | Check DNS, load balancer, deployment |
+
+### Database
+| Metric | Warning | Critical | Action |
+|--------|---------|----------|--------|
+| Connection pool utilization | > 70% | > 90% | Increase pool_size in db.py |
+| Slow queries (> 1s) | > 5/min | > 20/min | Add indexes, optimize queries |
+| Deadlocks | Any | > 3/min | Review concurrent write patterns |
+| DB size growth | > 1GB/week | > 5GB/week | Check for runaway logging, add retention |
+
+### Background Workers (Celery)
+| Metric | Warning | Critical | Action |
+|--------|---------|----------|--------|
+| Queue depth | > 100 tasks | > 500 tasks | Scale workers, check for stuck tasks |
+| Task failure rate | > 5% | > 15% | Check Sentry for task errors |
+| Briefing generation time | > 30s | > 60s | Check LLM API latency |
+| Worker heartbeat | Missing > 2 min | Missing > 5 min | Restart workers, check Redis |
+
+### AI Agents
+| Metric | Warning | Critical | Action |
+|--------|---------|----------|--------|
+| Agent response time | > 5s | > 15s | Check LLM provider status |
+| Token budget per query | > 15K | > 20K | Review prompt sizes, context length |
+| Agent error rate | > 5% | > 10% | Check API keys, rate limits |
+| Hallucination flags | Any | > 3/day | Review RAG pipeline, embedding freshness |
+
+### Voice/Telephony
+| Metric | Warning | Critical | Action |
+|--------|---------|----------|--------|
+| Telnyx API errors | > 1% | > 5% | Check API key, account balance |
+| SMS delivery rate | < 95% | < 90% | Check phone number reputation |
+| Voice workflow expiry rate | > 20% | > 40% | Adjust DEFAULT_EXPIRY_HOURS |
+| Webhook processing time | > 2s | > 5s | Check webhook handler performance |
+
+## Alert Configuration
+
+### DataDog Monitors (Recommended)
+```yaml
+# API Health
+- name: "API Error Rate High"
+  type: metric alert
+  query: "avg(last_5m):sum:trace.fastapi.request.errors{service:mortgage-crm} / sum:trace.fastapi.request.hits{service:mortgage-crm} > 0.02"
+  critical: 0.02
+  warning: 0.005
+
+# Database
+- name: "Database Connection Pool Saturated"
+  type: metric alert
+  query: "avg(last_5m):avg:postgresql.connections{service:mortgage-crm} > 18"
+  critical: 18
+  warning: 14
+
+# Worker Health
+- name: "Celery Queue Depth"
+  type: metric alert
+  query: "avg(last_10m):avg:celery.queue.length{service:mortgage-crm} > 500"
+  critical: 500
+  warning: 100
+```
+
+### Sentry Alert Rules (Recommended)
+- **New issue**: Notify on first occurrence of any new error
+- **Regression**: Alert when a resolved issue re-occurs
+- **Spike**: Alert when error frequency exceeds 10x baseline in 1 hour
+- **Unhandled**: All unhandled exceptions → immediate PagerDuty/Slack
+
+## Escalation Procedures
+
+### Severity 1 — Service Down
+1. Check Railway deployment status
+2. Check `/health` endpoint
+3. Review Railway logs for crash loops
+4. If DB down: Check Railway PostgreSQL dashboard
+5. Escalate to on-call engineer
+
+### Severity 2 — Degraded Performance
+1. Check DataDog APM for slow endpoints
+2. Check `pg_stat_activity` for long-running queries
+3. Check Redis memory usage
+4. Review recent deploys for regression
+
+### Severity 3 — Feature Broken
+1. Check Sentry for related errors
+2. Review feature-specific logs
+3. Check integration health (Twilio, Telnyx, Salesforce, Encompass)
+
+## Railway Environment Variables Checklist
+
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `DATABASE_URL` | PostgreSQL connection | Yes |
+| `REDIS_URL` | Redis connection | Yes |
+| `SECRET_KEY` | JWT signing | Yes |
+| `DD_API_KEY` | DataDog APM | Recommended |
+| `DD_APP_KEY` | DataDog dashboards | Optional |
+| `SENTRY_DSN` | Error tracking | Recommended |
+| `SENDGRID_API_KEY` | Email delivery | Yes (for briefings) |
+| `TELNYX_API_KEY` | SMS/telephony | Yes (for voice features) |
+| `OPENAI_API_KEY` | AI agents | Yes |
+| `ENVIRONMENT` | production/staging/dev | Yes |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -160,6 +160,12 @@ const ConversationIntelligenceRecordingDetail = lazyRetry(() => import('./pages/
 const SmartDocs = lazyRetry(() => import('./pages/SmartDocs'));
 const SmartDocsClientDetail = lazyRetry(() => import('./pages/SmartDocsClientDetail'));
 const SmartDocsDashboard = lazyRetry(() => import('./pages/SmartDocsDashboard'));
+const SmartDocsAnalytics = lazyRetry(() => import('./pages/SmartDocsAnalytics'));
+const SmartDocsReviewQueue = lazyRetry(() => import('./pages/SmartDocsReviewQueue'));
+const SmartDocsSecurity = lazyRetry(() => import('./pages/SmartDocsSecurity'));
+const SmartDocsBankAnalysis = lazyRetry(() => import('./pages/SmartDocsBankAnalysis'));
+const SmartDocsIncome = lazyRetry(() => import('./pages/SmartDocsIncome'));
+const SmartDocsAdmin = lazyRetry(() => import('./pages/SmartDocsAdmin'));
 const AIDailyBlog = lazyRetry(() => import('./pages/AIDailyBlog'));
 // DEPRECATED: Experimental feature deregistered
 // const AvatarStudio = lazyRetry(() => import('./pages/AvatarStudio'));
@@ -3606,6 +3612,140 @@ function App() {
                   />
                   <main className={`app-main ${assistantOpen ? 'with-assistant' : ''}`}>
                     <LazyPage><SmartDocsClientDetail /></LazyPage>
+                  </main>
+                  <CoachCorner isOpen={coachOpen} onClose={() => setCoachOpen(false)} />
+                </div>
+              </PrivateRoute>
+            }
+          />
+
+          {/* Smart Docs Enterprise Pages */}
+          <Route
+            path="/smart-docs/analytics"
+            element={
+              <PrivateRoute>
+                <div className="app-layout">
+                  <Navigation
+                    onToggleAssistant={toggleAssistant}
+                    onToggleCoach={toggleCoach}
+                    onToggleTaskSidebar={toggleTaskSidebar}
+                    assistantOpen={assistantOpen}
+                    coachOpen={coachOpen}
+                    taskSidebarOpen={taskSidebarOpen}
+                    taskCounts={taskCounts}
+                  />
+                  <main className={`app-main ${assistantOpen ? 'with-assistant' : ''}`}>
+                    <LazyPage><SmartDocsAnalytics /></LazyPage>
+                  </main>
+                  <CoachCorner isOpen={coachOpen} onClose={() => setCoachOpen(false)} />
+                </div>
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/smart-docs/review-queue"
+            element={
+              <PrivateRoute>
+                <div className="app-layout">
+                  <Navigation
+                    onToggleAssistant={toggleAssistant}
+                    onToggleCoach={toggleCoach}
+                    onToggleTaskSidebar={toggleTaskSidebar}
+                    assistantOpen={assistantOpen}
+                    coachOpen={coachOpen}
+                    taskSidebarOpen={taskSidebarOpen}
+                    taskCounts={taskCounts}
+                  />
+                  <main className={`app-main ${assistantOpen ? 'with-assistant' : ''}`}>
+                    <LazyPage><SmartDocsReviewQueue /></LazyPage>
+                  </main>
+                  <CoachCorner isOpen={coachOpen} onClose={() => setCoachOpen(false)} />
+                </div>
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/smart-docs/security"
+            element={
+              <PrivateRoute>
+                <div className="app-layout">
+                  <Navigation
+                    onToggleAssistant={toggleAssistant}
+                    onToggleCoach={toggleCoach}
+                    onToggleTaskSidebar={toggleTaskSidebar}
+                    assistantOpen={assistantOpen}
+                    coachOpen={coachOpen}
+                    taskSidebarOpen={taskSidebarOpen}
+                    taskCounts={taskCounts}
+                  />
+                  <main className={`app-main ${assistantOpen ? 'with-assistant' : ''}`}>
+                    <LazyPage><SmartDocsSecurity /></LazyPage>
+                  </main>
+                  <CoachCorner isOpen={coachOpen} onClose={() => setCoachOpen(false)} />
+                </div>
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/smart-docs/bank-analysis"
+            element={
+              <PrivateRoute>
+                <div className="app-layout">
+                  <Navigation
+                    onToggleAssistant={toggleAssistant}
+                    onToggleCoach={toggleCoach}
+                    onToggleTaskSidebar={toggleTaskSidebar}
+                    assistantOpen={assistantOpen}
+                    coachOpen={coachOpen}
+                    taskSidebarOpen={taskSidebarOpen}
+                    taskCounts={taskCounts}
+                  />
+                  <main className={`app-main ${assistantOpen ? 'with-assistant' : ''}`}>
+                    <LazyPage><SmartDocsBankAnalysis /></LazyPage>
+                  </main>
+                  <CoachCorner isOpen={coachOpen} onClose={() => setCoachOpen(false)} />
+                </div>
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/smart-docs/income"
+            element={
+              <PrivateRoute>
+                <div className="app-layout">
+                  <Navigation
+                    onToggleAssistant={toggleAssistant}
+                    onToggleCoach={toggleCoach}
+                    onToggleTaskSidebar={toggleTaskSidebar}
+                    assistantOpen={assistantOpen}
+                    coachOpen={coachOpen}
+                    taskSidebarOpen={taskSidebarOpen}
+                    taskCounts={taskCounts}
+                  />
+                  <main className={`app-main ${assistantOpen ? 'with-assistant' : ''}`}>
+                    <LazyPage><SmartDocsIncome /></LazyPage>
+                  </main>
+                  <CoachCorner isOpen={coachOpen} onClose={() => setCoachOpen(false)} />
+                </div>
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/smart-docs/admin"
+            element={
+              <PrivateRoute>
+                <div className="app-layout">
+                  <Navigation
+                    onToggleAssistant={toggleAssistant}
+                    onToggleCoach={toggleCoach}
+                    onToggleTaskSidebar={toggleTaskSidebar}
+                    assistantOpen={assistantOpen}
+                    coachOpen={coachOpen}
+                    taskSidebarOpen={taskSidebarOpen}
+                    taskCounts={taskCounts}
+                  />
+                  <main className={`app-main ${assistantOpen ? 'with-assistant' : ''}`}>
+                    <LazyPage><SmartDocsAdmin /></LazyPage>
                   </main>
                   <CoachCorner isOpen={coachOpen} onClose={() => setCoachOpen(false)} />
                 </div>

--- a/frontend/src/components/smart-docs/AnalyticsCard.css
+++ b/frontend/src/components/smart-docs/AnalyticsCard.css
@@ -1,0 +1,117 @@
+/* ============================================================
+   AnalyticsCard — reusable metric display card
+   ============================================================ */
+
+.analytics-card {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  /* Default: no left accent border */
+  border-left: 3px solid transparent;
+  transition: border-color 0.15s ease;
+}
+
+/* ── Status modifiers ── */
+.analytics-card--success {
+  border-left-color: var(--color-success);
+}
+
+.analytics-card--warning {
+  border-left-color: var(--color-warning);
+}
+
+.analytics-card--error {
+  border-left-color: var(--color-error);
+}
+
+/* ── Header: icon + title ── */
+.analytics-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.analytics-card__icon {
+  display: flex;
+  align-items: center;
+  color: var(--color-text-tertiary);
+  flex-shrink: 0;
+}
+
+.analytics-card__title {
+  font-size: var(--font-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-secondary);
+  letter-spacing: 0.06em;
+  line-height: var(--line-tight);
+}
+
+/* ── Body: value + subtitle ── */
+.analytics-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.analytics-card__value {
+  font-size: var(--font-3xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-text-primary);
+  line-height: var(--line-tight);
+}
+
+.analytics-card__subtitle {
+  font-size: var(--font-xs);
+  font-weight: var(--weight-normal, 400);
+  color: var(--color-text-tertiary);
+  line-height: var(--line-normal);
+}
+
+/* ── Footer: trend ── */
+.analytics-card__footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.analytics-card__trend {
+  font-size: var(--font-sm);
+  font-weight: var(--weight-medium);
+  border-radius: var(--radius-full);
+  padding: 2px var(--space-xs);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+}
+
+.analytics-card__trend--positive {
+  color: var(--color-success);
+  background: rgba(33, 127, 141, 0.08);
+}
+
+.analytics-card__trend--negative {
+  color: var(--color-error);
+  background: rgba(192, 21, 47, 0.08);
+}
+
+/* ── Children slot ── */
+.analytics-card__children {
+  border-top: 1px solid var(--color-border-light);
+  padding-top: var(--space-sm);
+  margin-top: var(--space-xs);
+}
+
+/* ── Mobile ── */
+@media (max-width: 480px) {
+  .analytics-card {
+    padding: var(--space-md);
+  }
+
+  .analytics-card__value {
+    font-size: var(--font-2xl);
+  }
+}

--- a/frontend/src/components/smart-docs/AnalyticsCard.jsx
+++ b/frontend/src/components/smart-docs/AnalyticsCard.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import './AnalyticsCard.css';
+
+/**
+ * AnalyticsCard — reusable metric display card.
+ *
+ * Props:
+ *   title    {string}       — metric label, displayed uppercase
+ *   value    {string|number}— the main metric value, displayed large
+ *   subtitle {string}       — optional small text below value
+ *   trend    {number}       — optional % change; positive = green, negative = red
+ *   status   {string}       — "success" | "warning" | "error"; adds left border + modifier class
+ *   icon     {node}         — optional icon element before title
+ *   children {node}         — optional additional content below footer
+ */
+function AnalyticsCard({ title, value, subtitle, trend, status, icon, children }) {
+  const cardClass = [
+    'analytics-card',
+    status ? `analytics-card--${status}` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const trendPositive = typeof trend === 'number' && trend > 0;
+  const trendNegative = typeof trend === 'number' && trend < 0;
+  const trendClass = trendPositive
+    ? 'analytics-card__trend analytics-card__trend--positive'
+    : trendNegative
+    ? 'analytics-card__trend analytics-card__trend--negative'
+    : 'analytics-card__trend';
+
+  const trendLabel =
+    typeof trend === 'number'
+      ? trendPositive
+        ? `+${trend}%`
+        : `${trend}%`
+      : null;
+
+  return (
+    <div className={cardClass}>
+      <div className="analytics-card__header">
+        {icon && <span className="analytics-card__icon">{icon}</span>}
+        <span className="analytics-card__title">{String(title).toUpperCase()}</span>
+      </div>
+
+      <div className="analytics-card__body">
+        <span className="analytics-card__value">{value}</span>
+        {subtitle && (
+          <span className="analytics-card__subtitle">{subtitle}</span>
+        )}
+      </div>
+
+      {trendLabel !== null && (
+        <div className="analytics-card__footer">
+          <span className={trendClass}>{trendLabel}</span>
+        </div>
+      )}
+
+      {children && (
+        <div className="analytics-card__children">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default AnalyticsCard;

--- a/frontend/src/components/smart-docs/BankAnalysisPanel.css
+++ b/frontend/src/components/smart-docs/BankAnalysisPanel.css
@@ -1,0 +1,359 @@
+/**
+ * BankAnalysisPanel Styles
+ *
+ * BEM prefix: .bap
+ */
+
+/* ---------------------------------------------------------------------------
+   Panel Container
+--------------------------------------------------------------------------- */
+
+.bap {
+  background: var(--color-bg-primary, #ffffff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+/* ---------------------------------------------------------------------------
+   Panel Header
+--------------------------------------------------------------------------- */
+
+.bap__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md, 16px);
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.bap__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #1f2937);
+}
+
+.bap__risk-badge {
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.bap__risk-badge--error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.bap__risk-badge--warning {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.bap__risk-badge--success {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+/* ---------------------------------------------------------------------------
+   Summary Grid
+--------------------------------------------------------------------------- */
+
+.bap__summary {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  background: var(--color-bg-secondary, #f9fafb);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.bap__summary-item {
+  padding: 20px 24px;
+  border-right: 1px solid var(--color-border, #e5e7eb);
+}
+
+.bap__summary-item:last-child {
+  border-right: none;
+}
+
+.bap__summary-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #6b7280);
+  margin-bottom: 6px;
+}
+
+.bap__summary-value {
+  display: block;
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #1f2937);
+}
+
+/* ---------------------------------------------------------------------------
+   Sections
+--------------------------------------------------------------------------- */
+
+.bap__section {
+  padding: 24px;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.bap__section:last-child {
+  border-bottom: none;
+}
+
+.bap__section-title {
+  margin: 0 0 16px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+/* ---------------------------------------------------------------------------
+   Deposits Table
+--------------------------------------------------------------------------- */
+
+.bap__table-container {
+  overflow-x: auto;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+}
+
+.bap__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.bap__table thead tr {
+  background: var(--color-bg-secondary, #f9fafb);
+}
+
+.bap__table th {
+  padding: 10px 14px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #6b7280);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  white-space: nowrap;
+}
+
+.bap__table td {
+  padding: 12px 14px;
+  color: var(--color-text-primary, #1f2937);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  vertical-align: middle;
+}
+
+.bap__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.bap__table tbody tr:hover {
+  background: var(--color-bg-secondary, #f9fafb);
+}
+
+/* Sourced badge */
+.bap__sourced-yes {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.bap__sourced-no {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+/* Source button */
+.bap__source-btn {
+  padding: 5px 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background: var(--color-primary, #2563eb);
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+.bap__source-btn:hover {
+  background: var(--color-primary-dark, #1d4ed8);
+}
+
+/* ---------------------------------------------------------------------------
+   Flagged Items (NSF / Overdrafts)
+--------------------------------------------------------------------------- */
+
+.bap__flag-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bap__flag {
+  padding: 12px 16px;
+  border-radius: 8px;
+  border-left: 4px solid var(--color-border, #e5e7eb);
+  background: var(--color-bg-secondary, #f9fafb);
+  font-size: 0.875rem;
+}
+
+.bap__flag--error {
+  border-left-color: #dc2626;
+  background: #fff5f5;
+}
+
+.bap__flag--error .bap__flag-label {
+  color: #b91c1c;
+}
+
+.bap__flag--warning {
+  border-left-color: #f59e0b;
+  background: #fffbeb;
+}
+
+.bap__flag--warning .bap__flag-label {
+  color: #92400e;
+}
+
+.bap__flag-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.bap__flag-label {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-text-primary, #1f2937);
+}
+
+.bap__flag-date {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+  flex-shrink: 0;
+}
+
+.bap__flag-amount {
+  font-weight: 700;
+  color: var(--color-text-primary, #1f2937);
+}
+
+.bap__flag-desc {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+  margin-top: 2px;
+}
+
+/* ---------------------------------------------------------------------------
+   Undisclosed Debts
+--------------------------------------------------------------------------- */
+
+.bap__debt-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bap__debt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border-left: 4px solid #f59e0b;
+  background: #fffbeb;
+  font-size: 0.875rem;
+}
+
+.bap__debt-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.bap__debt-payee {
+  font-weight: 600;
+  color: var(--color-text-primary, #1f2937);
+  display: block;
+  margin-bottom: 2px;
+}
+
+.bap__debt-category {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.bap__debt-amount {
+  font-weight: 700;
+  color: #92400e;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   Empty State
+--------------------------------------------------------------------------- */
+
+.bap__empty {
+  padding: 24px;
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+/* ---------------------------------------------------------------------------
+   Responsive
+--------------------------------------------------------------------------- */
+
+@media (max-width: 640px) {
+  .bap__summary {
+    grid-template-columns: 1fr;
+  }
+
+  .bap__summary-item {
+    border-right: none;
+    border-bottom: 1px solid var(--color-border, #e5e7eb);
+  }
+
+  .bap__summary-item:last-child {
+    border-bottom: none;
+  }
+
+  .bap__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .bap__debt {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/components/smart-docs/BankAnalysisPanel.jsx
+++ b/frontend/src/components/smart-docs/BankAnalysisPanel.jsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import './BankAnalysisPanel.css';
+
+/**
+ * BankAnalysisPanel
+ *
+ * Displays a full bank statement analysis result including:
+ * - Summary metrics (avg balance, income, expenses)
+ * - Large deposits table with sourcing actions
+ * - NSF / overdraft flags
+ * - Undisclosed debt indicators
+ *
+ * Props:
+ *   analysis       {object}   — bank analysis data object
+ *   onSourceDeposit {function} — called with the deposit object when "Source" is clicked
+ */
+function BankAnalysisPanel({ analysis, onSourceDeposit }) {
+  if (!analysis) return null;
+
+  const summary = analysis.summary || {};
+  const largeDeposits = analysis.large_deposits || [];
+  const nsfOverdrafts = analysis.nsf_overdrafts || [];
+  const undisclosedDebts = analysis.undisclosed_debts || [];
+  const riskLevel = (analysis.risk_level || 'LOW').toUpperCase();
+
+  // Derive badge modifier from risk level
+  function getRiskBadgeModifier(level) {
+    if (level === 'HIGH') return 'error';
+    if (level === 'MEDIUM') return 'warning';
+    return 'success';
+  }
+
+  const riskModifier = getRiskBadgeModifier(riskLevel);
+
+  function formatCurrency(amount) {
+    if (amount == null) return '—';
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0,
+    }).format(amount);
+  }
+
+  function formatDate(dateStr) {
+    if (!dateStr) return '—';
+    try {
+      return new Date(dateStr).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return dateStr;
+    }
+  }
+
+  return (
+    <div className="bap">
+      {/* Header */}
+      <div className="bap__header">
+        <h2 className="bap__title">Bank Statement Analysis</h2>
+        <span className={`bap__risk-badge bap__risk-badge--${riskModifier}`}>
+          {riskLevel} RISK
+        </span>
+      </div>
+
+      {/* Summary */}
+      <div className="bap__summary">
+        <div className="bap__summary-item">
+          <span className="bap__summary-label">Avg Monthly Balance</span>
+          <span className="bap__summary-value">
+            {formatCurrency(summary.avg_monthly_balance)}
+          </span>
+        </div>
+        <div className="bap__summary-item">
+          <span className="bap__summary-label">Avg Monthly Income</span>
+          <span className="bap__summary-value">
+            {formatCurrency(summary.avg_monthly_income)}
+          </span>
+        </div>
+        <div className="bap__summary-item">
+          <span className="bap__summary-label">Avg Monthly Expenses</span>
+          <span className="bap__summary-value">
+            {formatCurrency(summary.avg_monthly_expenses)}
+          </span>
+        </div>
+      </div>
+
+      {/* Large Deposits */}
+      <div className="bap__section">
+        <h3 className="bap__section-title">
+          Large Deposits ({largeDeposits.length})
+        </h3>
+        {largeDeposits.length === 0 ? (
+          <p className="bap__empty">No large deposits found.</p>
+        ) : (
+          <div className="bap__table-container">
+            <table className="bap__table">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Amount</th>
+                  <th>Description</th>
+                  <th>Sourced</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {largeDeposits.map((deposit, idx) => {
+                  const isSourced = Boolean(deposit.sourced || deposit.is_sourced);
+                  return (
+                    <tr key={deposit.id || idx}>
+                      <td>{formatDate(deposit.date || deposit.transaction_date)}</td>
+                      <td>{formatCurrency(deposit.amount)}</td>
+                      <td>{deposit.description || deposit.memo || '—'}</td>
+                      <td>
+                        {isSourced ? (
+                          <span className="bap__sourced-yes">Yes</span>
+                        ) : (
+                          <span className="bap__sourced-no">No</span>
+                        )}
+                      </td>
+                      <td>
+                        {!isSourced && typeof onSourceDeposit === 'function' && (
+                          <button
+                            className="bap__source-btn"
+                            onClick={() => onSourceDeposit(deposit)}
+                            type="button"
+                          >
+                            Source
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* NSF / Overdrafts */}
+      <div className="bap__section">
+        <h3 className="bap__section-title">
+          NSF / Overdrafts ({nsfOverdrafts.length})
+        </h3>
+        {nsfOverdrafts.length === 0 ? (
+          <p className="bap__empty">No NSF or overdraft events found.</p>
+        ) : (
+          <div className="bap__flag-list">
+            {nsfOverdrafts.map((item, idx) => (
+              <div key={item.id || idx} className="bap__flag bap__flag--error">
+                <div className="bap__flag-header">
+                  <span className="bap__flag-label">
+                    {item.type || item.event_type || 'NSF / Overdraft'}
+                  </span>
+                  <span className="bap__flag-date">
+                    {formatDate(item.date || item.transaction_date)}
+                  </span>
+                </div>
+                {item.amount != null && (
+                  <div className="bap__flag-amount">{formatCurrency(item.amount)}</div>
+                )}
+                {(item.description || item.memo) && (
+                  <div className="bap__flag-desc">
+                    {item.description || item.memo}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Undisclosed Debts */}
+      <div className="bap__section">
+        <h3 className="bap__section-title">
+          Undisclosed Debts ({undisclosedDebts.length})
+        </h3>
+        {undisclosedDebts.length === 0 ? (
+          <p className="bap__empty">No undisclosed debts detected.</p>
+        ) : (
+          <div className="bap__debt-list">
+            {undisclosedDebts.map((debt, idx) => (
+              <div key={debt.id || idx} className="bap__flag bap__flag--warning">
+                <div className="bap__debt-info">
+                  <span className="bap__debt-payee">
+                    {debt.payee || debt.creditor || debt.description || 'Unknown Payee'}
+                  </span>
+                  {(debt.category || debt.debt_type) && (
+                    <span className="bap__debt-category">
+                      {debt.category || debt.debt_type}
+                    </span>
+                  )}
+                </div>
+                {debt.monthly_amount != null && (
+                  <span className="bap__debt-amount">
+                    {formatCurrency(debt.monthly_amount)}/mo
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default BankAnalysisPanel;

--- a/frontend/src/components/smart-docs/DocumentTimeline.css
+++ b/frontend/src/components/smart-docs/DocumentTimeline.css
@@ -1,0 +1,142 @@
+/* ============================================================
+   DocumentTimeline — Vertical event timeline for loan documents
+   ============================================================ */
+
+/* Loading state */
+.dt-loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+.dt-loading__spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: dt-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes dt-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Empty state */
+.dt-empty {
+  padding: var(--space-md);
+  color: var(--color-text-tertiary);
+  font-size: var(--font-sm);
+}
+
+/* Timeline container */
+.dt-timeline {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Individual event row */
+.dt-event {
+  display: flex;
+  gap: var(--space-sm);
+  min-height: 0;
+}
+
+/* Left track: marker circle + vertical connector */
+.dt-event__track {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 28px;
+}
+
+/* Circular marker */
+.dt-marker {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-xs);
+  font-weight: var(--weight-bold);
+  color: #fff;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+/* Marker color variants */
+.dt-marker--primary  { background-color: var(--color-primary); }
+.dt-marker--success  { background-color: var(--color-success); }
+.dt-marker--error    { background-color: var(--color-error); }
+.dt-marker--warning  { background-color: var(--color-warning); }
+.dt-marker--info     { background-color: var(--color-info); }
+
+/* Vertical connector line between markers */
+.dt-connector {
+  width: 2px;
+  flex: 1;
+  min-height: var(--space-md);
+  background-color: var(--color-border);
+  margin: 2px 0;
+}
+
+/* Right-side event content */
+.dt-event__body {
+  flex: 1;
+  padding-bottom: var(--space-md);
+  min-width: 0;
+}
+
+/* Meta row: type label + timestamp */
+.dt-event__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+  margin-top: 4px; /* vertically center with marker */
+}
+
+.dt-event__type {
+  font-size: var(--font-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-secondary);
+  letter-spacing: 0.04em;
+}
+
+.dt-event__timestamp {
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+}
+
+/* Document type (bold) */
+.dt-event__doc-type {
+  font-size: var(--font-sm);
+  font-weight: var(--weight-bold);
+  color: var(--color-text-primary);
+  margin-top: var(--space-xs);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Description text */
+.dt-event__description {
+  font-size: var(--font-sm);
+  color: var(--color-text-secondary);
+  margin-top: var(--space-xs);
+  line-height: 1.4;
+}
+
+/* User name */
+.dt-event__user {
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+  margin-top: var(--space-xs);
+}

--- a/frontend/src/components/smart-docs/DocumentTimeline.jsx
+++ b/frontend/src/components/smart-docs/DocumentTimeline.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import toast from 'react-hot-toast';
+import toast from '../../utils/toast';
 import { getLoanTimeline } from '../../services/docAnalyticsApi';
 import './DocumentTimeline.css';
 

--- a/frontend/src/components/smart-docs/DocumentTimeline.jsx
+++ b/frontend/src/components/smart-docs/DocumentTimeline.jsx
@@ -1,0 +1,160 @@
+/**
+ * DocumentTimeline Component
+ *
+ * Displays a vertical timeline of document events for a given loan,
+ * fetched from the doc analytics API.
+ */
+
+import React, { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { getLoanTimeline } from '../../services/docAnalyticsApi';
+import './DocumentTimeline.css';
+
+// Map event types to single-letter icons shown in the circular marker
+const EVENT_ICONS = {
+  uploaded: 'U',
+  reviewed: 'R',
+  approved: 'A',
+  rejected: 'X',
+  requested: 'Q',
+  expired: 'E',
+  renewed: 'N',
+  esigned: 'S',
+};
+
+// Map event types to CSS modifier classes that control marker color
+const EVENT_COLOR_CLASS = {
+  uploaded: 'dt-marker--primary',
+  reviewed: 'dt-marker--primary',
+  approved: 'dt-marker--success',
+  rejected: 'dt-marker--error',
+  requested: 'dt-marker--warning',
+  expired: 'dt-marker--error',
+  renewed: 'dt-marker--success',
+  esigned: 'dt-marker--primary',
+};
+
+function formatTimestamp(ts) {
+  if (!ts) return '';
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return ts;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+const DocumentTimeline = ({ loanId }) => {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!loanId) return;
+
+    let cancelled = false;
+
+    async function fetchTimeline() {
+      setLoading(true);
+      try {
+        const data = await getLoanTimeline(loanId);
+        if (!cancelled) {
+          // API may return { events: [...] } or a plain array
+          const list = Array.isArray(data) ? data : (data?.events ?? []);
+          setEvents(list);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          toast.error('Failed to load document timeline');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchTimeline();
+    return () => { cancelled = true; };
+  }, [loanId]);
+
+  if (loading) {
+    return (
+      <div className="dt-loading">
+        <span className="dt-loading__spinner" aria-hidden="true" />
+        <span>Loading timeline…</span>
+      </div>
+    );
+  }
+
+  if (!events.length) {
+    return (
+      <div className="dt-empty">
+        No events
+      </div>
+    );
+  }
+
+  return (
+    <div className="dt-timeline" role="list" aria-label="Document event timeline">
+      {events.map((event, index) => {
+        const type = (event.event_type || event.type || '').toLowerCase();
+        const icon = EVENT_ICONS[type] ?? type.charAt(0).toUpperCase();
+        const colorClass = EVENT_COLOR_CLASS[type] ?? 'dt-marker--primary';
+        const isLast = index === events.length - 1;
+
+        return (
+          <div
+            key={event.id ?? index}
+            className="dt-event"
+            role="listitem"
+          >
+            {/* Left column: marker + connector line */}
+            <div className="dt-event__track">
+              <div className={`dt-marker ${colorClass}`} aria-hidden="true">
+                {icon}
+              </div>
+              {!isLast && <div className="dt-connector" aria-hidden="true" />}
+            </div>
+
+            {/* Right column: event content */}
+            <div className="dt-event__body">
+              <div className="dt-event__meta">
+                <span className="dt-event__type">
+                  {type.toUpperCase()}
+                </span>
+                {(event.timestamp || event.created_at) && (
+                  <span className="dt-event__timestamp">
+                    {formatTimestamp(event.timestamp || event.created_at)}
+                  </span>
+                )}
+              </div>
+
+              {(event.doc_type || event.document_type) && (
+                <div className="dt-event__doc-type">
+                  {event.doc_type || event.document_type}
+                </div>
+              )}
+
+              {event.description && (
+                <div className="dt-event__description">
+                  {event.description}
+                </div>
+              )}
+
+              {(event.user_name || event.user) && (
+                <div className="dt-event__user">
+                  {event.user_name || event.user}
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default DocumentTimeline;

--- a/frontend/src/components/smart-docs/DocumentTimeline.jsx
+++ b/frontend/src/components/smart-docs/DocumentTimeline.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import toast from '../../utils/toast';
+import { toast } from '../../utils/toast';
 import { getLoanTimeline } from '../../services/docAnalyticsApi';
 import './DocumentTimeline.css';
 

--- a/frontend/src/components/smart-docs/IncomeWorksheet.css
+++ b/frontend/src/components/smart-docs/IncomeWorksheet.css
@@ -1,0 +1,274 @@
+/* ============================================================
+   IncomeWorksheet — bordered card with income source table
+   and maker-checker approval actions
+   ============================================================ */
+
+.iw {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.iw--empty {
+  padding: var(--space-xl);
+  text-align: center;
+  color: var(--color-text-tertiary);
+}
+
+/* ── Header ── */
+.iw__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-lg);
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border-light);
+  gap: var(--space-md);
+}
+
+.iw__header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.iw__title {
+  margin: 0;
+  font-size: var(--font-lg);
+  font-weight: var(--weight-bold);
+  color: var(--color-text-primary);
+  line-height: var(--line-tight);
+}
+
+/* Status badge */
+.iw__status-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.iw__status-badge--success {
+  background: rgba(33, 127, 141, 0.12);
+  color: var(--color-success);
+  border: 1px solid rgba(33, 127, 141, 0.25);
+}
+
+.iw__status-badge--error {
+  background: rgba(192, 21, 47, 0.10);
+  color: var(--color-error);
+  border: 1px solid rgba(192, 21, 47, 0.25);
+}
+
+.iw__status-badge--warning {
+  background: rgba(168, 75, 47, 0.10);
+  color: var(--color-warning);
+  border: 1px solid rgba(168, 75, 47, 0.25);
+}
+
+/* Total monthly income */
+.iw__header-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.iw__total-label {
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.iw__total-value {
+  font-size: var(--font-2xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-primary);
+  line-height: var(--line-tight);
+}
+
+/* ── Table ── */
+.iw__table-wrapper {
+  overflow-x: auto;
+}
+
+.iw__empty-table {
+  padding: var(--space-xl);
+  text-align: center;
+  color: var(--color-text-tertiary);
+  font-size: var(--font-sm);
+}
+
+.iw__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-sm);
+}
+
+.iw__table thead {
+  background: var(--color-bg-secondary);
+}
+
+.iw__table th {
+  padding: 10px var(--space-md);
+  text-align: left;
+  font-size: var(--font-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--color-border-light);
+  white-space: nowrap;
+}
+
+.iw__table td {
+  padding: 12px var(--space-md);
+  color: var(--color-text-primary);
+  border-bottom: 1px solid var(--color-border-light);
+  vertical-align: middle;
+}
+
+.iw__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.iw__table tbody tr:hover td {
+  background: var(--color-bg-hover);
+}
+
+.iw__cell-name {
+  font-weight: var(--weight-medium);
+}
+
+.iw__cell-amount {
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Confidence badges */
+.iw__confidence {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-semibold);
+}
+
+.iw__confidence--high {
+  background: rgba(33, 127, 141, 0.12);
+  color: var(--color-success);
+}
+
+.iw__confidence--medium {
+  background: rgba(168, 75, 47, 0.10);
+  color: var(--color-warning);
+}
+
+.iw__confidence--low {
+  background: rgba(192, 21, 47, 0.10);
+  color: var(--color-error);
+}
+
+/* Verified badge */
+.iw__verified-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-semibold);
+}
+
+.iw__verified-badge--yes {
+  background: rgba(33, 127, 141, 0.12);
+  color: var(--color-success);
+}
+
+.iw__verified-badge--no {
+  background: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+}
+
+/* Override button */
+.iw__override-btn {
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+
+.iw__override-btn:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: rgba(33, 127, 141, 0.05);
+}
+
+/* ── Actions footer ── */
+.iw__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-lg);
+  border-top: 1px solid var(--color-border-light);
+  background: var(--color-bg-surface);
+}
+
+.iw__btn {
+  padding: 8px 20px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-sm);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.iw__btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+  border: 1px solid var(--color-primary);
+}
+
+.iw__btn--primary:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+.iw__btn--secondary {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+
+.iw__btn--secondary:hover {
+  background: var(--color-bg-hover);
+  border-color: var(--color-text-secondary);
+  color: var(--color-text-primary);
+}
+
+/* ── Mobile ── */
+@media (max-width: 768px) {
+  .iw__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-sm);
+  }
+
+  .iw__header-right {
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/components/smart-docs/IncomeWorksheet.jsx
+++ b/frontend/src/components/smart-docs/IncomeWorksheet.jsx
@@ -1,0 +1,162 @@
+/**
+ * IncomeWorksheet
+ *
+ * Displays income sources for a loan with maker-checker approval controls.
+ *
+ * Props:
+ *   income          {object}   — income object with status, sources[], etc.
+ *   onApprove       {function} — called when Approve button is clicked
+ *   onReject        {function} — called when Reject button is clicked
+ *   onOverrideSource {function} — called with (sourceId) when Override is clicked
+ */
+import React from 'react';
+import './IncomeWorksheet.css';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatCurrency(amount) {
+  if (amount == null || amount === '') return '$0.00';
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number(amount));
+}
+
+function getConfidenceClass(confidence) {
+  const pct = Number(confidence);
+  if (pct >= 90) return 'iw__confidence--high';
+  if (pct >= 70) return 'iw__confidence--medium';
+  return 'iw__confidence--low';
+}
+
+function getStatusBadgeClass(status) {
+  const s = (status || '').toUpperCase();
+  if (s === 'APPROVED') return 'iw__status-badge iw__status-badge--success';
+  if (s === 'REJECTED') return 'iw__status-badge iw__status-badge--error';
+  return 'iw__status-badge iw__status-badge--warning';
+}
+
+function calcTotalMonthly(sources) {
+  if (!Array.isArray(sources)) return 0;
+  return sources.reduce((sum, src) => sum + Number(src.monthly_amount || src.amount || 0), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+function IncomeWorksheet({ income, onApprove, onReject, onOverrideSource }) {
+  if (!income) {
+    return (
+      <div className="iw iw--empty">
+        <p>No income data loaded.</p>
+      </div>
+    );
+  }
+
+  const status = (income.status || 'PENDING').toUpperCase();
+  const sources = income.sources || [];
+  const totalMonthly = calcTotalMonthly(sources);
+  const isTerminal = status === 'APPROVED' || status === 'REJECTED';
+
+  return (
+    <div className="iw">
+      {/* Header */}
+      <div className="iw__header">
+        <div className="iw__header-left">
+          <h2 className="iw__title">Income Calculation</h2>
+          <span className={getStatusBadgeClass(status)}>{status}</span>
+        </div>
+        <div className="iw__header-right">
+          <span className="iw__total-label">Total Monthly Income</span>
+          <span className="iw__total-value">{formatCurrency(totalMonthly)}</span>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="iw__table-wrapper">
+        {sources.length === 0 ? (
+          <div className="iw__empty-table">No income sources found.</div>
+        ) : (
+          <table className="iw__table">
+            <thead>
+              <tr>
+                <th>Source Name</th>
+                <th>Type</th>
+                <th>Monthly Amount</th>
+                <th>Confidence</th>
+                <th>Verified</th>
+                <th>Override</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sources.map((src, idx) => {
+                const sourceId = src.id || src.source_id || idx;
+                const confidence = src.confidence != null ? Number(src.confidence) : null;
+                const isVerified = src.verified === true || src.verified === 'true';
+                const monthlyAmount = src.monthly_amount != null ? src.monthly_amount : src.amount;
+
+                return (
+                  <tr key={sourceId}>
+                    <td className="iw__cell-name">{src.name || src.source_name || '—'}</td>
+                    <td>{src.type || src.income_type || '—'}</td>
+                    <td className="iw__cell-amount">{formatCurrency(monthlyAmount)}</td>
+                    <td>
+                      {confidence != null ? (
+                        <span className={`iw__confidence ${getConfidenceClass(confidence)}`}>
+                          {confidence}%
+                        </span>
+                      ) : (
+                        <span className="iw__confidence iw__confidence--low">N/A</span>
+                      )}
+                    </td>
+                    <td>
+                      <span className={`iw__verified-badge ${isVerified ? 'iw__verified-badge--yes' : 'iw__verified-badge--no'}`}>
+                        {isVerified ? 'Yes' : 'No'}
+                      </span>
+                    </td>
+                    <td>
+                      <button
+                        className="iw__override-btn"
+                        onClick={() => onOverrideSource && onOverrideSource(sourceId)}
+                        type="button"
+                      >
+                        Override
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Actions footer — only shown when not yet approved/rejected */}
+      {!isTerminal && (
+        <div className="iw__actions">
+          <button
+            className="iw__btn iw__btn--primary"
+            onClick={onApprove}
+            type="button"
+          >
+            Approve Income
+          </button>
+          <button
+            className="iw__btn iw__btn--secondary"
+            onClick={onReject}
+            type="button"
+          >
+            Reject
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default IncomeWorksheet;

--- a/frontend/src/components/smart-docs/ReviewQueueItem.css
+++ b/frontend/src/components/smart-docs/ReviewQueueItem.css
@@ -1,0 +1,252 @@
+/* ============================================================
+   ReviewQueueItem — 5-column grid row for the review queue
+   ============================================================ */
+
+/* ── Row container ── */
+.rqi {
+  display: grid;
+  grid-template-columns: 90px 1fr 160px 150px 220px;
+  align-items: center;
+  gap: var(--space-md, 16px);
+  padding: var(--space-md, 16px) var(--space-lg, 24px);
+  background: var(--color-bg-surface, #fff);
+  border: 1px solid var(--color-border-light, #e5e7eb);
+  border-left: 4px solid transparent;
+  border-radius: var(--radius-md, 8px);
+  transition: box-shadow 0.15s ease, border-left-color 0.15s ease;
+}
+
+.rqi:hover {
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0,0,0,0.08));
+}
+
+/* ── Priority accent borders ── */
+.rqi--critical {
+  border-left-color: var(--color-error, #c0152f);
+}
+
+.rqi--high {
+  border-left-color: var(--color-warning, #d97706);
+}
+
+/* ── Claimed: dim the whole row ── */
+.rqi--claimed {
+  opacity: 0.7;
+}
+
+/* ============================================================
+   Columns
+   ============================================================ */
+
+.rqi__col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0; /* allow text-overflow */
+}
+
+/* ---- Col 1: Priority badge ---- */
+.rqi__col--priority {
+  align-items: center;
+}
+
+.rqi__priority {
+  display: inline-block;
+  font-size: var(--font-xs, 0.7rem);
+  font-weight: var(--weight-bold, 700);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: var(--radius-full, 9999px);
+  white-space: nowrap;
+}
+
+.rqi__priority--critical {
+  background: rgba(192, 21, 47, 0.12);
+  color: var(--color-error, #c0152f);
+}
+
+.rqi__priority--high {
+  background: rgba(217, 119, 6, 0.12);
+  color: var(--color-warning, #d97706);
+}
+
+.rqi__priority--normal {
+  background: rgba(245, 158, 11, 0.10);
+  color: #92400e;
+}
+
+.rqi__priority--low {
+  background: rgba(16, 185, 129, 0.10);
+  color: var(--color-success, #059669);
+}
+
+/* ---- Col 2: Doc info ---- */
+.rqi__col--info {
+  gap: 3px;
+}
+
+.rqi__doc-type {
+  font-size: var(--font-sm, 0.875rem);
+  font-weight: var(--weight-semibold, 600);
+  color: var(--color-text-primary, #111827);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rqi__borrower {
+  font-size: var(--font-sm, 0.875rem);
+  color: var(--color-text-secondary, #374151);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rqi__loan-num {
+  font-size: var(--font-xs, 0.75rem);
+  color: var(--color-text-tertiary, #6b7280);
+  font-family: var(--font-mono, monospace);
+}
+
+/* ---- Col 3: Meta ---- */
+.rqi__col--meta {
+  gap: 6px;
+}
+
+.rqi__meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-size: var(--font-xs, 0.75rem);
+  color: var(--color-text-secondary, #374151);
+}
+
+.rqi__meta-label {
+  font-size: 0.65rem;
+  font-weight: var(--weight-semibold, 600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-tertiary, #9ca3af);
+}
+
+/* ---- Col 4: Claim status ---- */
+.rqi__col--claim {
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.rqi__claim-tag {
+  display: inline-block;
+  font-size: var(--font-xs, 0.75rem);
+  font-weight: var(--weight-medium, 500);
+  padding: 3px 10px;
+  border-radius: var(--radius-full, 9999px);
+  white-space: nowrap;
+}
+
+.rqi__claim-tag--open {
+  background: var(--color-bg-secondary, #f9fafb);
+  color: var(--color-text-tertiary, #6b7280);
+  border: 1px solid var(--color-border-light, #e5e7eb);
+}
+
+.rqi__claim-tag--mine {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary, #2563eb);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+}
+
+.rqi__claim-tag--other {
+  background: var(--color-bg-secondary, #f9fafb);
+  color: var(--color-text-secondary, #374151);
+  border: 1px solid var(--color-border-light, #e5e7eb);
+}
+
+/* ---- Col 5: Actions ---- */
+.rqi__col--actions {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-xs, 8px);
+}
+
+/* ── Buttons ── */
+.rqi__btn {
+  font-size: var(--font-sm, 0.875rem);
+  font-weight: var(--weight-medium, 500);
+  padding: 6px 14px;
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+  line-height: 1.4;
+}
+
+.rqi__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.rqi__btn--primary {
+  background: var(--color-primary, #2563eb);
+  color: #fff;
+  border-color: var(--color-primary, #2563eb);
+}
+
+.rqi__btn--primary:hover:not(:disabled) {
+  background: var(--color-primary-dark, #1d4ed8);
+  border-color: var(--color-primary-dark, #1d4ed8);
+}
+
+.rqi__btn--secondary {
+  background: var(--color-bg-secondary, #f9fafb);
+  color: var(--color-text-secondary, #374151);
+  border-color: var(--color-border-light, #e5e7eb);
+}
+
+.rqi__btn--secondary:hover:not(:disabled) {
+  background: var(--color-bg-hover, #f3f4f6);
+}
+
+.rqi__btn--ghost {
+  background: transparent;
+  color: var(--color-text-tertiary, #6b7280);
+  border-color: transparent;
+}
+
+.rqi__btn--ghost:hover:not(:disabled) {
+  color: var(--color-text-primary, #111827);
+  background: var(--color-bg-secondary, #f9fafb);
+}
+
+.rqi__btn--danger {
+  background: rgba(192, 21, 47, 0.06);
+  color: var(--color-error, #c0152f);
+  border-color: rgba(192, 21, 47, 0.2);
+}
+
+.rqi__btn--danger:hover:not(:disabled) {
+  background: rgba(192, 21, 47, 0.12);
+}
+
+/* ============================================================
+   Mobile — stack at 768px
+   ============================================================ */
+@media (max-width: 768px) {
+  .rqi {
+    grid-template-columns: 1fr;
+    gap: var(--space-sm, 12px);
+    border-left-width: 4px;
+  }
+
+  .rqi__col--priority {
+    align-items: flex-start;
+  }
+
+  .rqi__col--actions {
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/components/smart-docs/ReviewQueueItem.jsx
+++ b/frontend/src/components/smart-docs/ReviewQueueItem.jsx
@@ -1,0 +1,206 @@
+/**
+ * ReviewQueueItem Component
+ *
+ * Renders a single item in the document review queue as a 5-column grid row:
+ * Priority badge | Doc info | Meta | Claim status | Action buttons
+ *
+ * Props:
+ *   document      {object}   — queue item from the API
+ *   onClaim       {function} — (documentId) => void
+ *   onRelease     {function} — (documentId) => void
+ *   onAiReview    {function} — (documentId) => void
+ *   onViewDetail  {function} — (documentId) => void
+ *   currentUserId {string}   — logged-in user's ID for claim ownership check
+ */
+import React from 'react';
+import './ReviewQueueItem.css';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(dateStr) {
+  if (!dateStr) return '—';
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function formatConfidence(value) {
+  if (value == null) return '—';
+  const pct = typeof value === 'number' && value <= 1 ? Math.round(value * 100) : Math.round(value);
+  return `${pct}%`;
+}
+
+function getPriorityMod(priority) {
+  switch ((priority || '').toUpperCase()) {
+    case 'CRITICAL': return 'rqi__priority--critical';
+    case 'HIGH':     return 'rqi__priority--high';
+    case 'NORMAL':   return 'rqi__priority--normal';
+    case 'LOW':      return 'rqi__priority--low';
+    default:         return 'rqi__priority--normal';
+  }
+}
+
+function getRowMod(priority) {
+  switch ((priority || '').toUpperCase()) {
+    case 'CRITICAL': return 'rqi--critical';
+    case 'HIGH':     return 'rqi--high';
+    default:         return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function ReviewQueueItem({
+  document,
+  onClaim,
+  onRelease,
+  onAiReview,
+  onViewDetail,
+  currentUserId,
+}) {
+  if (!document) return null;
+
+  const {
+    id,
+    doc_type,
+    borrower_name,
+    loan_number,
+    priority,
+    uploaded_at,
+    ai_confidence,
+    claimed_by_id,
+    claimed_by_name,
+  } = document;
+
+  const isClaimed         = Boolean(claimed_by_id);
+  const isClaimedByMe     = isClaimed && String(claimed_by_id) === String(currentUserId);
+  const isClaimedByOther  = isClaimed && !isClaimedByMe;
+
+  const rowClass = [
+    'rqi',
+    getRowMod(priority),
+    isClaimed ? 'rqi--claimed' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  // ---- Col 1: Priority badge -----------------------------------------------
+  const priorityBadge = (
+    <div className="rqi__col rqi__col--priority">
+      <span className={`rqi__priority ${getPriorityMod(priority)}`}>
+        {(priority || 'NORMAL').toUpperCase()}
+      </span>
+    </div>
+  );
+
+  // ---- Col 2: Doc info -------------------------------------------------------
+  const docInfo = (
+    <div className="rqi__col rqi__col--info">
+      <span className="rqi__doc-type">{doc_type || 'Unknown Type'}</span>
+      {borrower_name && <span className="rqi__borrower">{borrower_name}</span>}
+      {loan_number   && <span className="rqi__loan-num">#{loan_number}</span>}
+    </div>
+  );
+
+  // ---- Col 3: Meta -----------------------------------------------------------
+  const meta = (
+    <div className="rqi__col rqi__col--meta">
+      {uploaded_at && (
+        <span className="rqi__meta-item">
+          <span className="rqi__meta-label">Uploaded</span>
+          <span>{formatDate(uploaded_at)}</span>
+        </span>
+      )}
+      {ai_confidence != null && (
+        <span className="rqi__meta-item">
+          <span className="rqi__meta-label">AI confidence</span>
+          <span>{formatConfidence(ai_confidence)}</span>
+        </span>
+      )}
+    </div>
+  );
+
+  // ---- Col 4: Claim status ---------------------------------------------------
+  const claimStatus = (
+    <div className="rqi__col rqi__col--claim">
+      {isClaimedByMe && (
+        <span className="rqi__claim-tag rqi__claim-tag--mine">Claimed by you</span>
+      )}
+      {isClaimedByOther && (
+        <span className="rqi__claim-tag rqi__claim-tag--other">
+          Claimed by {claimed_by_name || 'reviewer'}
+        </span>
+      )}
+      {!isClaimed && (
+        <span className="rqi__claim-tag rqi__claim-tag--open">Unclaimed</span>
+      )}
+    </div>
+  );
+
+  // ---- Col 5: Actions -------------------------------------------------------
+  const actions = (
+    <div className="rqi__col rqi__col--actions">
+      {/* View detail always available */}
+      <button
+        className="rqi__btn rqi__btn--ghost"
+        onClick={() => onViewDetail && onViewDetail(id)}
+        title="View detail"
+      >
+        View
+      </button>
+
+      {/* Unclaimed: Claim + AI Review */}
+      {!isClaimed && (
+        <>
+          <button
+            className="rqi__btn rqi__btn--primary"
+            onClick={() => onClaim && onClaim(id)}
+            title="Claim this document for review"
+          >
+            Claim
+          </button>
+          <button
+            className="rqi__btn rqi__btn--secondary"
+            onClick={() => onAiReview && onAiReview(id)}
+            title="Run AI review"
+          >
+            AI Review
+          </button>
+        </>
+      )}
+
+      {/* Claimed by me: Review + Release */}
+      {isClaimedByMe && (
+        <>
+          <button
+            className="rqi__btn rqi__btn--primary"
+            onClick={() => onViewDetail && onViewDetail(id)}
+            title="Review this document"
+          >
+            Review
+          </button>
+          <button
+            className="rqi__btn rqi__btn--danger"
+            onClick={() => onRelease && onRelease(id)}
+            title="Release back to queue"
+          >
+            Release
+          </button>
+        </>
+      )}
+    </div>
+  );
+
+  return (
+    <div className={rowClass}>
+      {priorityBadge}
+      {docInfo}
+      {meta}
+      {claimStatus}
+      {actions}
+    </div>
+  );
+}

--- a/frontend/src/components/smart-docs/__tests__/AnalyticsCard.test.jsx
+++ b/frontend/src/components/smart-docs/__tests__/AnalyticsCard.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../AnalyticsCard.css', () => ({}));
+
+import AnalyticsCard from '../AnalyticsCard';
+
+describe('AnalyticsCard', () => {
+  // 1. Renders title and value
+  it('renders title and value', () => {
+    render(<AnalyticsCard title="Total Loans" value={42} />);
+    expect(screen.getByText('TOTAL LOANS')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  // 2. Renders subtitle when provided
+  it('renders subtitle when provided', () => {
+    render(<AnalyticsCard title="Pipeline" value="$1.2M" subtitle="last 30 days" />);
+    expect(screen.getByText('last 30 days')).toBeInTheDocument();
+  });
+
+  // 3. Renders positive trend as "+N%"
+  it('renders positive trend as "+N%"', () => {
+    render(<AnalyticsCard title="Volume" value="$500K" trend={12} />);
+    expect(screen.getByText('+12%')).toBeInTheDocument();
+  });
+
+  // 4. Renders negative trend as "-N%"
+  it('renders negative trend as "-N%"', () => {
+    render(<AnalyticsCard title="Fallout" value="3" trend={-5} />);
+    expect(screen.getByText('-5%')).toBeInTheDocument();
+  });
+
+  // 5. Applies status class
+  it('applies status modifier class for error', () => {
+    const { container } = render(<AnalyticsCard title="Issues" value="2" status="error" />);
+    expect(container.firstChild).toHaveClass('analytics-card--error');
+  });
+
+  it('applies status modifier class for success', () => {
+    const { container } = render(<AnalyticsCard title="Closed" value="10" status="success" />);
+    expect(container.firstChild).toHaveClass('analytics-card--success');
+  });
+
+  it('applies status modifier class for warning', () => {
+    const { container } = render(<AnalyticsCard title="Expiring" value="4" status="warning" />);
+    expect(container.firstChild).toHaveClass('analytics-card--warning');
+  });
+
+  // 6. Renders children when provided
+  it('renders children when provided', () => {
+    render(
+      <AnalyticsCard title="Metrics" value="100">
+        <span>extra content</span>
+      </AnalyticsCard>
+    );
+    expect(screen.getByText('extra content')).toBeInTheDocument();
+  });
+
+  // Additional: does not render subtitle when omitted
+  it('does not render subtitle when not provided', () => {
+    const { container } = render(<AnalyticsCard title="Score" value="88" />);
+    expect(container.querySelector('.analytics-card__subtitle')).toBeNull();
+  });
+
+  // Additional: does not render trend when not provided
+  it('does not render trend when not provided', () => {
+    const { container } = render(<AnalyticsCard title="Count" value="5" />);
+    expect(container.querySelector('.analytics-card__trend')).toBeNull();
+  });
+
+  // Additional: renders icon when provided
+  it('renders icon when provided', () => {
+    render(<AnalyticsCard title="Docs" value="7" icon={<span data-testid="test-icon" />} />);
+    expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/smart-docs/index.js
+++ b/frontend/src/components/smart-docs/index.js
@@ -2,3 +2,8 @@ export { default as NeedsListView } from './NeedsListView';
 export { default as SmartDocumentUpload } from './SmartDocumentUpload';
 export { default as DocumentStatusCard } from './DocumentStatusCard';
 export { default as FreshnessIndicator } from './FreshnessIndicator';
+export { default as AnalyticsCard } from './AnalyticsCard';
+export { default as ReviewQueueItem } from './ReviewQueueItem';
+export { default as DocumentTimeline } from './DocumentTimeline';
+export { default as BankAnalysisPanel } from './BankAnalysisPanel';
+export { default as IncomeWorksheet } from './IncomeWorksheet';

--- a/frontend/src/hooks/__tests__/useDocAnalytics.test.js
+++ b/frontend/src/hooks/__tests__/useDocAnalytics.test.js
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted ensures mock fns are defined before vi.mock hoisting
+// ---------------------------------------------------------------------------
+
+const mockGetDashboard = vi.hoisted(() => vi.fn());
+const mockGetSlaCompliance = vi.hoisted(() => vi.fn());
+const mockGetBottlenecks = vi.hoisted(() => vi.fn());
+
+vi.mock('../../services/docAnalyticsApi', () => ({
+  getDashboard: mockGetDashboard,
+  getSlaCompliance: mockGetSlaCompliance,
+  getBottlenecks: mockGetBottlenecks,
+}));
+
+import useDocAnalytics from '../useDocAnalytics';
+
+// ---------------------------------------------------------------------------
+// Sample fixture data
+// ---------------------------------------------------------------------------
+
+const DASHBOARD_DATA = {
+  total_loans: 42,
+  avg_completeness: 78.5,
+  missing_docs_count: 12,
+};
+
+const SLA_DATA = {
+  compliant_count: 35,
+  breached_count: 7,
+  compliance_rate: 83.3,
+};
+
+const BOTTLENECKS_DATA = {
+  bottlenecks: [
+    { stage: 'UNDERWRITING', avg_days: 9.2, count: 5 },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useDocAnalytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDashboard.mockResolvedValue(DASHBOARD_DATA);
+    mockGetSlaCompliance.mockResolvedValue(SLA_DATA);
+    mockGetBottlenecks.mockResolvedValue(BOTTLENECKS_DATA);
+  });
+
+  // =========================================================================
+  // 1. Loads dashboard data on mount
+  // =========================================================================
+
+  it('sets loading=true initially, then false after data loads', async () => {
+    const { result } = renderHook(() => useDocAnalytics());
+
+    // loading starts true synchronously
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  it('populates dashboard, sla, and bottlenecks on mount', async () => {
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.dashboard).toEqual(DASHBOARD_DATA);
+    expect(result.current.sla).toEqual(SLA_DATA);
+    expect(result.current.bottlenecks).toEqual(BOTTLENECKS_DATA);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls all three API functions with the default days value (30)', async () => {
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetDashboard).toHaveBeenCalledOnce();
+    expect(mockGetDashboard).toHaveBeenCalledWith(30);
+
+    expect(mockGetSlaCompliance).toHaveBeenCalledOnce();
+    expect(mockGetSlaCompliance).toHaveBeenCalledWith(30);
+
+    expect(mockGetBottlenecks).toHaveBeenCalledOnce();
+    expect(mockGetBottlenecks).toHaveBeenCalledWith(30);
+  });
+
+  it('passes a custom days value to all three API functions', async () => {
+    const { result } = renderHook(() => useDocAnalytics(90));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetDashboard).toHaveBeenCalledWith(90);
+    expect(mockGetSlaCompliance).toHaveBeenCalledWith(90);
+    expect(mockGetBottlenecks).toHaveBeenCalledWith(90);
+  });
+
+  it('re-fetches when the days prop changes', async () => {
+    const { result, rerender } = renderHook(({ days }) => useDocAnalytics(days), {
+      initialProps: { days: 30 },
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetDashboard).toHaveBeenCalledTimes(1);
+
+    // Change the days prop
+    rerender({ days: 60 });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetDashboard).toHaveBeenCalledTimes(2);
+    expect(mockGetDashboard).toHaveBeenLastCalledWith(60);
+  });
+
+  // =========================================================================
+  // 2. refresh() reloads data
+  // =========================================================================
+
+  it('refresh() reloads all three API functions', async () => {
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetDashboard).toHaveBeenCalledTimes(1);
+
+    // Call refresh
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockGetDashboard).toHaveBeenCalledTimes(2);
+    expect(mockGetSlaCompliance).toHaveBeenCalledTimes(2);
+    expect(mockGetBottlenecks).toHaveBeenCalledTimes(2);
+  });
+
+  it('refresh() sets loading=true while in flight, then false', async () => {
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Trigger refresh and immediately check loading
+    let refreshPromise;
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      await refreshPromise;
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('refresh() updates state with fresh API data', async () => {
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const updatedDashboard = { ...DASHBOARD_DATA, total_loans: 99 };
+    mockGetDashboard.mockResolvedValueOnce(updatedDashboard);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.dashboard).toEqual(updatedDashboard);
+  });
+
+  // =========================================================================
+  // 3. Sets error on failure
+  // =========================================================================
+
+  it('sets error message when getDashboard fails', async () => {
+    mockGetDashboard.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.dashboard).toBeNull();
+  });
+
+  it('sets error message when getSlaCompliance fails', async () => {
+    mockGetSlaCompliance.mockRejectedValue(new Error('SLA endpoint unavailable'));
+
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('SLA endpoint unavailable');
+  });
+
+  it('sets error message when getBottlenecks fails', async () => {
+    mockGetBottlenecks.mockRejectedValue(new Error('Bottlenecks timeout'));
+
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Bottlenecks timeout');
+  });
+
+  it('clears a previous error on a successful refresh', async () => {
+    mockGetDashboard.mockRejectedValueOnce(new Error('First failure'));
+
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('First failure');
+
+    // Next call succeeds
+    mockGetDashboard.mockResolvedValue(DASHBOARD_DATA);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.dashboard).toEqual(DASHBOARD_DATA);
+  });
+
+  it('sets loading=false even when a fetch fails (finally block)', async () => {
+    mockGetBottlenecks.mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useDocAnalytics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // loading must be false regardless of the error
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/frontend/src/hooks/__tests__/useReviewQueue.test.js
+++ b/frontend/src/hooks/__tests__/useReviewQueue.test.js
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted ensures mockApi is defined before the hoisted vi.mock
+// ---------------------------------------------------------------------------
+
+const mockApi = vi.hoisted(() => ({
+  getQueue: vi.fn(),
+  getQueueStats: vi.fn(),
+  claimDocument: vi.fn(),
+  releaseDocument: vi.fn(),
+}));
+
+vi.mock('../../services/docReviewApi', () => ({
+  getQueue: mockApi.getQueue,
+  getQueueStats: mockApi.getQueueStats,
+  claimDocument: mockApi.claimDocument,
+  releaseDocument: mockApi.releaseDocument,
+}));
+
+import useReviewQueue from '../useReviewQueue';
+
+// ---------------------------------------------------------------------------
+// Default mock responses
+// ---------------------------------------------------------------------------
+
+const MOCK_ITEMS = [
+  { id: 1, doc_type: 'paystubs', priority: 'HIGH' },
+  { id: 2, doc_type: 'w2', priority: 'NORMAL' },
+];
+
+const MOCK_STATS = {
+  total: 10,
+  claimed: 3,
+  unclaimed: 7,
+};
+
+function setDefaultMocks() {
+  mockApi.getQueue.mockResolvedValue({ items: MOCK_ITEMS, total: 2 });
+  mockApi.getQueueStats.mockResolvedValue(MOCK_STATS);
+  mockApi.claimDocument.mockResolvedValue({ id: 1, status: 'claimed' });
+  mockApi.releaseDocument.mockResolvedValue({ id: 1, status: 'released' });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useReviewQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDefaultMocks();
+  });
+
+  // =========================================================================
+  // Mount / initial load
+  // =========================================================================
+
+  describe('initial load', () => {
+    it('loads queue items and stats on mount', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.items).toEqual(MOCK_ITEMS);
+      expect(result.current.stats).toEqual(MOCK_STATS);
+      expect(result.current.total).toBe(2);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('calls getQueue and getQueueStats in parallel on mount', async () => {
+      renderHook(() => useReviewQueue());
+
+      await waitFor(() => {
+        expect(mockApi.getQueue).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockApi.getQueueStats).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts with default filters { limit: 50, offset: 0 }', () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      expect(result.current.filters).toEqual({ limit: 50, offset: 0 });
+    });
+
+    it('passes default filters to getQueue on mount', async () => {
+      renderHook(() => useReviewQueue());
+
+      await waitFor(() => {
+        expect(mockApi.getQueue).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+      });
+    });
+
+    it('sets loading=true initially then false after load', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      // loading starts true
+      expect(result.current.loading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+
+    it('sets error when getQueue rejects', async () => {
+      mockApi.getQueue.mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBe('Network error');
+      expect(result.current.items).toEqual([]);
+    });
+  });
+
+  // =========================================================================
+  // claim
+  // =========================================================================
+
+  describe('claim', () => {
+    it('calls claimDocument with documentId and reviewerId', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.claim(42, 'user-123');
+      });
+
+      expect(mockApi.claimDocument).toHaveBeenCalledWith(42, 'user-123');
+    });
+
+    it('refreshes the queue and stats after claiming', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // Reset call counts after initial load
+      mockApi.getQueue.mockClear();
+      mockApi.getQueueStats.mockClear();
+
+      await act(async () => {
+        await result.current.claim(42, 'user-123');
+      });
+
+      expect(mockApi.getQueue).toHaveBeenCalledTimes(1);
+      expect(mockApi.getQueueStats).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates errors from claimDocument', async () => {
+      mockApi.claimDocument.mockRejectedValue(new Error('Already claimed'));
+
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await expect(result.current.claim(42)).rejects.toThrow('Already claimed');
+      });
+    });
+  });
+
+  // =========================================================================
+  // release
+  // =========================================================================
+
+  describe('release', () => {
+    it('calls releaseDocument with documentId', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.release(7);
+      });
+
+      expect(mockApi.releaseDocument).toHaveBeenCalledWith(7);
+    });
+
+    it('refreshes the queue and stats after releasing', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      mockApi.getQueue.mockClear();
+      mockApi.getQueueStats.mockClear();
+
+      await act(async () => {
+        await result.current.release(7);
+      });
+
+      expect(mockApi.getQueue).toHaveBeenCalledTimes(1);
+      expect(mockApi.getQueueStats).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // =========================================================================
+  // setFilters
+  // =========================================================================
+
+  describe('setFilters', () => {
+    it('merges new filters and resets offset to 0', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.setFilters({ priority: 'HIGH' });
+      });
+
+      expect(result.current.filters).toEqual({ limit: 50, offset: 0, priority: 'HIGH' });
+    });
+
+    it('triggers a reload with merged filters', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      mockApi.getQueue.mockClear();
+
+      act(() => {
+        result.current.setFilters({ priority: 'HIGH' });
+      });
+
+      await waitFor(() => {
+        expect(mockApi.getQueue).toHaveBeenCalledWith({
+          limit: 50,
+          offset: 0,
+          priority: 'HIGH',
+        });
+      });
+    });
+
+    it('resets offset to 0 even if current offset is non-zero', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // Move to page 2
+      act(() => {
+        result.current.nextPage();
+      });
+
+      await waitFor(() => {
+        expect(result.current.filters.offset).toBe(50);
+      });
+
+      // setFilters should reset offset
+      act(() => {
+        result.current.setFilters({ docType: 'w2' });
+      });
+
+      expect(result.current.filters.offset).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // Pagination
+  // =========================================================================
+
+  describe('pagination', () => {
+    it('nextPage increments offset by limit', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.nextPage();
+      });
+
+      expect(result.current.filters.offset).toBe(50);
+    });
+
+    it('prevPage decrements offset by limit', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // First go to page 2
+      act(() => {
+        result.current.nextPage();
+      });
+
+      await waitFor(() => expect(result.current.filters.offset).toBe(50));
+
+      // Then go back
+      act(() => {
+        result.current.prevPage();
+      });
+
+      expect(result.current.filters.offset).toBe(0);
+    });
+
+    it('prevPage does not go below offset 0', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => {
+        result.current.prevPage();
+      });
+
+      expect(result.current.filters.offset).toBe(0);
+    });
+
+    it('nextPage triggers a reload with updated offset', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      mockApi.getQueue.mockClear();
+
+      act(() => {
+        result.current.nextPage();
+      });
+
+      await waitFor(() => {
+        expect(mockApi.getQueue).toHaveBeenCalledWith({ limit: 50, offset: 50 });
+      });
+    });
+  });
+
+  // =========================================================================
+  // refresh
+  // =========================================================================
+
+  describe('refresh', () => {
+    it('reloads queue and stats', async () => {
+      const { result } = renderHook(() => useReviewQueue());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      mockApi.getQueue.mockClear();
+      mockApi.getQueueStats.mockClear();
+
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      expect(mockApi.getQueue).toHaveBeenCalledTimes(1);
+      expect(mockApi.getQueueStats).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/hooks/useDocAnalytics.js
+++ b/frontend/src/hooks/useDocAnalytics.js
@@ -1,0 +1,55 @@
+/**
+ * useDocAnalytics Hook
+ *
+ * Loads analytics dashboard data (dashboard summary, SLA compliance,
+ * and bottleneck analysis) in parallel. Re-fetches when `days` changes.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { getDashboard, getSlaCompliance, getBottlenecks } from '../services/docAnalyticsApi';
+
+/**
+ * @param {number} days - Lookback window in days (default 30)
+ * @returns {{ dashboard, sla, bottlenecks, loading, error, refresh }}
+ */
+export function useDocAnalytics(days = 30) {
+  const [dashboard, setDashboard] = useState(null);
+  const [sla, setSla] = useState(null);
+  const [bottlenecks, setBottlenecks] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [dashboardData, slaData, bottlenecksData] = await Promise.all([
+        getDashboard(days),
+        getSlaCompliance(days),
+        getBottlenecks(days),
+      ]);
+      setDashboard(dashboardData);
+      setSla(slaData);
+      setBottlenecks(bottlenecksData);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  return {
+    dashboard,
+    sla,
+    bottlenecks,
+    loading,
+    error,
+    refresh: fetchAll,
+  };
+}
+
+export default useDocAnalytics;

--- a/frontend/src/hooks/useReviewQueue.js
+++ b/frontend/src/hooks/useReviewQueue.js
@@ -1,0 +1,148 @@
+/**
+ * Perennia AI - useReviewQueue Hook
+ *
+ * Manages document review queue state: items, stats, pagination, filtering,
+ * and claim/release actions. Delegates API calls to docReviewApi.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { getQueue, getQueueStats, claimDocument, releaseDocument } from '../services/docReviewApi';
+
+const DEFAULT_FILTERS = { limit: 50, offset: 0 };
+
+/**
+ * Hook for managing the document review queue.
+ *
+ * @returns {{
+ *   items: Array,
+ *   stats: object|null,
+ *   total: number,
+ *   loading: boolean,
+ *   error: string|null,
+ *   filters: object,
+ *   setFilters: function,
+ *   nextPage: function,
+ *   prevPage: function,
+ *   claim: function,
+ *   release: function,
+ *   refresh: function,
+ * }}
+ */
+export default function useReviewQueue() {
+  const [items, setItems] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [filters, setFiltersState] = useState(DEFAULT_FILTERS);
+
+  // Track mounted state to prevent state updates after unmount
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Core load function — accepts an optional filters override so callers can
+  // pass freshly-computed filters before the state update has propagated.
+  // ---------------------------------------------------------------------------
+
+  const load = useCallback(async (filtersOverride) => {
+    const activeFilters = filtersOverride ?? filters;
+    setLoading(true);
+    setError(null);
+    try {
+      const [queueResponse, statsResponse] = await Promise.all([
+        getQueue(activeFilters),
+        getQueueStats(),
+      ]);
+      if (!mountedRef.current) return;
+      setItems(queueResponse.items ?? []);
+      setTotal(queueResponse.total ?? 0);
+      setStats(statsResponse);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setItems([]);
+      setError(err.message ?? String(err));
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [filters]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Load on mount
+  useEffect(() => {
+    load(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Reload whenever filters change (skip initial mount — load() above handles it)
+  const isFirstRender = useRef(true);
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    load(filters);
+  }, [filters]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ---------------------------------------------------------------------------
+  // Filter management
+  // ---------------------------------------------------------------------------
+
+  const setFilters = useCallback((newFilters) => {
+    setFiltersState((prev) => ({ ...prev, ...newFilters, offset: 0 }));
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Pagination
+  // ---------------------------------------------------------------------------
+
+  const nextPage = useCallback(() => {
+    setFiltersState((prev) => ({ ...prev, offset: prev.offset + prev.limit }));
+  }, []);
+
+  const prevPage = useCallback(() => {
+    setFiltersState((prev) => ({
+      ...prev,
+      offset: Math.max(0, prev.offset - prev.limit),
+    }));
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
+
+  const claim = useCallback(async (documentId, reviewerId) => {
+    await claimDocument(documentId, reviewerId);
+    await load();
+  }, [load]);
+
+  const release = useCallback(async (documentId) => {
+    await releaseDocument(documentId);
+    await load();
+  }, [load]);
+
+  const refresh = useCallback(async () => {
+    await load();
+  }, [load]);
+
+  return {
+    items,
+    stats,
+    total,
+    loading,
+    error,
+    filters,
+    setFilters,
+    nextPage,
+    prevPage,
+    claim,
+    release,
+    refresh,
+  };
+}

--- a/frontend/src/pages/AriaVoiceApp.css
+++ b/frontend/src/pages/AriaVoiceApp.css
@@ -961,7 +961,10 @@
   .aria-fallback,
   .aria-fallback-shimmer,
   .aria-login-btn:hover,
-  .aria-stop-btn {
+  .aria-stop-btn,
+  .aria-ci-recording-dot,
+  .aria-ci-badge-new,
+  .aria-ci-recording-indicator {
     animation: none !important;
     transition: none !important;
   }

--- a/frontend/src/pages/SmartDocsAdmin.css
+++ b/frontend/src/pages/SmartDocsAdmin.css
@@ -1,0 +1,274 @@
+/* Smart Docs Admin Configuration Page */
+
+.sd-admin {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+/* Header */
+.sd-admin__header {
+  margin-bottom: 24px;
+}
+
+.sd-admin__title {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: #1e293b;
+  margin: 0;
+}
+
+.sd-admin__subtitle {
+  color: #64748b;
+  font-size: 0.9em;
+  margin: 4px 0 0;
+}
+
+/* Tabs — matches other Smart Docs pages */
+.sd-admin__tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 2px solid #e2e8f0;
+  margin-bottom: 24px;
+}
+
+.sd-admin__tab {
+  padding: 10px 20px;
+  border: none;
+  background: none;
+  font-size: 0.92em;
+  font-weight: 500;
+  color: #64748b;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.sd-admin__tab:hover {
+  color: #1e293b;
+}
+
+.sd-admin__tab.active {
+  color: #2563eb;
+  border-bottom-color: #2563eb;
+  font-weight: 600;
+}
+
+/* Content */
+.sd-admin__content {
+  min-height: 200px;
+}
+
+/* Loading / Empty */
+.sd-admin__loading {
+  text-align: center;
+  padding: 48px 24px;
+  color: #94a3b8;
+  font-size: 0.95em;
+}
+
+.sd-admin__empty {
+  text-align: center;
+  padding: 48px 24px;
+  color: #94a3b8;
+  font-size: 0.95em;
+  background: #f8fafc;
+  border: 1px dashed #e2e8f0;
+  border-radius: 10px;
+}
+
+/* Card */
+.sd-admin__card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 24px;
+}
+
+.sd-admin__card-title {
+  font-size: 1em;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0 0 20px;
+}
+
+/* Form */
+.sd-admin__form {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Field row: label left, input right */
+.sd-admin__field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  border-bottom: 1px solid #f1f5f9;
+  gap: 16px;
+}
+
+.sd-admin__field:last-child {
+  border-bottom: none;
+}
+
+.sd-admin__label {
+  font-size: 0.9em;
+  font-weight: 500;
+  color: #334155;
+  flex: 1;
+}
+
+/* Checkbox: 20x20px */
+.sd-admin__checkbox {
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  accent-color: #2563eb;
+  flex-shrink: 0;
+}
+
+/* Number inputs: 100px, right-aligned */
+.sd-admin__number-input {
+  width: 100px;
+  padding: 7px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.9em;
+  color: #1e293b;
+  text-align: right;
+  background: #fff;
+  flex-shrink: 0;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.sd-admin__number-input:focus {
+  outline: none;
+  border-color: #93c5fd;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
+}
+
+/* Form actions — align right */
+.sd-admin__form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+}
+
+/* Section header: title + Add button */
+.sd-admin__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  gap: 12px;
+}
+
+.sd-admin__section-title {
+  font-size: 1em;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0;
+}
+
+/* Buttons */
+.sd-admin__btn {
+  padding: 9px 18px;
+  border-radius: 7px;
+  font-size: 0.88em;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.sd-admin__btn--primary {
+  background: #2563eb;
+  color: #fff;
+}
+
+.sd-admin__btn--primary:hover {
+  background: #1d4ed8;
+}
+
+/* Table */
+.sd-admin__table-container {
+  overflow-x: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+}
+
+.sd-admin__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88em;
+}
+
+.sd-admin__table thead th {
+  background: #f8fafc;
+  padding: 11px 14px;
+  text-align: left;
+  font-weight: 600;
+  color: #475569;
+  font-size: 0.82em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid #e2e8f0;
+  white-space: nowrap;
+}
+
+.sd-admin__table tbody td {
+  padding: 11px 14px;
+  color: #334155;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: middle;
+}
+
+.sd-admin__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.sd-admin__table tbody tr:hover {
+  background: #f8fafc;
+}
+
+/* Badge */
+.sd-admin__badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 99px;
+  font-size: 0.82em;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* ============================================================
+   Mobile: stack form fields vertically at 480px
+   ============================================================ */
+@media (max-width: 480px) {
+  .sd-admin {
+    padding: 16px;
+  }
+
+  .sd-admin__field {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .sd-admin__number-input {
+    width: 100%;
+    text-align: left;
+  }
+
+  .sd-admin__checkbox {
+    align-self: flex-start;
+  }
+
+  .sd-admin__section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/SmartDocsAdmin.js
+++ b/frontend/src/pages/SmartDocsAdmin.js
@@ -1,0 +1,262 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import docReviewApi from '../services/docReviewApi';
+import docSecurityApi from '../services/docSecurityApi';
+import { toast } from '../utils/toast';
+import './SmartDocsAdmin.css';
+
+const TABS = [
+  { key: 'auto-review', label: 'Auto-Review Settings' },
+  { key: 'retention', label: 'Retention Policies' },
+];
+
+// ---------------------------------------------------------------------------
+// Auto-Review Settings Tab
+// ---------------------------------------------------------------------------
+function AutoReviewTab({ autoReview, setAutoReview, onSave }) {
+  if (!autoReview) {
+    return <div className="sd-admin__empty">No auto-review settings available.</div>;
+  }
+
+  function handleChange(e) {
+    const { name, type, value, checked } = e.target;
+    setAutoReview(prev => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : Number(value),
+    }));
+  }
+
+  return (
+    <div className="sd-admin__card">
+      <h3 className="sd-admin__card-title">Auto-Review Configuration</h3>
+      <div className="sd-admin__form">
+        <div className="sd-admin__field">
+          <label htmlFor="ar-enabled" className="sd-admin__label">Enable Auto-Review</label>
+          <input
+            id="ar-enabled"
+            name="enabled"
+            type="checkbox"
+            className="sd-admin__checkbox"
+            checked={!!autoReview.enabled}
+            onChange={handleChange}
+          />
+        </div>
+        <div className="sd-admin__field">
+          <label htmlFor="ar-confidence" className="sd-admin__label">Confidence Threshold</label>
+          <input
+            id="ar-confidence"
+            name="confidence_threshold"
+            type="number"
+            className="sd-admin__number-input"
+            min={50}
+            max={100}
+            value={autoReview.confidence_threshold ?? 80}
+            onChange={handleChange}
+          />
+        </div>
+        <div className="sd-admin__field">
+          <label htmlFor="ar-quality" className="sd-admin__label">Quality Threshold</label>
+          <input
+            id="ar-quality"
+            name="quality_threshold"
+            type="number"
+            className="sd-admin__number-input"
+            min={50}
+            max={100}
+            value={autoReview.quality_threshold ?? 75}
+            onChange={handleChange}
+          />
+        </div>
+        <div className="sd-admin__field">
+          <label htmlFor="ar-max-approvals" className="sd-admin__label">Max Auto-Approvals per Day</label>
+          <input
+            id="ar-max-approvals"
+            name="max_auto_approvals_per_day"
+            type="number"
+            className="sd-admin__number-input"
+            min={0}
+            max={1000}
+            value={autoReview.max_auto_approvals_per_day ?? 50}
+            onChange={handleChange}
+          />
+        </div>
+      </div>
+      <div className="sd-admin__form-actions">
+        <button className="sd-admin__btn sd-admin__btn--primary" onClick={onSave}>
+          Save Settings
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Retention Policies Tab
+// ---------------------------------------------------------------------------
+function RetentionPoliciesTab({ policies, onAdd }) {
+  return (
+    <div>
+      <div className="sd-admin__section-header">
+        <h3 className="sd-admin__section-title">Retention Policies</h3>
+        <button className="sd-admin__btn sd-admin__btn--primary" onClick={onAdd}>
+          Add Policy
+        </button>
+      </div>
+      {(!policies || policies.length === 0) ? (
+        <div className="sd-admin__empty">No retention policies configured.</div>
+      ) : (
+        <div className="sd-admin__table-container">
+          <table className="sd-admin__table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Document Type</th>
+                <th>Retention (days)</th>
+                <th>Action</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {policies.map((policy, idx) => {
+                const isActive =
+                  policy.is_active !== false && policy.status !== 'inactive';
+                return (
+                  <tr key={policy.id || idx}>
+                    <td>{policy.policy_name || policy.name || '—'}</td>
+                    <td>{policy.doc_type || policy.document_type || '—'}</td>
+                    <td>{policy.retention_days != null ? policy.retention_days : '—'}</td>
+                    <td>{policy.action || policy.retention_action || '—'}</td>
+                    <td>
+                      <span
+                        className="sd-admin__badge"
+                        style={
+                          isActive
+                            ? { background: '#dcfce7', color: '#15803d' }
+                            : { background: '#f1f5f9', color: '#64748b' }
+                        }
+                      >
+                        {isActive ? 'Active' : 'Inactive'}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Page Component
+// ---------------------------------------------------------------------------
+export default function SmartDocsAdmin() {
+  const [activeTab, setActiveTab] = useState('auto-review');
+  const [autoReview, setAutoReview] = useState(null);
+  const [retentionPolicies, setRetentionPolicies] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [reviewRes, retentionRes] = await Promise.allSettled([
+        docReviewApi.getAutoReviewSettings(),
+        docSecurityApi.getRetentionPolicies(),
+      ]);
+
+      if (reviewRes.status === 'fulfilled') {
+        setAutoReview(reviewRes.value);
+      } else {
+        toast.error('Failed to load auto-review settings');
+      }
+
+      if (retentionRes.status === 'fulfilled') {
+        const data = retentionRes.value;
+        setRetentionPolicies(Array.isArray(data) ? data : data.policies || []);
+      } else {
+        toast.error('Failed to load retention policies');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  async function handleSaveAutoReview() {
+    if (!autoReview) return;
+    try {
+      await docReviewApi.updateAutoReviewSettings(autoReview);
+      toast.success('Auto-review settings saved');
+    } catch (err) {
+      toast.error(err.message || 'Failed to save settings');
+    }
+  }
+
+  async function handleAddPolicy() {
+    const name = window.prompt('Enter policy name:');
+    if (!name || !name.trim()) return;
+    try {
+      await docSecurityApi.createRetentionPolicy({
+        policy_name: name.trim(),
+        retention_days: 2555,
+        action: 'archive',
+        is_active: true,
+      });
+      toast.success('Retention policy created');
+      // Reload table
+      const data = await docSecurityApi.getRetentionPolicies();
+      setRetentionPolicies(Array.isArray(data) ? data : data.policies || []);
+    } catch (err) {
+      toast.error(err.message || 'Failed to create policy');
+    }
+  }
+
+  return (
+    <div className="sd-admin">
+      <div className="sd-admin__header">
+        <h1 className="sd-admin__title">Admin Configuration</h1>
+        <p className="sd-admin__subtitle">
+          Manage auto-review thresholds and document retention policies
+        </p>
+      </div>
+
+      <div className="sd-admin__tabs">
+        {TABS.map(tab => (
+          <button
+            key={tab.key}
+            className={`sd-admin__tab${activeTab === tab.key ? ' active' : ''}`}
+            onClick={() => setActiveTab(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="sd-admin__content">
+        {loading ? (
+          <div className="sd-admin__loading">Loading configuration...</div>
+        ) : (
+          <>
+            {activeTab === 'auto-review' && (
+              <AutoReviewTab
+                autoReview={autoReview}
+                setAutoReview={setAutoReview}
+                onSave={handleSaveAutoReview}
+              />
+            )}
+            {activeTab === 'retention' && (
+              <RetentionPoliciesTab
+                policies={retentionPolicies}
+                onAdd={handleAddPolicy}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SmartDocsAnalytics.css
+++ b/frontend/src/pages/SmartDocsAnalytics.css
@@ -1,0 +1,357 @@
+/**
+ * SmartDocsAnalytics Styles
+ *
+ * Uses CSS custom properties from the project's design system.
+ * Falls back to hard-coded values where variables may not be defined.
+ */
+
+/* ---------------------------------------------------------------------------
+   Page Container
+--------------------------------------------------------------------------- */
+
+.sd-analytics {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-lg, 24px);
+}
+
+/* ---------------------------------------------------------------------------
+   Header
+--------------------------------------------------------------------------- */
+
+.sd-analytics__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-md, 16px);
+  margin-bottom: var(--space-lg, 24px);
+}
+
+.sd-analytics__title-group {
+  flex: 1;
+}
+
+.sd-analytics__title {
+  margin: 0 0 4px;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #1f2937);
+}
+
+.sd-analytics__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.sd-analytics__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  flex-shrink: 0;
+}
+
+.sd-analytics__period-select {
+  padding: 8px 12px;
+  font-size: 0.9rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  background: var(--color-bg-primary, #ffffff);
+  color: var(--color-text-primary, #1f2937);
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.sd-analytics__period-select:focus {
+  outline: none;
+  border-color: var(--color-primary, #2563eb);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.sd-analytics__refresh-btn {
+  padding: 8px 16px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background: var(--color-primary, #2563eb);
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.sd-analytics__refresh-btn:hover {
+  background: var(--color-primary-dark, #1d4ed8);
+}
+
+/* ---------------------------------------------------------------------------
+   Tab Bar
+--------------------------------------------------------------------------- */
+
+.sd-analytics__tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  margin-bottom: var(--space-lg, 24px);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.sd-analytics__tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.sd-analytics__tab {
+  padding: 12px 20px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-text-secondary, #6b7280);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.2s, border-color 0.2s;
+  margin-bottom: -1px;
+}
+
+.sd-analytics__tab:hover {
+  color: var(--color-text-primary, #1f2937);
+}
+
+.sd-analytics__tab--active {
+  color: var(--color-primary, #2563eb);
+  border-bottom-color: var(--color-primary, #2563eb);
+}
+
+/* ---------------------------------------------------------------------------
+   Metric Grids
+--------------------------------------------------------------------------- */
+
+.sd-analytics__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-md, 16px);
+}
+
+.sd-analytics__grid--2 {
+  grid-template-columns: repeat(2, 1fr);
+  margin-bottom: var(--space-lg, 24px);
+}
+
+/* ---------------------------------------------------------------------------
+   Table
+--------------------------------------------------------------------------- */
+
+.sd-analytics__table-container {
+  overflow-x: auto;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 10px;
+  margin-top: var(--space-md, 16px);
+}
+
+.sd-analytics__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.sd-analytics__table thead tr {
+  background: var(--color-bg-secondary, #f9fafb);
+}
+
+.sd-analytics__table th {
+  padding: 12px 16px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #6b7280);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  white-space: nowrap;
+}
+
+.sd-analytics__table td {
+  padding: 12px 16px;
+  color: var(--color-text-primary, #1f2937);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.sd-analytics__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.sd-analytics__table tbody tr:hover {
+  background: var(--color-bg-secondary, #f9fafb);
+}
+
+/* ---------------------------------------------------------------------------
+   Bottleneck Cards
+--------------------------------------------------------------------------- */
+
+.sd-analytics__bottleneck-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md, 16px);
+}
+
+.sd-analytics__bottleneck {
+  padding: 16px 20px;
+  background: var(--color-bg-primary, #ffffff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-left: 4px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  transition: box-shadow 0.2s;
+}
+
+.sd-analytics__bottleneck:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.sd-analytics__bottleneck--critical {
+  border-left-color: #dc2626;
+}
+
+.sd-analytics__bottleneck--high {
+  border-left-color: #ea580c;
+}
+
+.sd-analytics__bottleneck--medium {
+  border-left-color: #d97706;
+}
+
+.sd-analytics__bottleneck--low {
+  border-left-color: #10b981;
+}
+
+.sd-analytics__bottleneck-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm, 8px);
+  margin-bottom: 8px;
+}
+
+.sd-analytics__bottleneck-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #1f2937);
+}
+
+.sd-analytics__severity-badge {
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.sd-analytics__severity-badge--critical {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.sd-analytics__severity-badge--high {
+  background: #ffedd5;
+  color: #9a3412;
+}
+
+.sd-analytics__severity-badge--medium {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.sd-analytics__severity-badge--low {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.sd-analytics__bottleneck-desc {
+  margin: 0 0 10px;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.sd-analytics__bottleneck-meta {
+  display: flex;
+  gap: var(--space-md, 16px);
+}
+
+.sd-analytics__bottleneck-stat {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #6b7280);
+  font-weight: 500;
+}
+
+/* ---------------------------------------------------------------------------
+   Empty & Status States
+--------------------------------------------------------------------------- */
+
+.sd-analytics__empty {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--color-text-secondary, #6b7280);
+  font-size: 0.9rem;
+}
+
+.loading,
+.error {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--color-text-secondary, #6b7280);
+  font-size: 0.9rem;
+}
+
+.error {
+  color: #dc2626;
+}
+
+.error p {
+  margin: 0 0 16px;
+}
+
+/* ---------------------------------------------------------------------------
+   Responsive
+--------------------------------------------------------------------------- */
+
+@media (max-width: 768px) {
+  .sd-analytics {
+    padding: var(--space-md, 16px);
+  }
+
+  .sd-analytics__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sd-analytics__controls {
+    justify-content: flex-end;
+  }
+
+  .sd-analytics__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .sd-analytics__grid--2 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .sd-analytics__grid,
+  .sd-analytics__grid--2 {
+    grid-template-columns: 1fr;
+  }
+
+  .sd-analytics__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sd-analytics__period-select,
+  .sd-analytics__refresh-btn {
+    width: 100%;
+  }
+}

--- a/frontend/src/pages/SmartDocsAnalytics.js
+++ b/frontend/src/pages/SmartDocsAnalytics.js
@@ -5,7 +5,7 @@
  * Tabs: Overview, SLA Compliance, AI Performance, Team Productivity, Bottlenecks
  */
 import React, { useState, useEffect } from 'react';
-import toast from '../utils/toast';
+import { toast } from '../utils/toast';
 import { useDocAnalytics } from '../hooks/useDocAnalytics';
 import AnalyticsCard from '../components/smart-docs/AnalyticsCard';
 import {

--- a/frontend/src/pages/SmartDocsAnalytics.js
+++ b/frontend/src/pages/SmartDocsAnalytics.js
@@ -1,0 +1,435 @@
+/**
+ * SmartDocsAnalytics Page
+ *
+ * Full analytics dashboard with 5 tabs and a period selector.
+ * Tabs: Overview, SLA Compliance, AI Performance, Team Productivity, Bottlenecks
+ */
+import React, { useState, useEffect } from 'react';
+import toast from 'react-hot-toast';
+import { useDocAnalytics } from '../hooks/useDocAnalytics';
+import AnalyticsCard from '../components/smart-docs/AnalyticsCard';
+import {
+  getAiPerformance,
+  getProcessorProductivity,
+  getTrends,
+} from '../services/docAnalyticsApi';
+import './SmartDocsAnalytics.css';
+
+const PERIOD_OPTIONS = [
+  { value: 7, label: '7 days' },
+  { value: 30, label: '30 days' },
+  { value: 90, label: '90 days' },
+];
+
+const TABS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'sla', label: 'SLA Compliance' },
+  { id: 'ai', label: 'AI Performance' },
+  { id: 'team', label: 'Team Productivity' },
+  { id: 'bottlenecks', label: 'Bottlenecks' },
+];
+
+const SEVERITY_LABELS = {
+  critical: 'Critical',
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+function SmartDocsAnalytics() {
+  const [days, setDays] = useState(30);
+  const [activeTab, setActiveTab] = useState('overview');
+
+  // Extended data loaded separately
+  const [aiPerf, setAiPerf] = useState(null);
+  const [processorData, setProcessorData] = useState(null);
+  const [trends, setTrends] = useState(null);
+
+  const { dashboard, sla, bottlenecks, loading, error, refresh } = useDocAnalytics(days);
+
+  // Load extended data when days or activeTab changes
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchExtended() {
+      try {
+        const [aiData, procData, trendData] = await Promise.all([
+          getAiPerformance(days),
+          getProcessorProductivity(days),
+          getTrends('weekly', days),
+        ]);
+        if (!cancelled) {
+          setAiPerf(aiData);
+          setProcessorData(procData);
+          setTrends(trendData);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          toast.error('Failed to load extended analytics data');
+        }
+      }
+    }
+
+    fetchExtended();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  function handlePeriodChange(e) {
+    setDays(Number(e.target.value));
+  }
+
+  function handleRefresh() {
+    refresh();
+  }
+
+  if (loading) {
+    return (
+      <div className="sd-analytics">
+        <div className="loading">Loading analytics...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="sd-analytics">
+        <div className="error">
+          <p>Failed to load analytics: {error}</p>
+          <button onClick={handleRefresh} className="sd-analytics__refresh-btn">
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sd-analytics">
+      {/* Header */}
+      <div className="sd-analytics__header">
+        <div className="sd-analytics__title-group">
+          <h1 className="sd-analytics__title">Document Analytics</h1>
+          <p className="sd-analytics__subtitle">
+            Performance metrics and compliance insights
+          </p>
+        </div>
+        <div className="sd-analytics__controls">
+          <select
+            className="sd-analytics__period-select"
+            value={days}
+            onChange={handlePeriodChange}
+            aria-label="Select time period"
+          >
+            {PERIOD_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <button className="sd-analytics__refresh-btn" onClick={handleRefresh}>
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Tab Bar */}
+      <div className="sd-analytics__tabs" role="tablist">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            className={[
+              'sd-analytics__tab',
+              activeTab === tab.id ? 'sd-analytics__tab--active' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      <div className="sd-analytics__content" role="tabpanel">
+        {activeTab === 'overview' && <OverviewTab dashboard={dashboard} />}
+        {activeTab === 'sla' && <SlaTab sla={sla} />}
+        {activeTab === 'ai' && <AiTab aiPerf={aiPerf} />}
+        {activeTab === 'team' && <TeamTab processorData={processorData} />}
+        {activeTab === 'bottlenecks' && <BottlenecksTab bottlenecks={bottlenecks} />}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Overview Tab
+// ---------------------------------------------------------------------------
+
+function OverviewTab({ dashboard }) {
+  const d = dashboard || {};
+
+  return (
+    <div className="sd-analytics__grid">
+      <AnalyticsCard
+        title="Total Documents"
+        value={d.total_documents ?? '-'}
+        subtitle={`Last ${d.period_days ?? 30} days`}
+      />
+      <AnalyticsCard
+        title="Pending Review"
+        value={d.pending_review ?? '-'}
+        status={d.pending_review > 20 ? 'warning' : undefined}
+        subtitle="Awaiting review"
+      />
+      <AnalyticsCard
+        title="Approved"
+        value={d.approved ?? '-'}
+        status="success"
+        subtitle="Documents approved"
+      />
+      <AnalyticsCard
+        title="Rejected"
+        value={d.rejected ?? '-'}
+        status={d.rejected > 10 ? 'error' : undefined}
+        subtitle="Documents rejected"
+      />
+      <AnalyticsCard
+        title="Avg Review Time"
+        value={d.avg_review_hours != null ? `${d.avg_review_hours}h` : '-'}
+        subtitle="Hours per document"
+      />
+      <AnalyticsCard
+        title="Auto-Approved"
+        value={d.auto_approved ?? '-'}
+        subtitle="AI auto-approvals"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SLA Compliance Tab
+// ---------------------------------------------------------------------------
+
+function SlaTab({ sla }) {
+  const s = sla || {};
+  const byDocType = s.by_doc_type || [];
+
+  return (
+    <div>
+      <div className="sd-analytics__grid sd-analytics__grid--2">
+        <AnalyticsCard
+          title="SLA Compliance Rate"
+          value={s.compliance_rate != null ? `${s.compliance_rate}%` : '-'}
+          status={
+            s.compliance_rate >= 90
+              ? 'success'
+              : s.compliance_rate >= 70
+              ? 'warning'
+              : 'error'
+          }
+          subtitle="Documents reviewed on time"
+        />
+        <AnalyticsCard
+          title="SLA Breaches"
+          value={s.breaches ?? '-'}
+          status={s.breaches > 0 ? 'error' : 'success'}
+          subtitle="Documents past SLA deadline"
+        />
+      </div>
+
+      {byDocType.length > 0 && (
+        <div className="sd-analytics__table-container">
+          <table className="sd-analytics__table">
+            <thead>
+              <tr>
+                <th>Doc Type</th>
+                <th>Total</th>
+                <th>On Time</th>
+                <th>Breached</th>
+                <th>Rate</th>
+              </tr>
+            </thead>
+            <tbody>
+              {byDocType.map((row, idx) => (
+                <tr key={row.doc_type || idx}>
+                  <td>{row.doc_type}</td>
+                  <td>{row.total ?? '-'}</td>
+                  <td>{row.on_time ?? '-'}</td>
+                  <td>{row.breached ?? '-'}</td>
+                  <td>
+                    {row.rate != null ? `${row.rate}%` : '-'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AI Performance Tab
+// ---------------------------------------------------------------------------
+
+function AiTab({ aiPerf }) {
+  const a = aiPerf || {};
+
+  return (
+    <div className="sd-analytics__grid">
+      <AnalyticsCard
+        title="Accuracy"
+        value={a.accuracy != null ? `${a.accuracy}%` : '-'}
+        status={a.accuracy >= 90 ? 'success' : a.accuracy >= 75 ? 'warning' : 'error'}
+        subtitle="Classification accuracy"
+      />
+      <AnalyticsCard
+        title="Total Reviewed"
+        value={a.total_reviewed ?? '-'}
+        subtitle="Documents processed by AI"
+      />
+      <AnalyticsCard
+        title="Auto-Approved"
+        value={a.auto_approved ?? '-'}
+        status="success"
+        subtitle="Automatically approved"
+      />
+      <AnalyticsCard
+        title="Escalated"
+        value={a.escalated ?? '-'}
+        subtitle="Sent for human review"
+      />
+      <AnalyticsCard
+        title="Avg Confidence"
+        value={a.avg_confidence != null ? `${a.avg_confidence}%` : '-'}
+        subtitle="Mean AI confidence score"
+      />
+      <AnalyticsCard
+        title="False Rejections"
+        value={a.false_rejections ?? '-'}
+        status={a.false_rejections > 5 ? 'error' : undefined}
+        subtitle="Incorrectly rejected"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Team Productivity Tab
+// ---------------------------------------------------------------------------
+
+function TeamTab({ processorData }) {
+  const processors = (processorData && processorData.processors) || [];
+
+  if (processors.length === 0) {
+    return (
+      <div className="sd-analytics__empty">
+        No processor data available for this period.
+      </div>
+    );
+  }
+
+  return (
+    <div className="sd-analytics__table-container">
+      <table className="sd-analytics__table">
+        <thead>
+          <tr>
+            <th>Processor</th>
+            <th>Reviewed</th>
+            <th>Approved</th>
+            <th>Rejected</th>
+            <th>Avg Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {processors.map((proc, idx) => (
+            <tr key={proc.processor_id || proc.name || idx}>
+              <td>{proc.name || proc.processor_name || 'Unknown'}</td>
+              <td>{proc.reviewed ?? '-'}</td>
+              <td>{proc.approved ?? '-'}</td>
+              <td>{proc.rejected ?? '-'}</td>
+              <td>
+                {proc.avg_time != null ? `${proc.avg_time}h` : '-'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bottlenecks Tab
+// ---------------------------------------------------------------------------
+
+function BottlenecksTab({ bottlenecks }) {
+  const items =
+    bottlenecks && bottlenecks.bottlenecks
+      ? bottlenecks.bottlenecks
+      : Array.isArray(bottlenecks)
+      ? bottlenecks
+      : [];
+
+  if (items.length === 0) {
+    return (
+      <div className="sd-analytics__empty">
+        No bottlenecks detected.
+      </div>
+    );
+  }
+
+  return (
+    <div className="sd-analytics__bottleneck-list">
+      {items.map((item, idx) => (
+        <div
+          key={idx}
+          className={[
+            'sd-analytics__bottleneck',
+            item.severity ? `sd-analytics__bottleneck--${item.severity}` : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          <div className="sd-analytics__bottleneck-header">
+            <span className="sd-analytics__bottleneck-name">
+              {item.stage || item.doc_type || 'Unknown stage'}
+            </span>
+            {item.severity && (
+              <span
+                className={`sd-analytics__severity-badge sd-analytics__severity-badge--${item.severity}`}
+              >
+                {SEVERITY_LABELS[item.severity] || item.severity}
+              </span>
+            )}
+          </div>
+          {item.description && (
+            <p className="sd-analytics__bottleneck-desc">{item.description}</p>
+          )}
+          <div className="sd-analytics__bottleneck-meta">
+            {item.count != null && (
+              <span className="sd-analytics__bottleneck-stat">
+                {item.count} documents
+              </span>
+            )}
+            {item.avg_days != null && (
+              <span className="sd-analytics__bottleneck-stat">
+                Avg {item.avg_days} days
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default SmartDocsAnalytics;

--- a/frontend/src/pages/SmartDocsAnalytics.js
+++ b/frontend/src/pages/SmartDocsAnalytics.js
@@ -5,7 +5,7 @@
  * Tabs: Overview, SLA Compliance, AI Performance, Team Productivity, Bottlenecks
  */
 import React, { useState, useEffect } from 'react';
-import toast from 'react-hot-toast';
+import toast from '../utils/toast';
 import { useDocAnalytics } from '../hooks/useDocAnalytics';
 import AnalyticsCard from '../components/smart-docs/AnalyticsCard';
 import {

--- a/frontend/src/pages/SmartDocsBankAnalysis.css
+++ b/frontend/src/pages/SmartDocsBankAnalysis.css
@@ -1,0 +1,157 @@
+/**
+ * SmartDocsBankAnalysis Page Styles
+ *
+ * BEM prefix: .sd-bank
+ * Uses CSS custom properties with hard-coded fallbacks.
+ */
+
+/* ---------------------------------------------------------------------------
+   Page Container
+--------------------------------------------------------------------------- */
+
+.sd-bank {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-lg, 24px);
+}
+
+/* ---------------------------------------------------------------------------
+   Header
+--------------------------------------------------------------------------- */
+
+.sd-bank__header {
+  margin-bottom: var(--space-lg, 24px);
+}
+
+.sd-bank__title {
+  margin: 0 0 4px;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #1f2937);
+}
+
+.sd-bank__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+/* ---------------------------------------------------------------------------
+   Summary Cards Grid
+--------------------------------------------------------------------------- */
+
+.sd-bank__summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-md, 16px);
+  margin-bottom: var(--space-lg, 24px);
+}
+
+/* ---------------------------------------------------------------------------
+   Search Row
+--------------------------------------------------------------------------- */
+
+.sd-bank__search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  margin-bottom: var(--space-lg, 24px);
+}
+
+.sd-bank__search-input {
+  flex: 1;
+  max-width: 400px;
+  padding: 10px 14px;
+  font-size: 0.9rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  background: var(--color-bg-primary, #ffffff);
+  color: var(--color-text-primary, #1f2937);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.sd-bank__search-input::placeholder {
+  color: var(--color-text-secondary, #9ca3af);
+}
+
+.sd-bank__search-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #2563eb);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.sd-bank__search-btn {
+  padding: 10px 20px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: var(--color-primary, #2563eb);
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+.sd-bank__search-btn:hover:not(:disabled) {
+  background: var(--color-primary-dark, #1d4ed8);
+}
+
+.sd-bank__search-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ---------------------------------------------------------------------------
+   Loading / Error States
+--------------------------------------------------------------------------- */
+
+.sd-bank__loading {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--color-text-secondary, #6b7280);
+  font-size: 0.9rem;
+}
+
+.sd-bank__error {
+  padding: 20px 24px;
+  background: #fff5f5;
+  border: 1px solid #fecaca;
+  border-radius: 10px;
+  color: #b91c1c;
+  font-size: 0.875rem;
+  margin-bottom: var(--space-lg, 24px);
+}
+
+/* ---------------------------------------------------------------------------
+   Responsive
+--------------------------------------------------------------------------- */
+
+@media (max-width: 768px) {
+  .sd-bank {
+    padding: var(--space-md, 16px);
+  }
+
+  .sd-bank__summary-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .sd-bank__summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sd-bank__search {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sd-bank__search-input {
+    max-width: none;
+  }
+
+  .sd-bank__search-btn {
+    width: 100%;
+  }
+}

--- a/frontend/src/pages/SmartDocsBankAnalysis.js
+++ b/frontend/src/pages/SmartDocsBankAnalysis.js
@@ -1,0 +1,223 @@
+/**
+ * SmartDocsBankAnalysis Page
+ *
+ * Bank statement analysis tool. Users enter a Loan ID to retrieve
+ * a full analysis including large deposits, NSF events, undisclosed
+ * debts, and an overall risk score.
+ *
+ * Summary AnalyticsCards at the top show aggregate metrics across
+ * all analyzed loans (fetched from docAnalyticsApi.getBankAnalysisSummary).
+ */
+import React, { useState, useEffect, useCallback } from 'react';
+import AnalyticsCard from '../components/smart-docs/AnalyticsCard';
+import BankAnalysisPanel from '../components/smart-docs/BankAnalysisPanel';
+import { getBankSummary, sourceDeposit } from '../services/docBankAnalysisApi';
+import { getBankAnalysisSummary } from '../services/docAnalyticsApi';
+import { toast } from '../utils/toast';
+import './SmartDocsBankAnalysis.css';
+
+function SmartDocsBankAnalysis() {
+  // Aggregate summary cards
+  const [summaryStats, setSummaryStats] = useState(null);
+
+  // Per-loan search
+  const [loanId, setLoanId] = useState('');
+  const [analysis, setAnalysis] = useState(null);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState('');
+
+  // Load aggregate stats on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSummary() {
+      try {
+        const data = await getBankAnalysisSummary(30);
+        if (!cancelled) {
+          setSummaryStats(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          toast.error('Failed to load bank analysis summary');
+        }
+      }
+    }
+
+    loadSummary();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Run analysis for a loan ID
+  const runAnalysis = useCallback(async (id) => {
+    const trimmed = (id || '').trim();
+    if (!trimmed) {
+      toast.warning('Please enter a Loan ID');
+      return;
+    }
+
+    setSearching(true);
+    setSearchError('');
+    setAnalysis(null);
+
+    try {
+      const data = await getBankSummary(trimmed);
+      setAnalysis(data);
+    } catch (err) {
+      const msg = err.message || 'Failed to load bank analysis';
+      setSearchError(msg);
+      toast.error(msg);
+    } finally {
+      setSearching(false);
+    }
+  }, []);
+
+  function handleInputChange(e) {
+    setLoanId(e.target.value);
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Enter') {
+      runAnalysis(loanId);
+    }
+  }
+
+  function handleAnalyzeClick() {
+    runAnalysis(loanId);
+  }
+
+  async function handleSourceDeposit(deposit) {
+    const description = window.prompt(
+      'Enter source description for this deposit:',
+      deposit.description || ''
+    );
+
+    // User cancelled
+    if (description === null) return;
+
+    if (!description.trim()) {
+      toast.warning('Source description cannot be empty');
+      return;
+    }
+
+    try {
+      await sourceDeposit(deposit.id, { description: description.trim() });
+      toast.success('Deposit sourced successfully');
+
+      // Refresh analysis to reflect updated sourcing
+      if (loanId.trim()) {
+        runAnalysis(loanId);
+      }
+    } catch (err) {
+      toast.error(err.message || 'Failed to source deposit');
+    }
+  }
+
+  // Derive card values from summaryStats
+  const s = summaryStats || {};
+  const totalAnalyzed = s.total_analyzed ?? s.total ?? '—';
+  const flagged = s.flagged ?? s.flagged_count ?? '—';
+  const unsourcedDeposits = s.unsourced_deposits ?? s.unsourced ?? '—';
+  const avgRiskScore = s.avg_risk_score != null
+    ? Math.round(s.avg_risk_score)
+    : '—';
+
+  // Risk status for avg score card
+  function riskStatus(score) {
+    if (score === '—') return undefined;
+    if (score >= 70) return 'error';
+    if (score >= 40) return 'warning';
+    return 'success';
+  }
+
+  return (
+    <div className="sd-bank">
+      {/* Page Header */}
+      <div className="sd-bank__header">
+        <h1 className="sd-bank__title">Bank Statement Analysis</h1>
+        <p className="sd-bank__subtitle">
+          Analyze bank statements for large deposits, overdrafts, and undisclosed debts
+        </p>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="sd-bank__summary-grid">
+        <AnalyticsCard
+          title="Total Analyzed"
+          value={totalAnalyzed}
+          subtitle="Loans analyzed (30 days)"
+        />
+        <AnalyticsCard
+          title="Flagged"
+          value={flagged}
+          status={typeof flagged === 'number' && flagged > 0 ? 'warning' : undefined}
+          subtitle="Loans with flags"
+        />
+        <AnalyticsCard
+          title="Unsourced Deposits"
+          value={unsourcedDeposits}
+          status={
+            typeof unsourcedDeposits === 'number' && unsourcedDeposits > 0
+              ? 'error'
+              : undefined
+          }
+          subtitle="Deposits needing documentation"
+        />
+        <AnalyticsCard
+          title="Avg Risk Score"
+          value={avgRiskScore !== '—' ? `${avgRiskScore}` : '—'}
+          status={riskStatus(avgRiskScore)}
+          subtitle="Mean risk across active loans"
+        />
+      </div>
+
+      {/* Loan Search */}
+      <div className="sd-bank__search">
+        <input
+          className="sd-bank__search-input"
+          type="text"
+          value={loanId}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          placeholder="Enter Loan ID"
+          aria-label="Loan ID"
+          disabled={searching}
+        />
+        <button
+          className="sd-bank__search-btn"
+          onClick={handleAnalyzeClick}
+          disabled={searching}
+          type="button"
+        >
+          {searching ? 'Analyzing...' : 'Analyze'}
+        </button>
+      </div>
+
+      {/* Error message */}
+      {searchError && (
+        <div className="sd-bank__error" role="alert">
+          {searchError}
+        </div>
+      )}
+
+      {/* Loading state */}
+      {searching && (
+        <div className="sd-bank__loading">
+          Loading bank analysis...
+        </div>
+      )}
+
+      {/* Analysis Panel */}
+      {!searching && analysis && (
+        <BankAnalysisPanel
+          analysis={analysis}
+          onSourceDeposit={handleSourceDeposit}
+        />
+      )}
+    </div>
+  );
+}
+
+export default SmartDocsBankAnalysis;

--- a/frontend/src/pages/SmartDocsIncome.css
+++ b/frontend/src/pages/SmartDocsIncome.css
@@ -1,0 +1,165 @@
+/* ============================================================
+   SmartDocsIncome — Income Calculation Page
+   ============================================================ */
+
+.sd-income {
+  padding: var(--space-lg);
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+/* ── Page header ── */
+.sd-income__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.sd-income__title {
+  margin: 0 0 var(--space-xs);
+  font-size: var(--font-2xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-text-primary);
+  line-height: var(--line-tight);
+}
+
+.sd-income__subtitle {
+  margin: 0;
+  font-size: var(--font-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--line-normal);
+}
+
+/* ── Summary analytics grid — 4 columns ── */
+.sd-income__summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-md);
+}
+
+/* ── Search bar ── */
+.sd-income__search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.sd-income__loan-input {
+  flex: 1;
+  min-width: 200px;
+  max-width: 360px;
+  padding: 9px 14px;
+  font-size: var(--font-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.sd-income__loan-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(33, 127, 141, 0.12);
+}
+
+.sd-income__loan-input::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+/* Buttons */
+.sd-income__btn {
+  padding: 9px 20px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-sm);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.sd-income__btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+  border: 1px solid var(--color-primary);
+}
+
+.sd-income__btn--primary:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+.sd-income__btn--secondary {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+
+.sd-income__btn--secondary:hover {
+  background: var(--color-bg-hover);
+  border-color: var(--color-text-secondary);
+  color: var(--color-text-primary);
+}
+
+/* ── Loading state ── */
+.sd-income__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  padding: var(--space-xl);
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+.sd-income__spinner {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: sd-income-spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes sd-income-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Responsive ── */
+
+/* 2-column grid at 768px */
+@media (max-width: 768px) {
+  .sd-income {
+    padding: var(--space-md);
+  }
+
+  .sd-income__summary-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* 1-column grid at 480px; search stacks */
+@media (max-width: 480px) {
+  .sd-income__summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sd-income__search {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sd-income__loan-input {
+    max-width: 100%;
+  }
+
+  .sd-income__btn {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/frontend/src/pages/SmartDocsIncome.js
+++ b/frontend/src/pages/SmartDocsIncome.js
@@ -1,0 +1,279 @@
+/**
+ * SmartDocsIncome Page
+ *
+ * Income calculation page with summary analytics cards, loan search,
+ * and a maker-checker approval worksheet.
+ */
+import React, { useState, useEffect, useCallback } from 'react';
+import AnalyticsCard from '../components/smart-docs/AnalyticsCard';
+import IncomeWorksheet from '../components/smart-docs/IncomeWorksheet';
+import {
+  calculateIncome,
+  getIncomeSources,
+  approveIncome,
+  rejectIncome,
+  overrideSource,
+} from '../services/docIncomeApi';
+import { getIncomeSummary } from '../services/docAnalyticsApi';
+import { toast } from '../utils/toast';
+import './SmartDocsIncome.css';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatCurrency(amount) {
+  if (amount == null) return '$0';
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(Number(amount));
+}
+
+function formatPct(value) {
+  if (value == null) return '—';
+  return `${Number(value).toFixed(1)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+function SmartDocsIncome() {
+  const [summary, setSummary] = useState(null);
+  const [summaryLoading, setSummaryLoading] = useState(true);
+
+  const [loanIdInput, setLoanIdInput] = useState('');
+  const [loanId, setLoanId] = useState(null);
+
+  const [income, setIncome] = useState(null);
+  const [worksheetLoading, setWorksheetLoading] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Load summary analytics on mount
+  // ---------------------------------------------------------------------------
+  const loadSummary = useCallback(async () => {
+    setSummaryLoading(true);
+    try {
+      const data = await getIncomeSummary(30);
+      setSummary(data);
+    } catch (err) {
+      toast.error('Failed to load income summary analytics');
+    } finally {
+      setSummaryLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSummary();
+  }, [loadSummary]);
+
+  // ---------------------------------------------------------------------------
+  // Load income sources for a loan
+  // ---------------------------------------------------------------------------
+  const loadIncomeSources = useCallback(async (id) => {
+    setWorksheetLoading(true);
+    setIncome(null);
+    try {
+      const data = await getIncomeSources(id);
+      setIncome(data);
+    } catch (err) {
+      toast.error(`Failed to load income sources: ${err.message}`);
+    } finally {
+      setWorksheetLoading(false);
+    }
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  function handleLoad() {
+    const id = loanIdInput.trim();
+    if (!id) {
+      toast.warning('Please enter a Loan ID');
+      return;
+    }
+    setLoanId(id);
+    loadIncomeSources(id);
+  }
+
+  async function handleCalculate() {
+    const id = loanIdInput.trim();
+    if (!id) {
+      toast.warning('Please enter a Loan ID');
+      return;
+    }
+    setWorksheetLoading(true);
+    setIncome(null);
+    try {
+      const data = await calculateIncome(id);
+      setLoanId(id);
+      setIncome(data);
+      toast.success('Income calculation complete');
+      // Refresh summary after new calculation
+      loadSummary();
+    } catch (err) {
+      toast.error(`Calculation failed: ${err.message}`);
+    } finally {
+      setWorksheetLoading(false);
+    }
+  }
+
+  async function handleApprove() {
+    if (!loanId) return;
+    try {
+      const updated = await approveIncome(loanId, 'Approved via Smart Docs');
+      setIncome((prev) => ({ ...prev, ...updated, status: 'APPROVED' }));
+      toast.success('Income approved');
+      loadSummary();
+    } catch (err) {
+      toast.error(`Approval failed: ${err.message}`);
+    }
+  }
+
+  async function handleReject() {
+    if (!loanId) return;
+    const reason = window.prompt('Enter rejection reason:');
+    if (!reason) return;
+    try {
+      const updated = await rejectIncome(loanId, reason);
+      setIncome((prev) => ({ ...prev, ...updated, status: 'REJECTED' }));
+      toast.success('Income rejected');
+      loadSummary();
+    } catch (err) {
+      toast.error(`Rejection failed: ${err.message}`);
+    }
+  }
+
+  async function handleOverrideSource(sourceId) {
+    const newAmountStr = window.prompt('Enter new monthly amount:');
+    if (newAmountStr == null) return;
+    const newAmount = parseFloat(newAmountStr);
+    if (isNaN(newAmount) || newAmount < 0) {
+      toast.error('Invalid amount entered');
+      return;
+    }
+    try {
+      await overrideSource(sourceId, { monthly_amount: newAmount });
+      // Reload sources after override
+      if (loanId) {
+        await loadIncomeSources(loanId);
+      }
+      toast.success('Income source overridden');
+    } catch (err) {
+      toast.error(`Override failed: ${err.message}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Derived summary card values
+  // ---------------------------------------------------------------------------
+
+  const totalCalculated = summary?.total_calculated ?? summary?.total_amount ?? null;
+  const pendingCount = summary?.pending_approval ?? summary?.pending_count ?? null;
+  const approvedCount = summary?.approved ?? summary?.approved_count ?? null;
+  const avgConfidence = summary?.avg_confidence ?? summary?.average_confidence ?? null;
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="sd-income">
+      {/* Page header */}
+      <div className="sd-income__header">
+        <div>
+          <h1 className="sd-income__title">Income Calculation</h1>
+          <p className="sd-income__subtitle">
+            Calculate, verify, and approve borrower income sources with AI-assisted analysis.
+          </p>
+        </div>
+      </div>
+
+      {/* Summary analytics cards */}
+      <div className="sd-income__summary-grid">
+        <AnalyticsCard
+          title="Total Calculated"
+          value={summaryLoading ? '—' : formatCurrency(totalCalculated)}
+          subtitle="Across all active loans"
+          status="success"
+        />
+        <AnalyticsCard
+          title="Pending Approval"
+          value={summaryLoading ? '—' : (pendingCount ?? '—')}
+          subtitle="Awaiting maker-checker review"
+          status="warning"
+        />
+        <AnalyticsCard
+          title="Approved"
+          value={summaryLoading ? '—' : (approvedCount ?? '—')}
+          subtitle="Last 30 days"
+          status="success"
+        />
+        <AnalyticsCard
+          title="Avg Confidence"
+          value={summaryLoading ? '—' : formatPct(avgConfidence)}
+          subtitle="AI extraction confidence"
+          status={
+            avgConfidence == null
+              ? undefined
+              : avgConfidence >= 90
+              ? 'success'
+              : avgConfidence >= 70
+              ? 'warning'
+              : 'error'
+          }
+        />
+      </div>
+
+      {/* Search / load section */}
+      <div className="sd-income__search">
+        <input
+          className="sd-income__loan-input"
+          type="text"
+          placeholder="Enter Loan ID"
+          value={loanIdInput}
+          onChange={(e) => setLoanIdInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleLoad();
+          }}
+          aria-label="Loan ID"
+        />
+        <button
+          className="sd-income__btn sd-income__btn--secondary"
+          onClick={handleLoad}
+          type="button"
+        >
+          Load
+        </button>
+        <button
+          className="sd-income__btn sd-income__btn--primary"
+          onClick={handleCalculate}
+          type="button"
+        >
+          Calculate Income
+        </button>
+      </div>
+
+      {/* Worksheet */}
+      {worksheetLoading ? (
+        <div className="sd-income__loading">
+          <div className="sd-income__spinner" />
+          <span>Loading income data...</span>
+        </div>
+      ) : income ? (
+        <IncomeWorksheet
+          income={income}
+          onApprove={handleApprove}
+          onReject={handleReject}
+          onOverrideSource={handleOverrideSource}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export default SmartDocsIncome;

--- a/frontend/src/pages/SmartDocsReviewQueue.css
+++ b/frontend/src/pages/SmartDocsReviewQueue.css
@@ -1,0 +1,296 @@
+/* ============================================================
+   SmartDocsReviewQueue Page
+   ============================================================ */
+
+/* ── Page container ── */
+.sd-review-queue {
+  padding: var(--space-lg, 24px);
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg, 24px);
+}
+
+/* ============================================================
+   Header
+   ============================================================ */
+
+.sd-review-queue__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md, 16px);
+  flex-wrap: wrap;
+}
+
+.sd-review-queue__header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sd-review-queue__title {
+  margin: 0;
+  font-size: var(--font-2xl, 1.5rem);
+  font-weight: var(--weight-bold, 700);
+  color: var(--color-text-primary, #111827);
+  line-height: var(--line-tight, 1.25);
+}
+
+.sd-review-queue__subtitle {
+  margin: 0;
+  font-size: var(--font-sm, 0.875rem);
+  color: var(--color-text-tertiary, #6b7280);
+}
+
+.sd-review-queue__header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 12px);
+  flex-shrink: 0;
+}
+
+/* ============================================================
+   Stat Cards — 4-column grid
+   ============================================================ */
+
+.sd-review-queue__stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-md, 16px);
+}
+
+/* ============================================================
+   Priority filter pills
+   ============================================================ */
+
+.sd-review-queue__filters {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs, 8px);
+  flex-wrap: wrap;
+}
+
+.sd-review-queue__filter-pill {
+  font-size: var(--font-sm, 0.875rem);
+  font-weight: var(--weight-medium, 500);
+  padding: 6px 16px;
+  border-radius: var(--radius-full, 9999px);
+  border: 1px solid var(--color-border-light, #e5e7eb);
+  background: var(--color-bg-surface, #fff);
+  color: var(--color-text-secondary, #374151);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  white-space: nowrap;
+}
+
+.sd-review-queue__filter-pill:hover {
+  background: var(--color-bg-secondary, #f9fafb);
+}
+
+.sd-review-queue__filter-pill--active {
+  background: var(--color-primary, #2563eb);
+  color: #fff;
+  border-color: var(--color-primary, #2563eb);
+}
+
+.sd-review-queue__filter-pill--active:hover {
+  background: var(--color-primary-dark, #1d4ed8);
+  border-color: var(--color-primary-dark, #1d4ed8);
+}
+
+/* ============================================================
+   Queue list
+   ============================================================ */
+
+.sd-review-queue__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 12px);
+}
+
+/* ============================================================
+   Pagination
+   ============================================================ */
+
+.sd-review-queue__pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md, 16px);
+  padding: var(--space-md, 16px) 0;
+}
+
+.sd-review-queue__page-info {
+  font-size: var(--font-sm, 0.875rem);
+  color: var(--color-text-secondary, #374151);
+  white-space: nowrap;
+}
+
+/* ============================================================
+   Shared button styles
+   ============================================================ */
+
+.sd-review-queue__btn {
+  font-size: var(--font-sm, 0.875rem);
+  font-weight: var(--weight-medium, 500);
+  padding: 8px 18px;
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, opacity 0.15s ease;
+  line-height: 1.4;
+}
+
+.sd-review-queue__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sd-review-queue__btn--primary {
+  background: var(--color-primary, #2563eb);
+  color: #fff;
+  border-color: var(--color-primary, #2563eb);
+}
+
+.sd-review-queue__btn--primary:hover:not(:disabled) {
+  background: var(--color-primary-dark, #1d4ed8);
+  border-color: var(--color-primary-dark, #1d4ed8);
+}
+
+.sd-review-queue__btn--secondary {
+  background: var(--color-bg-surface, #fff);
+  color: var(--color-text-secondary, #374151);
+  border-color: var(--color-border-light, #e5e7eb);
+}
+
+.sd-review-queue__btn--secondary:hover:not(:disabled) {
+  background: var(--color-bg-secondary, #f9fafb);
+}
+
+.sd-review-queue__btn--ghost {
+  background: transparent;
+  color: var(--color-text-tertiary, #6b7280);
+  border-color: transparent;
+}
+
+.sd-review-queue__btn--ghost:hover:not(:disabled) {
+  color: var(--color-text-primary, #111827);
+  background: var(--color-bg-secondary, #f9fafb);
+}
+
+/* ============================================================
+   States: loading, empty, error
+   ============================================================ */
+
+.sd-review-queue__loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md, 16px);
+  padding: var(--space-xl, 48px) 0;
+  color: var(--color-text-tertiary, #6b7280);
+  font-size: var(--font-sm, 0.875rem);
+}
+
+.sd-review-queue__spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--color-border-light, #e5e7eb);
+  border-top-color: var(--color-primary, #2563eb);
+  border-radius: 50%;
+  animation: sd-spin 0.75s linear infinite;
+}
+
+@keyframes sd-spin {
+  to { transform: rotate(360deg); }
+}
+
+.sd-review-queue__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md, 16px);
+  padding: var(--space-xl, 48px) 0;
+  color: var(--color-text-tertiary, #6b7280);
+  text-align: center;
+}
+
+.sd-review-queue__empty-icon {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.sd-review-queue__empty p {
+  margin: 0;
+  font-size: var(--font-sm, 0.875rem);
+}
+
+.sd-review-queue__error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md, 16px);
+  padding: var(--space-md, 16px);
+  background: rgba(192, 21, 47, 0.06);
+  border: 1px solid rgba(192, 21, 47, 0.2);
+  border-radius: var(--radius-md, 8px);
+  font-size: var(--font-sm, 0.875rem);
+  color: var(--color-error, #c0152f);
+}
+
+.sd-review-queue__error button {
+  font-size: var(--font-sm, 0.875rem);
+  font-weight: var(--weight-medium, 500);
+  padding: 4px 12px;
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid rgba(192, 21, 47, 0.3);
+  background: transparent;
+  color: var(--color-error, #c0152f);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.sd-review-queue__error button:hover {
+  background: rgba(192, 21, 47, 0.1);
+}
+
+/* ============================================================
+   Responsive — 768px: 2-col stats, stacked header
+   ============================================================ */
+
+@media (max-width: 768px) {
+  .sd-review-queue__stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .sd-review-queue__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .sd-review-queue__header-actions {
+    width: 100%;
+  }
+
+  .sd-review-queue__header-actions .sd-review-queue__btn {
+    flex: 1;
+    text-align: center;
+  }
+}
+
+/* ============================================================
+   Responsive — 480px: 1-col stats
+   ============================================================ */
+
+@media (max-width: 480px) {
+  .sd-review-queue__stats {
+    grid-template-columns: 1fr;
+  }
+
+  .sd-review-queue__pagination {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/pages/SmartDocsReviewQueue.js
+++ b/frontend/src/pages/SmartDocsReviewQueue.js
@@ -9,7 +9,7 @@
  * - Batch AI Review for all unclaimed items grouped by loan
  */
 import React, { useState, useCallback } from 'react';
-import toast from 'react-hot-toast';
+import toast from '../utils/toast';
 
 import useReviewQueue from '../hooks/useReviewQueue';
 import ReviewQueueItem from '../components/smart-docs/ReviewQueueItem';

--- a/frontend/src/pages/SmartDocsReviewQueue.js
+++ b/frontend/src/pages/SmartDocsReviewQueue.js
@@ -1,0 +1,331 @@
+/**
+ * SmartDocsReviewQueue Page
+ *
+ * Displays the document review queue with:
+ * - Summary stat cards (In Queue, High Priority, Claimed, Avg Wait)
+ * - Priority filter tabs
+ * - Paginated list of ReviewQueueItem rows
+ * - Claim / release / AI review actions with toast feedback
+ * - Batch AI Review for all unclaimed items grouped by loan
+ */
+import React, { useState, useCallback } from 'react';
+import toast from 'react-hot-toast';
+
+import useReviewQueue from '../hooks/useReviewQueue';
+import ReviewQueueItem from '../components/smart-docs/ReviewQueueItem';
+import AnalyticsCard from '../components/smart-docs/AnalyticsCard';
+import docReviewApi from '../services/docReviewApi';
+
+import './SmartDocsReviewQueue.css';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PRIORITY_FILTERS = ['ALL', 'CRITICAL', 'HIGH', 'NORMAL', 'LOW'];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatAvgWait(minutes) {
+  if (minutes == null) return '—';
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  return `${(minutes / 60).toFixed(1)}h`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function SmartDocsReviewQueue() {
+  const currentUserId = localStorage.getItem('userId') || localStorage.getItem('user_id') || null;
+
+  const {
+    items,
+    stats,
+    total,
+    loading,
+    error,
+    filters,
+    setFilters,
+    nextPage,
+    prevPage,
+    claim,
+    release,
+    refresh,
+  } = useReviewQueue();
+
+  const [activePriority, setActivePriority] = useState('ALL');
+  const [batchLoading, setBatchLoading] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Priority filter
+  // ---------------------------------------------------------------------------
+
+  const handlePriorityFilter = useCallback((priority) => {
+    setActivePriority(priority);
+    if (priority === 'ALL') {
+      setFilters({ priority: undefined });
+    } else {
+      setFilters({ priority });
+    }
+  }, [setFilters]);
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
+
+  const handleClaim = useCallback(async (documentId) => {
+    try {
+      await claim(documentId, currentUserId);
+      toast.success('Document claimed for review');
+    } catch (err) {
+      toast.error(err.message || 'Failed to claim document');
+    }
+  }, [claim, currentUserId]);
+
+  const handleRelease = useCallback(async (documentId) => {
+    try {
+      await release(documentId);
+      toast.success('Document released back to queue');
+    } catch (err) {
+      toast.error(err.message || 'Failed to release document');
+    }
+  }, [release]);
+
+  const handleAiReview = useCallback(async (documentId) => {
+    try {
+      await docReviewApi.aiReview(documentId);
+      toast.success('AI review started');
+      await refresh();
+    } catch (err) {
+      toast.error(err.message || 'AI review failed');
+    }
+  }, [refresh]);
+
+  const handleViewDetail = useCallback((documentId) => {
+    // Navigate using window.location to keep this page self-contained
+    window.location.href = `/smart-docs/document/${documentId}`;
+  }, []);
+
+  const handleBatchAiReview = useCallback(async () => {
+    const unclaimed = items.filter((item) => !item.claimed_by_id);
+    if (!unclaimed.length) {
+      toast('No unclaimed documents to review', { icon: 'ℹ️' });
+      return;
+    }
+
+    // Group by loan_id
+    const byLoan = unclaimed.reduce((acc, item) => {
+      const key = item.loan_id || 'unknown';
+      if (!acc[key]) acc[key] = [];
+      acc[key].push(item);
+      return acc;
+    }, {});
+
+    const loanIds = Object.keys(byLoan).filter((k) => k !== 'unknown');
+    if (!loanIds.length) {
+      toast.error('Could not determine loan IDs for batch review');
+      return;
+    }
+
+    setBatchLoading(true);
+    let successCount = 0;
+    let errorCount = 0;
+
+    await Promise.all(
+      loanIds.map(async (loanId) => {
+        try {
+          await docReviewApi.batchAiReview(loanId);
+          successCount += byLoan[loanId].length;
+        } catch {
+          errorCount += byLoan[loanId].length;
+        }
+      })
+    );
+
+    setBatchLoading(false);
+    await refresh();
+
+    if (errorCount === 0) {
+      toast.success(`Batch AI review started for ${successCount} document${successCount !== 1 ? 's' : ''}`);
+    } else if (successCount === 0) {
+      toast.error('Batch AI review failed');
+    } else {
+      toast.success(`Batch AI review: ${successCount} started, ${errorCount} failed`);
+    }
+  }, [items, refresh]);
+
+  // ---------------------------------------------------------------------------
+  // Stat card values
+  // ---------------------------------------------------------------------------
+
+  const inQueue       = stats?.in_queue       ?? total ?? 0;
+  const highPriority  = stats?.high_priority  ?? 0;
+  const claimed       = stats?.claimed        ?? 0;
+  const avgWaitMins   = stats?.avg_wait_minutes ?? null;
+
+  // ---------------------------------------------------------------------------
+  // Pagination display
+  // ---------------------------------------------------------------------------
+
+  const limit   = filters.limit  ?? 50;
+  const offset  = filters.offset ?? 0;
+  const from    = total === 0 ? 0 : offset + 1;
+  const to      = Math.min(offset + limit, total);
+  const hasPrev = offset > 0;
+  const hasNext = to < total;
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="sd-review-queue">
+
+      {/* ── Header ── */}
+      <div className="sd-review-queue__header">
+        <div className="sd-review-queue__header-text">
+          <h1 className="sd-review-queue__title">Document Review Queue</h1>
+          <p className="sd-review-queue__subtitle">
+            Claim, review, and AI-analyze uploaded borrower documents.
+          </p>
+        </div>
+        <div className="sd-review-queue__header-actions">
+          <button
+            className="sd-review-queue__btn sd-review-queue__btn--secondary"
+            onClick={refresh}
+            disabled={loading}
+          >
+            {loading ? 'Loading…' : 'Refresh'}
+          </button>
+          <button
+            className="sd-review-queue__btn sd-review-queue__btn--primary"
+            onClick={handleBatchAiReview}
+            disabled={batchLoading || loading}
+          >
+            {batchLoading ? 'Running…' : 'Batch AI Review'}
+          </button>
+        </div>
+      </div>
+
+      {/* ── Stat cards ── */}
+      <div className="sd-review-queue__stats">
+        <AnalyticsCard
+          title="In Queue"
+          value={inQueue}
+          subtitle="documents awaiting review"
+        />
+        <AnalyticsCard
+          title="High Priority"
+          value={highPriority}
+          subtitle="CRITICAL + HIGH items"
+          status={highPriority > 0 ? 'error' : undefined}
+        />
+        <AnalyticsCard
+          title="Claimed"
+          value={claimed}
+          subtitle="currently being reviewed"
+          status="warning"
+        />
+        <AnalyticsCard
+          title="Avg Wait"
+          value={formatAvgWait(avgWaitMins)}
+          subtitle="time in queue"
+        />
+      </div>
+
+      {/* ── Priority filter tabs ── */}
+      <div className="sd-review-queue__filters" role="group" aria-label="Filter by priority">
+        {PRIORITY_FILTERS.map((p) => (
+          <button
+            key={p}
+            className={[
+              'sd-review-queue__filter-pill',
+              activePriority === p ? 'sd-review-queue__filter-pill--active' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            onClick={() => handlePriorityFilter(p)}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Error state ── */}
+      {error && (
+        <div className="sd-review-queue__error">
+          <span>Could not load queue: {error}</span>
+          <button onClick={refresh}>Retry</button>
+        </div>
+      )}
+
+      {/* ── Loading skeleton ── */}
+      {loading && !error && items.length === 0 && (
+        <div className="sd-review-queue__loading">
+          <div className="sd-review-queue__spinner" />
+          <p>Loading review queue…</p>
+        </div>
+      )}
+
+      {/* ── Empty state ── */}
+      {!loading && !error && items.length === 0 && (
+        <div className="sd-review-queue__empty">
+          <span className="sd-review-queue__empty-icon">📋</span>
+          <p>No documents in the review queue.</p>
+          {activePriority !== 'ALL' && (
+            <button
+              className="sd-review-queue__btn sd-review-queue__btn--ghost"
+              onClick={() => handlePriorityFilter('ALL')}
+            >
+              Clear filter
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* ── Queue list ── */}
+      {items.length > 0 && (
+        <div className="sd-review-queue__list">
+          {items.map((doc) => (
+            <ReviewQueueItem
+              key={doc.id}
+              document={doc}
+              onClaim={handleClaim}
+              onRelease={handleRelease}
+              onAiReview={handleAiReview}
+              onViewDetail={handleViewDetail}
+              currentUserId={currentUserId}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* ── Pagination ── */}
+      {total > limit && (
+        <div className="sd-review-queue__pagination">
+          <button
+            className="sd-review-queue__btn sd-review-queue__btn--secondary"
+            onClick={prevPage}
+            disabled={!hasPrev || loading}
+          >
+            Previous
+          </button>
+          <span className="sd-review-queue__page-info">
+            Showing {from}–{to} of {total}
+          </span>
+          <button
+            className="sd-review-queue__btn sd-review-queue__btn--secondary"
+            onClick={nextPage}
+            disabled={!hasNext || loading}
+          >
+            Next
+          </button>
+        </div>
+      )}
+
+    </div>
+  );
+}

--- a/frontend/src/pages/SmartDocsReviewQueue.js
+++ b/frontend/src/pages/SmartDocsReviewQueue.js
@@ -9,7 +9,7 @@
  * - Batch AI Review for all unclaimed items grouped by loan
  */
 import React, { useState, useCallback } from 'react';
-import toast from '../utils/toast';
+import { toast } from '../utils/toast';
 
 import useReviewQueue from '../hooks/useReviewQueue';
 import ReviewQueueItem from '../components/smart-docs/ReviewQueueItem';
@@ -112,7 +112,7 @@ export default function SmartDocsReviewQueue() {
   const handleBatchAiReview = useCallback(async () => {
     const unclaimed = items.filter((item) => !item.claimed_by_id);
     if (!unclaimed.length) {
-      toast('No unclaimed documents to review', { icon: 'ℹ️' });
+      toast.info('No unclaimed documents to review');
       return;
     }
 
@@ -139,7 +139,8 @@ export default function SmartDocsReviewQueue() {
         try {
           await docReviewApi.batchAiReview(loanId);
           successCount += byLoan[loanId].length;
-        } catch {
+        } catch (err) {
+          console.error(`Batch AI review failed for loan ${loanId}:`, err);
           errorCount += byLoan[loanId].length;
         }
       })

--- a/frontend/src/pages/SmartDocsSecurity.css
+++ b/frontend/src/pages/SmartDocsSecurity.css
@@ -1,0 +1,353 @@
+/* Smart Docs Security & Compliance Page */
+
+.sd-security {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+/* Header */
+.sd-security__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 24px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.sd-security__title {
+  font-size: 1.6em;
+  font-weight: 700;
+  color: #1e293b;
+  margin: 0;
+}
+
+.sd-security__subtitle {
+  color: #64748b;
+  font-size: 0.9em;
+  margin: 4px 0 0;
+}
+
+/* Period Selector */
+.sd-security__period-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.sd-security__period-label {
+  font-size: 0.85em;
+  font-weight: 500;
+  color: #475569;
+}
+
+.sd-security__period-select {
+  padding: 8px 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.88em;
+  color: #334155;
+  background: #fff;
+  cursor: pointer;
+}
+
+.sd-security__period-select:focus {
+  outline: none;
+  border-color: #93c5fd;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
+}
+
+/* Tabs */
+.sd-security__tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 2px solid #e2e8f0;
+  margin-bottom: 20px;
+}
+
+.sd-security__tab {
+  padding: 10px 20px;
+  border: none;
+  background: none;
+  font-size: 0.92em;
+  font-weight: 500;
+  color: #64748b;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.sd-security__tab:hover {
+  color: #1e293b;
+}
+
+.sd-security__tab.active {
+  color: #2563eb;
+  border-bottom-color: #2563eb;
+  font-weight: 600;
+}
+
+/* Content area */
+.sd-security__content {
+  min-height: 200px;
+}
+
+/* Loading / Empty */
+.sd-security__loading {
+  text-align: center;
+  padding: 48px 24px;
+  color: #94a3b8;
+  font-size: 0.95em;
+}
+
+.sd-security__empty {
+  text-align: center;
+  padding: 48px 24px;
+  color: #94a3b8;
+  font-size: 0.95em;
+  background: #f8fafc;
+  border: 1px dashed #e2e8f0;
+  border-radius: 10px;
+}
+
+.sd-security__empty--success {
+  color: #15803d;
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
+/* ============================================================
+   Compliance Grid (4-column)
+   ============================================================ */
+.sd-security__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+/* Open Issues */
+.sd-security__issues {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 20px;
+}
+
+.sd-security__issues-title {
+  font-size: 0.95em;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0 0 14px;
+}
+
+.sd-security__issues-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sd-security__issue-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-left: 4px solid #e2e8f0;
+  background: #f8fafc;
+  border-radius: 0 6px 6px 0;
+}
+
+.sd-security__issue-text {
+  font-size: 0.88em;
+  color: #334155;
+  flex: 1;
+}
+
+/* ============================================================
+   Table
+   ============================================================ */
+.sd-security__table-container {
+  overflow-x: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.sd-security__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.sd-security__table th {
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 0.78em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #94a3b8;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  white-space: nowrap;
+}
+
+.sd-security__table td {
+  padding: 11px 16px;
+  font-size: 0.88em;
+  color: #334155;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: middle;
+}
+
+.sd-security__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.sd-security__table tbody tr:hover td {
+  background: #f8fafc;
+}
+
+/* Timestamp cell: monospace for readability */
+.sd-security__ts-cell {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 0.82em !important;
+  white-space: nowrap;
+  color: #64748b !important;
+}
+
+/* Details cell: truncate at 300px */
+.sd-security__details-cell {
+  max-width: 300px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ============================================================
+   Badge
+   ============================================================ */
+.sd-security__badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.72em;
+  font-weight: 600;
+  padding: 3px 9px;
+  border-radius: 12px;
+  text-transform: capitalize;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+
+/* ============================================================
+   Suspicious Activity Alerts
+   ============================================================ */
+.sd-security__alerts {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sd-security__alert {
+  border-left: 4px solid #e2e8f0;
+  border-radius: 0 10px 10px 0;
+  padding: 14px 18px;
+  transition: box-shadow 0.15s;
+}
+
+.sd-security__alert:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.sd-security__alert-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.sd-security__alert-type {
+  font-size: 0.9em;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.sd-security__alert-desc {
+  font-size: 0.88em;
+  color: #475569;
+  margin: 0 0 8px;
+  line-height: 1.5;
+}
+
+.sd-security__alert-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 0.78em;
+  color: #94a3b8;
+  flex-wrap: wrap;
+}
+
+/* ============================================================
+   Responsive: 768px → 2-column grid
+   ============================================================ */
+@media (max-width: 768px) {
+  .sd-security {
+    padding: 16px;
+  }
+
+  .sd-security__header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .sd-security__period-selector {
+    justify-content: flex-end;
+  }
+
+  .sd-security__tabs {
+    overflow-x: auto;
+  }
+
+  .sd-security__tab {
+    padding: 10px 14px;
+    font-size: 0.88em;
+  }
+
+  .sd-security__grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+
+  .sd-security__details-cell {
+    max-width: 160px;
+  }
+}
+
+/* ============================================================
+   Responsive: 480px → 1-column grid
+   ============================================================ */
+@media (max-width: 480px) {
+  .sd-security__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sd-security__table th,
+  .sd-security__table td {
+    padding: 10px 12px;
+  }
+
+  .sd-security__alert-header {
+    flex-wrap: wrap;
+  }
+
+  .sd-security__details-cell {
+    max-width: 120px;
+  }
+}

--- a/frontend/src/pages/SmartDocsSecurity.js
+++ b/frontend/src/pages/SmartDocsSecurity.js
@@ -1,0 +1,406 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  getAuditLog,
+  getComplianceReport,
+  getSuspiciousActivity,
+  getRetentionPolicies,
+} from '../services/docSecurityApi';
+import AnalyticsCard from '../components/smart-docs/AnalyticsCard';
+import { toast } from '../utils/toast';
+import './SmartDocsSecurity.css';
+
+const TABS = [
+  { key: 'audit', label: 'Audit Log' },
+  { key: 'compliance', label: 'Compliance Report' },
+  { key: 'suspicious', label: 'Suspicious Activity' },
+  { key: 'retention', label: 'Retention Policies' },
+];
+
+const PERIOD_OPTIONS = [
+  { value: 7, label: 'Last 7 days' },
+  { value: 30, label: 'Last 30 days' },
+  { value: 90, label: 'Last 90 days' },
+  { value: 365, label: 'Last 365 days' },
+];
+
+const ACTION_COLORS = {
+  view: { bg: '#dbeafe', color: '#1d4ed8' },
+  download: { bg: '#dcfce7', color: '#15803d' },
+  upload: { bg: '#ede9fe', color: '#6d28d9' },
+  delete: { bg: '#fee2e2', color: '#dc2626' },
+  share: { bg: '#fef3c7', color: '#92400e' },
+  edit: { bg: '#ffedd5', color: '#c2410c' },
+  encrypt: { bg: '#e0f2fe', color: '#0369a1' },
+  watermark: { bg: '#fce7f3', color: '#9d174d' },
+};
+
+const SEVERITY_STYLES = {
+  critical: { bg: '#fee2e2', border: '#dc2626', color: '#991b1b', label: 'Critical' },
+  high: { bg: '#ffedd5', border: '#f97316', color: '#c2410c', label: 'High' },
+  medium: { bg: '#fef3c7', border: '#f59e0b', color: '#92400e', label: 'Medium' },
+  low: { bg: '#f0fdf4', border: '#22c55e', color: '#15803d', label: 'Low' },
+};
+
+function getActionStyle(action) {
+  if (!action) return { bg: '#f1f5f9', color: '#475569' };
+  const key = action.toLowerCase();
+  return ACTION_COLORS[key] || { bg: '#f1f5f9', color: '#475569' };
+}
+
+function getSeverityStyle(severity) {
+  const key = (severity || '').toLowerCase();
+  return SEVERITY_STYLES[key] || SEVERITY_STYLES.low;
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return '—';
+  try {
+    return new Date(ts).toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return ts;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Audit Log Tab
+// ---------------------------------------------------------------------------
+function AuditLogTab({ entries }) {
+  if (!entries || entries.length === 0) {
+    return (
+      <div className="sd-security__empty">
+        No audit log entries found for this period.
+      </div>
+    );
+  }
+
+  return (
+    <div className="sd-security__table-container">
+      <table className="sd-security__table">
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>User</th>
+            <th>Action</th>
+            <th>Document</th>
+            <th>Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry, idx) => {
+            const actionStyle = getActionStyle(entry.action);
+            return (
+              <tr key={entry.id || idx}>
+                <td className="sd-security__ts-cell">
+                  {formatTimestamp(entry.timestamp || entry.created_at)}
+                </td>
+                <td>{entry.user_name || entry.user_email || entry.user_id || '—'}</td>
+                <td>
+                  <span
+                    className="sd-security__badge"
+                    style={{ background: actionStyle.bg, color: actionStyle.color }}
+                  >
+                    {entry.action || '—'}
+                  </span>
+                </td>
+                <td>{entry.document_name || entry.document_id || '—'}</td>
+                <td className="sd-security__details-cell">
+                  {entry.details || '—'}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compliance Report Tab
+// ---------------------------------------------------------------------------
+function ComplianceReportTab({ report }) {
+  if (!report) {
+    return <div className="sd-security__empty">No compliance data available.</div>;
+  }
+
+  const score = report.compliance_score ?? report.score ?? 0;
+  const encrypted = report.encrypted_documents ?? report.encrypted ?? 0;
+  const integrity = report.integrity_verified ?? report.verified ?? 0;
+  const retention = report.retention_compliant ?? report.compliant ?? 0;
+  const issues = report.open_issues || report.issues || [];
+
+  return (
+    <div>
+      <div className="sd-security__grid">
+        <AnalyticsCard
+          title="Compliance Score"
+          value={`${Math.round(score)}%`}
+          status={score >= 90 ? 'success' : score >= 70 ? 'warning' : 'error'}
+          subtitle="Overall document compliance"
+        />
+        <AnalyticsCard
+          title="Encrypted Documents"
+          value={encrypted}
+          subtitle="Documents with encryption enabled"
+        />
+        <AnalyticsCard
+          title="Integrity Verified"
+          value={integrity}
+          subtitle="Hash-verified documents"
+        />
+        <AnalyticsCard
+          title="Retention Compliant"
+          value={retention}
+          subtitle="Documents meeting retention policy"
+        />
+      </div>
+
+      {issues.length > 0 && (
+        <div className="sd-security__issues">
+          <h3 className="sd-security__issues-title">Open Issues</h3>
+          <ul className="sd-security__issues-list">
+            {issues.map((issue, idx) => {
+              const sev = getSeverityStyle(issue.severity);
+              return (
+                <li
+                  key={issue.id || idx}
+                  className="sd-security__issue-item"
+                  style={{ borderLeftColor: sev.border }}
+                >
+                  <span
+                    className="sd-security__badge"
+                    style={{ background: sev.bg, color: sev.color }}
+                  >
+                    {sev.label}
+                  </span>
+                  <span className="sd-security__issue-text">
+                    {issue.message || issue.description || issue.title || String(issue)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Suspicious Activity Tab
+// ---------------------------------------------------------------------------
+function SuspiciousActivityTab({ items }) {
+  if (!items || items.length === 0) {
+    return (
+      <div className="sd-security__empty sd-security__empty--success">
+        No suspicious activity detected.
+      </div>
+    );
+  }
+
+  return (
+    <div className="sd-security__alerts">
+      {items.map((item, idx) => {
+        const sev = getSeverityStyle(item.severity);
+        return (
+          <div
+            key={item.id || idx}
+            className="sd-security__alert"
+            style={{ borderLeftColor: sev.border, background: sev.bg }}
+          >
+            <div className="sd-security__alert-header">
+              <span className="sd-security__alert-type">{item.type || item.alert_type || 'Alert'}</span>
+              <span
+                className="sd-security__badge"
+                style={{ background: sev.border + '20', color: sev.color }}
+              >
+                {sev.label}
+              </span>
+            </div>
+            <p className="sd-security__alert-desc">
+              {item.description || item.message || '—'}
+            </p>
+            <div className="sd-security__alert-meta">
+              {item.user_name || item.user_email ? (
+                <span>User: {item.user_name || item.user_email}</span>
+              ) : null}
+              <span>{formatTimestamp(item.timestamp || item.created_at)}</span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Retention Policies Tab
+// ---------------------------------------------------------------------------
+function RetentionPoliciesTab({ policies }) {
+  if (!policies || policies.length === 0) {
+    return (
+      <div className="sd-security__empty">No retention policies configured.</div>
+    );
+  }
+
+  return (
+    <div className="sd-security__table-container">
+      <table className="sd-security__table">
+        <thead>
+          <tr>
+            <th>Policy Name</th>
+            <th>Document Type</th>
+            <th>Retention Days</th>
+            <th>Action</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {policies.map((policy, idx) => {
+            const isActive = policy.is_active !== false && policy.status !== 'inactive';
+            return (
+              <tr key={policy.id || idx}>
+                <td>{policy.policy_name || policy.name || '—'}</td>
+                <td>{policy.doc_type || policy.document_type || '—'}</td>
+                <td>{policy.retention_days != null ? policy.retention_days : '—'}</td>
+                <td>{policy.action || policy.retention_action || '—'}</td>
+                <td>
+                  <span
+                    className="sd-security__badge"
+                    style={
+                      isActive
+                        ? { background: '#dcfce7', color: '#15803d' }
+                        : { background: '#f1f5f9', color: '#64748b' }
+                    }
+                  >
+                    {isActive ? 'Active' : 'Inactive'}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Page Component
+// ---------------------------------------------------------------------------
+export default function SmartDocsSecurity() {
+  const [activeTab, setActiveTab] = useState('audit');
+  const [days, setDays] = useState(30);
+  const [loading, setLoading] = useState(false);
+
+  const [auditLog, setAuditLog] = useState([]);
+  const [compliance, setCompliance] = useState(null);
+  const [suspicious, setSuspicious] = useState([]);
+  const [retentionPolicies, setRetentionPolicies] = useState([]);
+
+  const loadData = useCallback(async (selectedDays) => {
+    setLoading(true);
+    try {
+      const [auditRes, complianceRes, suspiciousRes, retentionRes] = await Promise.allSettled([
+        getAuditLog({ days: selectedDays }),
+        getComplianceReport(selectedDays),
+        getSuspiciousActivity(selectedDays),
+        getRetentionPolicies(),
+      ]);
+
+      if (auditRes.status === 'fulfilled') {
+        const data = auditRes.value;
+        setAuditLog(Array.isArray(data) ? data : data.entries || data.logs || data.audit_log || []);
+      } else {
+        toast.error('Failed to load audit log');
+      }
+
+      if (complianceRes.status === 'fulfilled') {
+        setCompliance(complianceRes.value);
+      } else {
+        toast.error('Failed to load compliance report');
+      }
+
+      if (suspiciousRes.status === 'fulfilled') {
+        const data = suspiciousRes.value;
+        setSuspicious(Array.isArray(data) ? data : data.items || data.alerts || data.activity || []);
+      } else {
+        toast.error('Failed to load suspicious activity');
+      }
+
+      if (retentionRes.status === 'fulfilled') {
+        const data = retentionRes.value;
+        setRetentionPolicies(Array.isArray(data) ? data : data.policies || []);
+      } else {
+        toast.error('Failed to load retention policies');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData(days);
+  }, [days, loadData]);
+
+  function handlePeriodChange(e) {
+    setDays(Number(e.target.value));
+  }
+
+  return (
+    <div className="sd-security">
+      <div className="sd-security__header">
+        <div>
+          <h1 className="sd-security__title">Security &amp; Compliance</h1>
+          <p className="sd-security__subtitle">
+            Audit trails, compliance monitoring, suspicious activity, and retention policies
+          </p>
+        </div>
+        <div className="sd-security__period-selector">
+          <label htmlFor="sd-period" className="sd-security__period-label">Period</label>
+          <select
+            id="sd-period"
+            className="sd-security__period-select"
+            value={days}
+            onChange={handlePeriodChange}
+          >
+            {PERIOD_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="sd-security__tabs">
+        {TABS.map(tab => (
+          <button
+            key={tab.key}
+            className={`sd-security__tab${activeTab === tab.key ? ' active' : ''}`}
+            onClick={() => setActiveTab(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="sd-security__content">
+        {loading ? (
+          <div className="sd-security__loading">Loading security data...</div>
+        ) : (
+          <>
+            {activeTab === 'audit' && <AuditLogTab entries={auditLog} />}
+            {activeTab === 'compliance' && <ComplianceReportTab report={compliance} />}
+            {activeTab === 'suspicious' && <SuspiciousActivityTab items={suspicious} />}
+            {activeTab === 'retention' && <RetentionPoliciesTab policies={retentionPolicies} />}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/aria/AriaCalendarPage.css
+++ b/frontend/src/pages/aria/AriaCalendarPage.css
@@ -3,9 +3,9 @@
 .aria-calendar-page {
   min-height: 100vh;
   min-height: -webkit-fill-available;
-  background: #fff;
+  background: var(--aria-color-bg, #fff);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  color: #1f2937;
+  color: var(--aria-color-text-primary, #1f2937);
   padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
 }
 
@@ -14,9 +14,9 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  background: #fff;
+  background: var(--aria-color-bg, #fff);
   padding: env(safe-area-inset-top, 12px) 16px 12px;
-  border-bottom: 1px solid #f3f4f6;
+  border-bottom: 1px solid var(--aria-color-bg-tertiary, #f3f4f6);
 }
 
 .aria-cal-header__title-row {
@@ -39,37 +39,38 @@
 .aria-cal-header__month {
   font-size: 24px;
   font-weight: 700;
-  color: #111827;
+  color: var(--aria-color-text-primary, #111827);
 }
 
 .aria-cal-header__chevron {
   font-size: 12px;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary, #6b7280);
 }
 
+/* WCAG touch target fix: 44px minimum (was 40×40) */
 .aria-cal-header__list-btn {
-  width: 40px;
-  height: 40px;
+  min-width: var(--aria-touch-target-min, 44px);
+  min-height: var(--aria-touch-target-min, 44px);
   display: flex;
   align-items: center;
   justify-content: center;
   border: none;
-  background: #f9fafb;
-  border-radius: 10px;
+  background: var(--aria-color-bg-secondary, #f9fafb);
+  border-radius: var(--aria-radius-md, 10px);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }
 
 .aria-cal-header__list-btn:active {
-  background: #e5e7eb;
+  background: var(--aria-color-border, #e5e7eb);
 }
 
 /* Month picker */
 .aria-cal-month-picker {
   margin-top: 12px;
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
+  background: var(--aria-color-bg, #fff);
+  border: 1px solid var(--aria-color-border, #e5e7eb);
+  border-radius: var(--aria-radius-lg, 12px);
   padding: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
@@ -83,14 +84,15 @@
   font-size: 16px;
 }
 
+/* WCAG touch target fix: 44px minimum (was 32×32) */
 .aria-cal-month-picker__nav button {
-  width: 32px;
-  height: 32px;
+  min-width: var(--aria-touch-target-min, 44px);
+  min-height: var(--aria-touch-target-min, 44px);
   display: flex;
   align-items: center;
   justify-content: center;
   border: none;
-  background: #f3f4f6;
+  background: var(--aria-color-bg-tertiary, #f3f4f6);
   border-radius: 8px;
   cursor: pointer;
   font-size: 16px;
@@ -105,22 +107,22 @@
 .aria-cal-month-picker__item {
   padding: 8px 4px;
   border: none;
-  background: #f9fafb;
+  background: var(--aria-color-bg-secondary, #f9fafb);
   border-radius: 8px;
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
+  color: var(--aria-color-text-secondary, #374151);
   -webkit-tap-highlight-color: transparent;
 }
 
 .aria-cal-month-picker__item:active {
-  background: #e5e7eb;
+  background: var(--aria-color-border, #e5e7eb);
 }
 
 .aria-cal-month-picker__item--active {
-  background: #1a73e8;
-  color: #fff;
+  background: var(--aria-color-accent, #1a73e8);
+  color: var(--aria-color-bg, #fff);
 }
 
 /* Content */
@@ -136,21 +138,21 @@
 .aria-cal-day-header {
   font-size: 14px;
   font-weight: 700;
-  color: #111827;
+  color: var(--aria-color-text-primary, #111827);
   margin-bottom: 8px;
   padding-bottom: 4px;
 }
 
 .aria-cal-day-header--today {
-  color: #1a73e8;
+  color: var(--aria-color-accent, #1a73e8);
 }
 
 /* Appointment card */
 .aria-cal-card {
   display: flex;
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
+  background: var(--aria-color-bg, #fff);
+  border: 1px solid var(--aria-color-border, #e5e7eb);
+  border-radius: var(--aria-radius-lg, 12px);
   margin-bottom: 8px;
   overflow: hidden;
   cursor: pointer;
@@ -159,7 +161,7 @@
 }
 
 .aria-cal-card:active {
-  background: #f9fafb;
+  background: var(--aria-color-bg-secondary, #f9fafb);
 }
 
 .aria-cal-card--expanded {
@@ -181,19 +183,19 @@
 .aria-cal-card__attendee {
   font-size: 16px;
   font-weight: 600;
-  color: #111827;
+  color: var(--aria-color-text-primary, #111827);
   line-height: 1.3;
 }
 
 .aria-cal-card__title {
   font-size: 14px;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary, #6b7280);
   margin-top: 2px;
 }
 
 .aria-cal-card__time {
   font-size: 13px;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted, #9ca3af);
   margin-top: 4px;
 }
 
@@ -201,7 +203,7 @@
 .aria-cal-card__details {
   margin-top: 12px;
   padding-top: 12px;
-  border-top: 1px solid #f3f4f6;
+  border-top: 1px solid var(--aria-color-bg-tertiary, #f3f4f6);
 }
 
 .aria-cal-card__detail-row {
@@ -214,14 +216,14 @@
 
 .aria-cal-card__detail-label {
   font-weight: 600;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary, #6b7280);
   min-width: 90px;
   flex-shrink: 0;
 }
 
 .aria-cal-card__detail-notes p {
   margin: 4px 0 0;
-  color: #374151;
+  color: var(--aria-color-text-secondary, #374151);
   font-size: 14px;
   line-height: 1.5;
 }
@@ -256,20 +258,22 @@
   gap: 8px;
 }
 
+/* WCAG touch target fix: explicit 44px minimum height */
 .aria-cal-card__action-btn {
   padding: 8px 16px;
-  border: 1px solid #d1d5db;
+  min-height: var(--aria-touch-target-min, 44px);
+  border: 1px solid var(--aria-color-border-light, #d1d5db);
   border-radius: 8px;
-  background: #fff;
+  background: var(--aria-color-bg, #fff);
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
+  color: var(--aria-color-text-secondary, #374151);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }
 
 .aria-cal-card__action-btn:active {
-  background: #f3f4f6;
+  background: var(--aria-color-bg-tertiary, #f3f4f6);
 }
 
 /* Loading / Error / Empty states */
@@ -281,15 +285,15 @@
   align-items: center;
   justify-content: center;
   padding: 60px 20px;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted, #9ca3af);
   font-size: 15px;
 }
 
 .aria-cal-spinner {
   width: 32px;
   height: 32px;
-  border: 3px solid #e5e7eb;
-  border-top-color: #1a73e8;
+  border: 3px solid var(--aria-color-border, #e5e7eb);
+  border-top-color: var(--aria-color-accent, #1a73e8);
   border-radius: 50%;
   animation: aria-cal-spin 0.7s linear infinite;
   margin-bottom: 12px;
@@ -299,12 +303,14 @@
   to { transform: rotate(360deg); }
 }
 
+/* WCAG touch target fix: explicit 44px minimum height */
 .aria-cal-error button {
   margin-top: 12px;
   padding: 8px 20px;
-  border: 1px solid #d1d5db;
+  min-height: var(--aria-touch-target-min, 44px);
+  border: 1px solid var(--aria-color-border-light, #d1d5db);
   border-radius: 8px;
-  background: #fff;
+  background: var(--aria-color-bg, #fff);
   font-size: 14px;
   cursor: pointer;
 }
@@ -331,6 +337,6 @@
 .aria-cal-header__list-btn:focus-visible,
 .aria-cal-month-picker__item:focus-visible,
 .aria-cal-card__action-btn:focus-visible {
-  outline: 2px solid #1a73e8;
+  outline: 2px solid var(--aria-color-accent, #1a73e8);
   outline-offset: 2px;
 }

--- a/frontend/src/pages/aria/AriaMortgageCalculator.css
+++ b/frontend/src/pages/aria/AriaMortgageCalculator.css
@@ -3,9 +3,9 @@
 .aria-calc-page {
   min-height: 100vh;
   min-height: -webkit-fill-available;
-  background: #fff;
+  background: var(--aria-color-bg, #fff);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  color: #1f2937;
+  color: var(--aria-color-text-primary, #1f2937);
   padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
 }
 
@@ -28,7 +28,7 @@
 }
 
 .aria-calc-back:active {
-  background: #f3f4f6;
+  background: var(--aria-color-bg-tertiary, #f3f4f6);
 }
 
 /* Content */
@@ -39,13 +39,13 @@
 .aria-calc-title {
   font-size: 28px;
   font-weight: 800;
-  color: #111827;
+  color: var(--aria-color-text-primary, #111827);
   margin: 0 0 6px;
 }
 
 .aria-calc-subtitle {
   font-size: 15px;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary, #6b7280);
   margin: 0 0 24px;
   line-height: 1.4;
 }
@@ -62,7 +62,7 @@
   margin-bottom: 20px;
   font-size: 16px;
   font-weight: 700;
-  color: #111827;
+  color: var(--aria-color-text-primary, #111827);
 }
 
 .aria-calc-section-icon {
@@ -84,21 +84,21 @@
   display: block;
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
+  color: var(--aria-color-text-secondary, #374151);
   margin-bottom: 6px;
 }
 
 .aria-calc-label-hint {
   font-weight: 400;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted, #9ca3af);
 }
 
 /* Toggle group (Purchase / Refinance, loan term) */
 .aria-calc-toggle-group {
   display: flex;
   gap: 0;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
+  border: 1px solid var(--aria-color-border-light, #d1d5db);
+  border-radius: var(--aria-radius-md, 10px);
   overflow: hidden;
 }
 
@@ -110,14 +110,14 @@
   gap: 8px;
   padding: 12px 16px;
   border: none;
-  background: #fff;
+  background: var(--aria-color-bg, #fff);
   font-size: 15px;
   font-weight: 500;
-  color: #374151;
+  color: var(--aria-color-text-secondary, #374151);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   transition: background 0.15s ease;
-  border-right: 1px solid #d1d5db;
+  border-right: 1px solid var(--aria-color-border-light, #d1d5db);
 }
 
 .aria-calc-toggle:last-child {
@@ -125,7 +125,7 @@
 }
 
 .aria-calc-toggle--active {
-  background: #f3f4f6;
+  background: var(--aria-color-bg-tertiary, #f3f4f6);
   font-weight: 600;
 }
 
@@ -133,14 +133,14 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  border: 2px solid #d1d5db;
+  border: 2px solid var(--aria-color-border-light, #d1d5db);
   flex-shrink: 0;
 }
 
 .aria-calc-toggle__radio--checked {
-  border-color: #111827;
-  background: #111827;
-  box-shadow: inset 0 0 0 3px #fff;
+  border-color: var(--aria-color-text-primary, #111827);
+  background: var(--aria-color-text-primary, #111827);
+  box-shadow: inset 0 0 0 3px var(--aria-color-bg, #fff);
 }
 
 /* Select dropdown */
@@ -151,11 +151,11 @@
 .aria-calc-select {
   width: 100%;
   padding: 12px 40px 12px 14px;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
-  background: #fff;
+  border: 1px solid var(--aria-color-border-light, #d1d5db);
+  border-radius: var(--aria-radius-md, 10px);
+  background: var(--aria-color-bg, #fff);
   font-size: 16px;
-  color: #111827;
+  color: var(--aria-color-text-primary, #111827);
   appearance: none;
   -webkit-appearance: none;
   cursor: pointer;
@@ -163,8 +163,8 @@
 
 .aria-calc-select:focus {
   outline: none;
-  border-color: #1a73e8;
-  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.15);
+  border-color: var(--aria-color-accent, #1a73e8);
+  box-shadow: 0 0 0 2px var(--aria-color-accent-light, rgba(26, 115, 232, 0.15));
 }
 
 .aria-calc-select-arrow {
@@ -173,7 +173,7 @@
   top: 50%;
   transform: translateY(-50%);
   pointer-events: none;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary, #6b7280);
   font-size: 14px;
 }
 
@@ -187,24 +187,24 @@
   border: none;
   background: transparent;
   font-size: 13px;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary, #6b7280);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }
 
 .aria-calc-info-link:active {
-  color: #374151;
+  color: var(--aria-color-text-secondary, #374151);
 }
 
 .aria-calc-info-box {
   margin-top: 8px;
   padding: 12px;
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
+  background: var(--aria-color-bg-secondary, #f9fafb);
+  border: 1px solid var(--aria-color-border, #e5e7eb);
+  border-radius: var(--aria-radius-md, 10px);
   font-size: 14px;
   line-height: 1.5;
-  color: #374151;
+  color: var(--aria-color-text-secondary, #374151);
 }
 
 .aria-calc-info-box strong {
@@ -220,28 +220,28 @@
 .aria-calc-currency-input {
   display: flex;
   align-items: center;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
+  border: 1px solid var(--aria-color-border-light, #d1d5db);
+  border-radius: var(--aria-radius-md, 10px);
   overflow: hidden;
-  background: #fff;
+  background: var(--aria-color-bg, #fff);
 }
 
 .aria-calc-currency-input:focus-within {
-  border-color: #1a73e8;
-  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.15);
+  border-color: var(--aria-color-accent, #1a73e8);
+  box-shadow: 0 0 0 2px var(--aria-color-accent-light, rgba(26, 115, 232, 0.15));
 }
 
 .aria-calc-currency-prefix {
   padding: 12px 0 12px 14px;
   font-size: 16px;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted, #9ca3af);
   flex-shrink: 0;
 }
 
 .aria-calc-currency-suffix {
   padding: 12px 14px 12px 0;
   font-size: 16px;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted, #9ca3af);
   flex-shrink: 0;
 }
 
@@ -252,7 +252,7 @@
   border: none;
   background: transparent;
   font-size: 16px;
-  color: #111827;
+  color: var(--aria-color-text-primary, #111827);
   outline: none;
 }
 
@@ -268,7 +268,7 @@
   margin: 10px 0 4px;
   -webkit-appearance: none;
   appearance: none;
-  background: #e5e7eb;
+  background: var(--aria-color-border, #e5e7eb);
   border-radius: 3px;
   outline: none;
 }
@@ -278,8 +278,8 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: #111827;
-  border: 3px solid #fff;
+  background: var(--aria-color-text-primary, #111827);
+  border: 3px solid var(--aria-color-bg, #fff);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
   cursor: pointer;
 }
@@ -288,8 +288,8 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: #111827;
-  border: 3px solid #fff;
+  background: var(--aria-color-text-primary, #111827);
+  border: 3px solid var(--aria-color-bg, #fff);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
   cursor: pointer;
 }
@@ -298,12 +298,12 @@
   display: flex;
   justify-content: space-between;
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted, #9ca3af);
 }
 
 .aria-calc-slider-value {
   font-weight: 700;
-  color: #111827;
+  color: var(--aria-color-text-primary, #111827);
   font-size: 16px;
 }
 
@@ -312,9 +312,9 @@
   width: 100%;
   padding: 16px;
   border: none;
-  border-radius: 12px;
-  background: #111827;
-  color: #fff;
+  border-radius: var(--aria-radius-lg, 12px);
+  background: var(--aria-color-text-primary, #111827);
+  color: var(--aria-color-bg, #fff);
   font-size: 16px;
   font-weight: 600;
   cursor: pointer;
@@ -324,27 +324,27 @@
 }
 
 .aria-calc-submit:active {
-  background: #374151;
+  background: var(--aria-color-text-secondary, #374151);
 }
 
 /* Results */
 .aria-calc-results {
   margin-top: 24px;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
+  border: 1px solid var(--aria-color-border, #e5e7eb);
+  border-radius: var(--aria-radius-xl, 16px);
   overflow: hidden;
 }
 
 .aria-calc-results__total {
   padding: 20px;
-  background: #f9fafb;
+  background: var(--aria-color-bg-secondary, #f9fafb);
   text-align: center;
 }
 
 .aria-calc-results__total-label {
   display: block;
   font-size: 14px;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary, #6b7280);
   margin-bottom: 4px;
 }
 
@@ -352,7 +352,7 @@
   display: block;
   font-size: 36px;
   font-weight: 800;
-  color: #111827;
+  color: var(--aria-color-text-primary, #111827);
 }
 
 .aria-calc-results__breakdown {
@@ -365,17 +365,17 @@
   align-items: center;
   padding: 8px 0;
   font-size: 15px;
-  color: #374151;
+  color: var(--aria-color-text-secondary, #374151);
 }
 
 .aria-calc-results__row--loan {
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary, #6b7280);
   font-size: 14px;
 }
 
 .aria-calc-results__divider {
   height: 1px;
-  background: #e5e7eb;
+  background: var(--aria-color-border, #e5e7eb);
   margin: 4px 0;
 }
 
@@ -386,7 +386,7 @@
 .aria-calc-info-link:focus-visible,
 .aria-calc-submit:focus-visible,
 .aria-calc-slider:focus-visible {
-  outline: 2px solid #1a73e8;
+  outline: 2px solid var(--aria-color-accent, #1a73e8);
   outline-offset: 2px;
 }
 

--- a/frontend/src/services/__tests__/docAnalyticsApi.test.js
+++ b/frontend/src/services/__tests__/docAnalyticsApi.test.js
@@ -1,0 +1,466 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock ./api so API_BASE_URL is deterministic
+// ---------------------------------------------------------------------------
+vi.mock('../api', () => ({
+  API_BASE_URL: 'http://test-api.local',
+}));
+
+// ---------------------------------------------------------------------------
+// Mock global fetch
+// ---------------------------------------------------------------------------
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock localStorage
+const mockLocalStorage = {
+  getItem: vi.fn(),
+};
+Object.defineProperty(global, 'localStorage', {
+  value: mockLocalStorage,
+  writable: true,
+});
+
+// ---------------------------------------------------------------------------
+// Import the module under test (after mocks are set up)
+// ---------------------------------------------------------------------------
+import {
+  getDashboard,
+  getPipelineCompleteness,
+  getSlaCompliance,
+  getAiPerformance,
+  getFollowupEffectiveness,
+  getIncomeSummary,
+  getBankAnalysisSummary,
+  getEsignMetrics,
+  getProcessorProductivity,
+  getLoanTimeline,
+  getTrends,
+  getBottlenecks,
+  docAnalyticsAPI,
+} from '../docAnalyticsApi';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a successful fetch response */
+function makeOkResponse(data) {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(data),
+  };
+}
+
+/** Build a failing fetch response */
+function makeErrorResponse(status, detail) {
+  return {
+    ok: false,
+    status,
+    json: vi.fn().mockResolvedValue({ detail }),
+  };
+}
+
+const BASE = 'http://test-api.local/api/v1/smart-docs';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('docAnalyticsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocalStorage.getItem.mockReturnValue('test-token-abc');
+    mockFetch.mockResolvedValue(makeOkResponse({ ok: true }));
+  });
+
+  // =========================================================================
+  // Named exports exist
+  // =========================================================================
+
+  describe('named exports', () => {
+    it('exports getDashboard as a function', () => {
+      expect(typeof getDashboard).toBe('function');
+    });
+    it('exports getPipelineCompleteness as a function', () => {
+      expect(typeof getPipelineCompleteness).toBe('function');
+    });
+    it('exports getSlaCompliance as a function', () => {
+      expect(typeof getSlaCompliance).toBe('function');
+    });
+    it('exports getAiPerformance as a function', () => {
+      expect(typeof getAiPerformance).toBe('function');
+    });
+    it('exports getFollowupEffectiveness as a function', () => {
+      expect(typeof getFollowupEffectiveness).toBe('function');
+    });
+    it('exports getIncomeSummary as a function', () => {
+      expect(typeof getIncomeSummary).toBe('function');
+    });
+    it('exports getBankAnalysisSummary as a function', () => {
+      expect(typeof getBankAnalysisSummary).toBe('function');
+    });
+    it('exports getEsignMetrics as a function', () => {
+      expect(typeof getEsignMetrics).toBe('function');
+    });
+    it('exports getProcessorProductivity as a function', () => {
+      expect(typeof getProcessorProductivity).toBe('function');
+    });
+    it('exports getLoanTimeline as a function', () => {
+      expect(typeof getLoanTimeline).toBe('function');
+    });
+    it('exports getTrends as a function', () => {
+      expect(typeof getTrends).toBe('function');
+    });
+    it('exports getBottlenecks as a function', () => {
+      expect(typeof getBottlenecks).toBe('function');
+    });
+  });
+
+  // =========================================================================
+  // Default export (docAnalyticsAPI object)
+  // =========================================================================
+
+  describe('default export — docAnalyticsAPI object', () => {
+    it('is exported as default', () => {
+      expect(docAnalyticsAPI).toBeDefined();
+    });
+
+    const expectedMethods = [
+      'getDashboard',
+      'getPipelineCompleteness',
+      'getSlaCompliance',
+      'getAiPerformance',
+      'getFollowupEffectiveness',
+      'getIncomeSummary',
+      'getBankAnalysisSummary',
+      'getEsignMetrics',
+      'getProcessorProductivity',
+      'getLoanTimeline',
+      'getTrends',
+      'getBottlenecks',
+    ];
+
+    expectedMethods.forEach((name) => {
+      it(`docAnalyticsAPI.${name} is a function`, () => {
+        expect(typeof docAnalyticsAPI[name]).toBe('function');
+      });
+    });
+  });
+
+  // =========================================================================
+  // Auth headers
+  // =========================================================================
+
+  describe('auth headers', () => {
+    it('sends Bearer token from localStorage', async () => {
+      await getDashboard();
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers['Authorization']).toBe('Bearer test-token-abc');
+    });
+
+    it('sends Content-Type: application/json', async () => {
+      await getDashboard();
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('sends empty Authorization when no token', async () => {
+      mockLocalStorage.getItem.mockReturnValue(null);
+      await getDashboard();
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers['Authorization']).toBe('');
+    });
+  });
+
+  // =========================================================================
+  // Error handling
+  // =========================================================================
+
+  describe('error handling', () => {
+    it('throws with detail message from JSON body on non-ok response', async () => {
+      mockFetch.mockResolvedValue(makeErrorResponse(422, 'Validation failed'));
+      await expect(getDashboard()).rejects.toThrow('Validation failed');
+    });
+
+    it('throws HTTP status message when detail field is missing', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: vi.fn().mockResolvedValue({}),
+      });
+      await expect(getDashboard()).rejects.toThrow('HTTP 500');
+    });
+
+    it('falls back gracefully when response body is not JSON', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: vi.fn().mockRejectedValue(new SyntaxError('bad json')),
+      });
+      await expect(getDashboard()).rejects.toThrow('Request failed');
+    });
+  });
+
+  // =========================================================================
+  // getDashboard
+  // =========================================================================
+
+  describe('getDashboard', () => {
+    it('calls /doc-analytics/dashboard with default days=30', async () => {
+      await getDashboard();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/dashboard?days=30`);
+    });
+
+    it('calls /doc-analytics/dashboard with custom days', async () => {
+      await getDashboard(90);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/dashboard?days=90`);
+    });
+
+    it('uses GET method', async () => {
+      await getDashboard();
+      const [, options] = mockFetch.mock.calls[0];
+      expect((options.method || 'GET').toUpperCase()).toBe('GET');
+    });
+
+    it('returns parsed JSON response', async () => {
+      const payload = { total_loans: 42 };
+      mockFetch.mockResolvedValue(makeOkResponse(payload));
+      const result = await getDashboard();
+      expect(result).toEqual(payload);
+    });
+  });
+
+  // =========================================================================
+  // getPipelineCompleteness
+  // =========================================================================
+
+  describe('getPipelineCompleteness', () => {
+    it('calls /doc-analytics/pipeline-completeness with no params by default', async () => {
+      await getPipelineCompleteness();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/pipeline-completeness`);
+    });
+
+    it('appends min_pct when provided', async () => {
+      await getPipelineCompleteness(50);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('min_pct=50');
+    });
+
+    it('appends max_pct when provided', async () => {
+      await getPipelineCompleteness(undefined, 90);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('max_pct=90');
+    });
+
+    it('appends both min_pct and max_pct when both provided', async () => {
+      await getPipelineCompleteness(20, 80);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('min_pct=20');
+      expect(url).toContain('max_pct=80');
+    });
+  });
+
+  // =========================================================================
+  // getSlaCompliance
+  // =========================================================================
+
+  describe('getSlaCompliance', () => {
+    it('calls /doc-analytics/sla-compliance with default days=30', async () => {
+      await getSlaCompliance();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/sla-compliance?days=30`);
+    });
+
+    it('calls /doc-analytics/sla-compliance with custom days', async () => {
+      await getSlaCompliance(60);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/sla-compliance?days=60`);
+    });
+  });
+
+  // =========================================================================
+  // getAiPerformance
+  // =========================================================================
+
+  describe('getAiPerformance', () => {
+    it('calls /doc-analytics/ai-performance with default days=30', async () => {
+      await getAiPerformance();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/ai-performance?days=30`);
+    });
+
+    it('calls /doc-analytics/ai-performance with custom days', async () => {
+      await getAiPerformance(14);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/ai-performance?days=14`);
+    });
+  });
+
+  // =========================================================================
+  // getFollowupEffectiveness
+  // =========================================================================
+
+  describe('getFollowupEffectiveness', () => {
+    it('calls /doc-analytics/followup-effectiveness with default days=30', async () => {
+      await getFollowupEffectiveness();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/followup-effectiveness?days=30`);
+    });
+
+    it('supports custom days', async () => {
+      await getFollowupEffectiveness(45);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/followup-effectiveness?days=45`);
+    });
+  });
+
+  // =========================================================================
+  // getIncomeSummary
+  // =========================================================================
+
+  describe('getIncomeSummary', () => {
+    it('calls /doc-analytics/income-summary with default days=30', async () => {
+      await getIncomeSummary();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/income-summary?days=30`);
+    });
+
+    it('supports custom days', async () => {
+      await getIncomeSummary(7);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/income-summary?days=7`);
+    });
+  });
+
+  // =========================================================================
+  // getBankAnalysisSummary
+  // =========================================================================
+
+  describe('getBankAnalysisSummary', () => {
+    it('calls /doc-analytics/bank-analysis-summary with default days=30', async () => {
+      await getBankAnalysisSummary();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/bank-analysis-summary?days=30`);
+    });
+
+    it('supports custom days', async () => {
+      await getBankAnalysisSummary(120);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/bank-analysis-summary?days=120`);
+    });
+  });
+
+  // =========================================================================
+  // getEsignMetrics
+  // =========================================================================
+
+  describe('getEsignMetrics', () => {
+    it('calls /doc-analytics/esign-metrics with default days=30', async () => {
+      await getEsignMetrics();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/esign-metrics?days=30`);
+    });
+
+    it('supports custom days', async () => {
+      await getEsignMetrics(180);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/esign-metrics?days=180`);
+    });
+  });
+
+  // =========================================================================
+  // getProcessorProductivity
+  // =========================================================================
+
+  describe('getProcessorProductivity', () => {
+    it('calls /doc-analytics/processor-productivity with default days=30', async () => {
+      await getProcessorProductivity();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/processor-productivity?days=30`);
+    });
+
+    it('supports custom days', async () => {
+      await getProcessorProductivity(365);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/processor-productivity?days=365`);
+    });
+  });
+
+  // =========================================================================
+  // getLoanTimeline
+  // =========================================================================
+
+  describe('getLoanTimeline', () => {
+    it('calls /doc-analytics/loan/{loanId}/timeline', async () => {
+      await getLoanTimeline('loan-123');
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/loan/loan-123/timeline`);
+    });
+
+    it('works with numeric-string loan IDs', async () => {
+      await getLoanTimeline('99');
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/loan/99/timeline`);
+    });
+
+    it('returns parsed JSON response', async () => {
+      const payload = { loan_id: 'loan-123', events: [] };
+      mockFetch.mockResolvedValue(makeOkResponse(payload));
+      const result = await getLoanTimeline('loan-123');
+      expect(result).toEqual(payload);
+    });
+  });
+
+  // =========================================================================
+  // getTrends
+  // =========================================================================
+
+  describe('getTrends', () => {
+    it('calls /doc-analytics/trends with defaults period=weekly&days=90', async () => {
+      await getTrends();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/trends?period=weekly&days=90`);
+    });
+
+    it('supports custom period', async () => {
+      await getTrends('monthly');
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('period=monthly');
+    });
+
+    it('supports custom days', async () => {
+      await getTrends('weekly', 30);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain('days=30');
+    });
+
+    it('supports both custom period and days', async () => {
+      await getTrends('daily', 14);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/trends?period=daily&days=14`);
+    });
+  });
+
+  // =========================================================================
+  // getBottlenecks
+  // =========================================================================
+
+  describe('getBottlenecks', () => {
+    it('calls /doc-analytics/bottlenecks with default days=30', async () => {
+      await getBottlenecks();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/bottlenecks?days=30`);
+    });
+
+    it('supports custom days', async () => {
+      await getBottlenecks(60);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-analytics/bottlenecks?days=60`);
+    });
+  });
+});

--- a/frontend/src/services/__tests__/docReviewApi.test.js
+++ b/frontend/src/services/__tests__/docReviewApi.test.js
@@ -29,16 +29,16 @@ const TOKEN = 'test-token-abc';
 const BASE = 'http://localhost:8000/api/v1/smart-docs/doc-review';
 
 function mockFetch(body = {}, ok = true, status = 200) {
-  global.fetch = jest.fn().mockResolvedValue({
+  global.fetch = vi.fn().mockResolvedValue({
     ok,
     status,
-    json: jest.fn().mockResolvedValue(body),
+    json: vi.fn().mockResolvedValue(body),
   });
 }
 
 beforeEach(() => {
   localStorage.setItem('token', TOKEN);
-  jest.clearAllMocks();
+  vi.clearAllMocks();
 });
 
 afterEach(() => {
@@ -421,34 +421,34 @@ describe('aiExtractAndReview', () => {
 
 describe('error handling', () => {
   it('throws with detail message from JSON error body', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
+    global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 404,
-      json: jest.fn().mockResolvedValue({ detail: 'Document not found' }),
+      json: vi.fn().mockResolvedValue({ detail: 'Document not found' }),
     });
     await expect(aiReview(999)).rejects.toThrow('Document not found');
   });
 
   it('throws fallback message when JSON parse fails', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
+    global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
-      json: jest.fn().mockRejectedValue(new SyntaxError('bad json')),
+      json: vi.fn().mockRejectedValue(new SyntaxError('bad json')),
     });
     await expect(getQueueStats()).rejects.toThrow('Request failed');
   });
 
   it('throws detail when body has detail but no extra fields', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
+    global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 409,
-      json: jest.fn().mockResolvedValue({ detail: 'Already claimed' }),
+      json: vi.fn().mockResolvedValue({ detail: 'Already claimed' }),
     });
     await expect(claimDocument(1, 'user-x')).rejects.toThrow('Already claimed');
   });
 
   it('re-throws network errors', async () => {
-    global.fetch = jest.fn().mockRejectedValue(new TypeError('Network request failed'));
+    global.fetch = vi.fn().mockRejectedValue(new TypeError('Network request failed'));
     await expect(getQueue()).rejects.toThrow('Network request failed');
   });
 });

--- a/frontend/src/services/__tests__/docReviewApi.test.js
+++ b/frontend/src/services/__tests__/docReviewApi.test.js
@@ -1,0 +1,454 @@
+/**
+ * Tests for the Document Review Queue API Service (docReviewApi.js)
+ *
+ * Uses fetch mocking to verify correct URL construction, HTTP methods,
+ * headers, request bodies, and error handling for all 13 endpoints.
+ */
+
+import docReviewApi, {
+  getQueue,
+  getQueueStats,
+  claimDocument,
+  releaseDocument,
+  aiReview,
+  batchAiReview,
+  crossValidate,
+  getReviewHistory,
+  getAutoReviewSettings,
+  updateAutoReviewSettings,
+  getReviewStats,
+  getLoanCompleteness,
+  aiExtractAndReview,
+} from '../docReviewApi';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TOKEN = 'test-token-abc';
+const BASE = 'http://localhost:8000/api/v1/smart-docs/doc-review';
+
+function mockFetch(body = {}, ok = true, status = 200) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  });
+}
+
+beforeEach(() => {
+  localStorage.setItem('token', TOKEN);
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Default export shape
+// ---------------------------------------------------------------------------
+
+describe('default export', () => {
+  it('exposes all 13 functions as properties', () => {
+    expect(docReviewApi.getQueue).toBe(getQueue);
+    expect(docReviewApi.getQueueStats).toBe(getQueueStats);
+    expect(docReviewApi.claimDocument).toBe(claimDocument);
+    expect(docReviewApi.releaseDocument).toBe(releaseDocument);
+    expect(docReviewApi.aiReview).toBe(aiReview);
+    expect(docReviewApi.batchAiReview).toBe(batchAiReview);
+    expect(docReviewApi.crossValidate).toBe(crossValidate);
+    expect(docReviewApi.getReviewHistory).toBe(getReviewHistory);
+    expect(docReviewApi.getAutoReviewSettings).toBe(getAutoReviewSettings);
+    expect(docReviewApi.updateAutoReviewSettings).toBe(updateAutoReviewSettings);
+    expect(docReviewApi.getReviewStats).toBe(getReviewStats);
+    expect(docReviewApi.getLoanCompleteness).toBe(getLoanCompleteness);
+    expect(docReviewApi.aiExtractAndReview).toBe(aiExtractAndReview);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth header utility
+// ---------------------------------------------------------------------------
+
+describe('auth header', () => {
+  it('sends Bearer token from localStorage', async () => {
+    mockFetch({ total: 0, items: [] });
+    await getQueue();
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.headers['Authorization']).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('sends empty Authorization when no token', async () => {
+    localStorage.removeItem('token');
+    mockFetch({ total: 0, items: [] });
+    await getQueue();
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.headers['Authorization']).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getQueue
+// ---------------------------------------------------------------------------
+
+describe('getQueue', () => {
+  it('calls GET /queue with default params', async () => {
+    mockFetch({ total: 0, items: [] });
+    await getQueue();
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toContain(`${BASE}/queue`);
+    expect(url).toContain('limit=50');
+    expect(url).toContain('offset=0');
+  });
+
+  it('appends priority and docType when provided', async () => {
+    mockFetch({ total: 1, items: [] });
+    await getQueue({ priority: 'HIGH', docType: 'W2', limit: 10, offset: 5 });
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toContain('priority=HIGH');
+    expect(url).toContain('doc_type=W2');
+    expect(url).toContain('limit=10');
+    expect(url).toContain('offset=5');
+  });
+
+  it('omits priority/docType when not provided', async () => {
+    mockFetch({ total: 0, items: [] });
+    await getQueue({ limit: 20 });
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).not.toContain('priority');
+    expect(url).not.toContain('doc_type');
+  });
+
+  it('uses GET method', async () => {
+    mockFetch({});
+    await getQueue();
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.method).toBeUndefined(); // fetch default is GET
+  });
+
+  it('returns parsed JSON', async () => {
+    const data = { total: 3, items: [{ id: 1 }] };
+    mockFetch(data);
+    const result = await getQueue();
+    expect(result).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getQueueStats
+// ---------------------------------------------------------------------------
+
+describe('getQueueStats', () => {
+  it('calls GET /queue/stats', async () => {
+    mockFetch({ total_in_queue: 5 });
+    await getQueueStats();
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/queue/stats`);
+  });
+
+  it('returns stats data', async () => {
+    const data = { total_in_queue: 5, by_priority: { critical: 1 } };
+    mockFetch(data);
+    const result = await getQueueStats();
+    expect(result).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claimDocument
+// ---------------------------------------------------------------------------
+
+describe('claimDocument', () => {
+  it('calls POST /queue/{documentId}/claim', async () => {
+    mockFetch({ document_id: 42, claimed_by: 'Alice' });
+    await claimDocument(42);
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/queue/42/claim`);
+    expect(options.method).toBe('POST');
+  });
+
+  it('includes reviewer_id in body when provided', async () => {
+    mockFetch({});
+    await claimDocument(42, 'user-123');
+    const [, options] = global.fetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({ reviewer_id: 'user-123' });
+  });
+
+  it('sends empty object in body when reviewerId is omitted', async () => {
+    mockFetch({});
+    await claimDocument(7);
+    const [, options] = global.fetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({});
+  });
+
+  it('sets Content-Type header', async () => {
+    mockFetch({});
+    await claimDocument(1);
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.headers['Content-Type']).toBe('application/json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// releaseDocument
+// ---------------------------------------------------------------------------
+
+describe('releaseDocument', () => {
+  it('calls POST /queue/{documentId}/release', async () => {
+    mockFetch({ released: true });
+    await releaseDocument(99);
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/queue/99/release`);
+    expect(options.method).toBe('POST');
+  });
+
+  it('returns parsed JSON', async () => {
+    const data = { document_id: 99, status: 'UPLOADED' };
+    mockFetch(data);
+    const result = await releaseDocument(99);
+    expect(result).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aiReview
+// ---------------------------------------------------------------------------
+
+describe('aiReview', () => {
+  it('calls POST /ai-review/{documentId}', async () => {
+    mockFetch({ decision: 'ACCEPT', confidence: 95 });
+    await aiReview(55);
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/ai-review/55`);
+    expect(options.method).toBe('POST');
+  });
+
+  it('returns AI review result', async () => {
+    const data = { document_id: 55, decision: 'ACCEPT', confidence: 90 };
+    mockFetch(data);
+    const result = await aiReview(55);
+    expect(result).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// batchAiReview
+// ---------------------------------------------------------------------------
+
+describe('batchAiReview', () => {
+  it('calls POST /ai-review/batch/{loanId}', async () => {
+    mockFetch({ loan_id: 10, total: 3 });
+    await batchAiReview(10);
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/ai-review/batch/10`);
+    expect(options.method).toBe('POST');
+  });
+
+  it('sends options in body', async () => {
+    mockFetch({});
+    await batchAiReview(10, { force_recheck: true });
+    const [, options] = global.fetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({ force_recheck: true });
+  });
+
+  it('sends empty object when no options provided', async () => {
+    mockFetch({});
+    await batchAiReview(10);
+    const [, options] = global.fetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// crossValidate
+// ---------------------------------------------------------------------------
+
+describe('crossValidate', () => {
+  it('calls POST /cross-validate/{loanId}', async () => {
+    mockFetch({ loan_id: 20, risk_level: 'LOW' });
+    await crossValidate(20);
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/cross-validate/20`);
+    expect(options.method).toBe('POST');
+  });
+
+  it('returns cross-validation result', async () => {
+    const data = { loan_id: 20, inconsistencies: [], risk_level: 'LOW' };
+    mockFetch(data);
+    const result = await crossValidate(20);
+    expect(result).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getReviewHistory
+// ---------------------------------------------------------------------------
+
+describe('getReviewHistory', () => {
+  it('calls GET /document/{documentId}/review-history', async () => {
+    mockFetch({ history: [] });
+    await getReviewHistory(33);
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/document/33/review-history`);
+  });
+
+  it('uses GET method (no method property)', async () => {
+    mockFetch({});
+    await getReviewHistory(33);
+    const [, options] = global.fetch.mock.calls[0];
+    expect(options.method).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAutoReviewSettings
+// ---------------------------------------------------------------------------
+
+describe('getAutoReviewSettings', () => {
+  it('calls GET /auto-review-settings', async () => {
+    mockFetch({ auto_approve_threshold: 90 });
+    await getAutoReviewSettings();
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/auto-review-settings`);
+  });
+
+  it('returns settings data', async () => {
+    const data = { auto_approve_threshold: 90, auto_reject_threshold: 30 };
+    mockFetch(data);
+    const result = await getAutoReviewSettings();
+    expect(result).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateAutoReviewSettings
+// ---------------------------------------------------------------------------
+
+describe('updateAutoReviewSettings', () => {
+  it('calls POST /auto-review-settings', async () => {
+    mockFetch({ updated: true });
+    await updateAutoReviewSettings({ auto_approve_threshold: 85 });
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/auto-review-settings`);
+    expect(options.method).toBe('POST');
+  });
+
+  it('sends settings in request body', async () => {
+    mockFetch({});
+    const settings = { auto_approve_threshold: 85, enabled_checks: ['quality', 'freshness'] };
+    await updateAutoReviewSettings(settings);
+    const [, options] = global.fetch.mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual(settings);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getReviewStats
+// ---------------------------------------------------------------------------
+
+describe('getReviewStats', () => {
+  it('calls GET /stats with default days=30', async () => {
+    mockFetch({ total_reviewed: 50 });
+    await getReviewStats();
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/stats?days=30`);
+  });
+
+  it('passes custom days value', async () => {
+    mockFetch({});
+    await getReviewStats(7);
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/stats?days=7`);
+  });
+
+  it('returns stats data', async () => {
+    const data = { total_reviewed: 50, auto_approved: 30 };
+    mockFetch(data);
+    const result = await getReviewStats(14);
+    expect(result).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLoanCompleteness
+// ---------------------------------------------------------------------------
+
+describe('getLoanCompleteness', () => {
+  it('calls GET /loan/{loanId}/completeness', async () => {
+    mockFetch({ completeness_pct: 75.0 });
+    await getLoanCompleteness(101);
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/loan/101/completeness`);
+  });
+
+  it('returns completeness data', async () => {
+    const data = { loan_id: 101, completeness_pct: 75.0, missing: 2 };
+    mockFetch(data);
+    const result = await getLoanCompleteness(101);
+    expect(result).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aiExtractAndReview
+// ---------------------------------------------------------------------------
+
+describe('aiExtractAndReview', () => {
+  it('calls POST /document/{documentId}/ai-extract-and-review', async () => {
+    mockFetch({ decision: 'ACCEPT' });
+    await aiExtractAndReview(77);
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(`${BASE}/document/77/ai-extract-and-review`);
+    expect(options.method).toBe('POST');
+  });
+
+  it('returns extraction and review result', async () => {
+    const data = { document_id: 77, decision: 'ACCEPT', extracted_fields: {} };
+    mockFetch(data);
+    const result = await aiExtractAndReview(77);
+    expect(result).toEqual(data);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe('error handling', () => {
+  it('throws with detail message from JSON error body', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: jest.fn().mockResolvedValue({ detail: 'Document not found' }),
+    });
+    await expect(aiReview(999)).rejects.toThrow('Document not found');
+  });
+
+  it('throws fallback message when JSON parse fails', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: jest.fn().mockRejectedValue(new SyntaxError('bad json')),
+    });
+    await expect(getQueueStats()).rejects.toThrow('Request failed');
+  });
+
+  it('throws detail when body has detail but no extra fields', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: jest.fn().mockResolvedValue({ detail: 'Already claimed' }),
+    });
+    await expect(claimDocument(1, 'user-x')).rejects.toThrow('Already claimed');
+  });
+
+  it('re-throws network errors', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new TypeError('Network request failed'));
+    await expect(getQueue()).rejects.toThrow('Network request failed');
+  });
+});

--- a/frontend/src/services/__tests__/docSecurityApi.test.js
+++ b/frontend/src/services/__tests__/docSecurityApi.test.js
@@ -1,0 +1,612 @@
+/**
+ * Tests for docSecurityApi, docBankAnalysisApi, and docIncomeApi service modules.
+ *
+ * Uses vitest + jsdom. fetch is mocked globally via vi.stubGlobal.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock the './api' module so API_BASE_URL is a predictable value
+// ---------------------------------------------------------------------------
+vi.mock('../api', () => ({
+  API_BASE_URL: 'http://localhost:8000',
+}));
+
+// ---------------------------------------------------------------------------
+// Mock localStorage
+// ---------------------------------------------------------------------------
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: vi.fn((key) => store[key] ?? null),
+    setItem: vi.fn((key, value) => { store[key] = String(value); }),
+    removeItem: vi.fn((key) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+})();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+// ---------------------------------------------------------------------------
+// Import service modules AFTER mocks are in place
+// ---------------------------------------------------------------------------
+import {
+  getAuditLog,
+  getDocumentAuditLog,
+  logAccess,
+  checkIntegrity,
+  batchIntegrityCheck,
+  getIntegrityHistory,
+  getFraudAnalysis,
+  getFraudSummary,
+  getRetentionPolicies,
+  createRetentionPolicy,
+  updateRetentionPolicy,
+  getExpiringRetentions,
+  watermarkDocument,
+  getEncryptionStatus,
+  encryptDocument,
+  getComplianceReport,
+  getSuspiciousActivity,
+  docSecurityAPI,
+} from '../docSecurityApi';
+
+import {
+  analyzeBankStatement,
+  getLargeDeposits,
+  getNsfOverdrafts,
+  getRiskScore,
+  getBankSummary,
+  sourceDeposit,
+  docBankAnalysisAPI,
+} from '../docBankAnalysisApi';
+
+import {
+  calculateIncome,
+  getIncomeHistory,
+  approveIncome,
+  rejectIncome,
+  docIncomeAPI,
+} from '../docIncomeApi';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a successful fetch mock that returns JSON data. */
+function mockFetchSuccess(data) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue(data),
+  });
+}
+
+/** Build a failed fetch mock (non-ok status with detail message). */
+function mockFetchError(detail, status = 400) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: vi.fn().mockResolvedValue({ detail }),
+  });
+}
+
+const BASE = 'http://localhost:8000/api/v1/smart-docs';
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  localStorageMock.getItem.mockReturnValue('test-token-abc');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ===========================================================================
+// docSecurityApi — Security tests
+// ===========================================================================
+
+describe('docSecurityApi', () => {
+  // -------------------------------------------------------------------------
+  describe('getAuditLog', () => {
+    it('calls audit-log endpoint with default params', async () => {
+      const fetchMock = mockFetchSuccess({ entries: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getAuditLog();
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toContain(`${BASE}/doc-security/audit-log`);
+      expect(url).toContain('days=30');
+      expect(url).toContain('limit=100');
+      expect(url).toContain('offset=0');
+      expect(opts.headers['Authorization']).toBe('Bearer test-token-abc');
+      expect(result).toEqual({ entries: [] });
+    });
+
+    it('appends optional documentId and action filters', async () => {
+      const fetchMock = mockFetchSuccess({ entries: [{ id: '1' }] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getAuditLog({ documentId: 'doc-123', action: 'view', days: 7 });
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain('document_id=doc-123');
+      expect(url).toContain('action=view');
+      expect(url).toContain('days=7');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getDocumentAuditLog', () => {
+    it('calls audit-log/{documentId} endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ events: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getDocumentAuditLog('doc-456');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/audit-log/doc-456`);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('logAccess', () => {
+    it('POSTs to log-access with correct body', async () => {
+      const fetchMock = mockFetchSuccess({ logged: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await logAccess('doc-789', 'download', 'via mobile');
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/log-access`);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({
+        document_id: 'doc-789',
+        action: 'download',
+        details: 'via mobile',
+      });
+    });
+
+    it('uses empty string for details when omitted', async () => {
+      const fetchMock = mockFetchSuccess({ logged: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await logAccess('doc-789', 'view');
+
+      const { details } = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(details).toBe('');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('checkIntegrity', () => {
+    it('calls integrity-check/{documentId} endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ status: 'ok' });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await checkIntegrity('doc-111');
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/integrity-check/doc-111`);
+      expect(opts.method).toBeUndefined(); // GET — no method set
+      expect(result).toEqual({ status: 'ok' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('batchIntegrityCheck', () => {
+    it('POSTs document_ids array to batch endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ results: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await batchIntegrityCheck(['a', 'b', 'c']);
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/integrity-check/batch`);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({ document_ids: ['a', 'b', 'c'] });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getIntegrityHistory', () => {
+    it('calls integrity-history/{documentId} endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ history: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getIntegrityHistory('doc-222');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/integrity-history/doc-222`);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getFraudAnalysis', () => {
+    it('calls fraud-analysis/{loanId} endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ risk: 'low' });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getFraudAnalysis('loan-999');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/fraud-analysis/loan-999`);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getFraudSummary', () => {
+    it('uses loan-scoped URL when loanId is provided', async () => {
+      const fetchMock = mockFetchSuccess({ summary: {} });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getFraudSummary('loan-abc');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/fraud/loan-abc/summary`);
+    });
+
+    it('uses global fraud-summary URL when loanId is omitted', async () => {
+      const fetchMock = mockFetchSuccess({ summary: {} });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getFraudSummary();
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/fraud-summary`);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('retention policies', () => {
+    it('getRetentionPolicies calls retention-policies endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ policies: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getRetentionPolicies();
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/retention-policies`);
+    });
+
+    it('createRetentionPolicy POSTs policy object', async () => {
+      const policy = { name: 'Default', days: 365 };
+      const fetchMock = mockFetchSuccess({ id: 'pol-1', ...policy });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await createRetentionPolicy(policy);
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/retention-policies`);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual(policy);
+    });
+
+    it('updateRetentionPolicy PUTs to retention-policies/{policyId}', async () => {
+      const fetchMock = mockFetchSuccess({ updated: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await updateRetentionPolicy('pol-1', { days: 730 });
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/retention-policies/pol-1`);
+      expect(opts.method).toBe('PUT');
+      expect(JSON.parse(opts.body)).toEqual({ days: 730 });
+    });
+
+    it('getExpiringRetentions passes days param', async () => {
+      const fetchMock = mockFetchSuccess({ items: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getExpiringRetentions(60);
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain('days=60');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('watermarkDocument', () => {
+    it('POSTs to watermark/{documentId} with options', async () => {
+      const fetchMock = mockFetchSuccess({ watermarked: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await watermarkDocument('doc-333', { text: 'CONFIDENTIAL' });
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/watermark/doc-333`);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({ text: 'CONFIDENTIAL' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('encryption', () => {
+    it('getEncryptionStatus calls encryption-status/{documentId}', async () => {
+      const fetchMock = mockFetchSuccess({ encrypted: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getEncryptionStatus('doc-444');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/encryption-status/doc-444`);
+    });
+
+    it('encryptDocument POSTs to encrypt/{documentId}', async () => {
+      const fetchMock = mockFetchSuccess({ encrypted: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await encryptDocument('doc-555');
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/doc-security/encrypt/doc-555`);
+      expect(opts.method).toBe('POST');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('compliance & suspicious activity', () => {
+    it('getComplianceReport passes days param', async () => {
+      const fetchMock = mockFetchSuccess({ report: {} });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getComplianceReport(90);
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain('days=90');
+      expect(url).toContain('compliance-report');
+    });
+
+    it('getSuspiciousActivity passes days param', async () => {
+      const fetchMock = mockFetchSuccess({ events: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getSuspiciousActivity(14);
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain('days=14');
+      expect(url).toContain('suspicious-activity');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('error handling', () => {
+    it('throws with detail message from error response', async () => {
+      const fetchMock = mockFetchError('Document not found', 404);
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(checkIntegrity('bad-id')).rejects.toThrow('Document not found');
+    });
+
+    it('throws with fallback message when JSON parse fails on error response', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: vi.fn().mockRejectedValue(new Error('not JSON')),
+      }));
+
+      // The handleResponse catch fallback returns { detail: 'Request failed' }
+      await expect(getAuditLog()).rejects.toThrow('Request failed');
+    });
+
+    it('sends no auth header when token is absent', async () => {
+      localStorageMock.getItem.mockReturnValue(null);
+      const fetchMock = mockFetchSuccess({});
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getRetentionPolicies();
+
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(opts.headers['Authorization']).toBe('');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('default export shape', () => {
+    it('docSecurityAPI default export contains all functions', () => {
+      expect(typeof docSecurityAPI.getAuditLog).toBe('function');
+      expect(typeof docSecurityAPI.logAccess).toBe('function');
+      expect(typeof docSecurityAPI.checkIntegrity).toBe('function');
+      expect(typeof docSecurityAPI.batchIntegrityCheck).toBe('function');
+      expect(typeof docSecurityAPI.getFraudAnalysis).toBe('function');
+      expect(typeof docSecurityAPI.getFraudSummary).toBe('function');
+      expect(typeof docSecurityAPI.getRetentionPolicies).toBe('function');
+      expect(typeof docSecurityAPI.watermarkDocument).toBe('function');
+      expect(typeof docSecurityAPI.encryptDocument).toBe('function');
+      expect(typeof docSecurityAPI.getComplianceReport).toBe('function');
+      expect(typeof docSecurityAPI.getSuspiciousActivity).toBe('function');
+    });
+  });
+});
+
+// ===========================================================================
+// docBankAnalysisApi — Bank Analysis tests
+// ===========================================================================
+
+describe('docBankAnalysisApi', () => {
+  describe('analyzeBankStatement', () => {
+    it('POSTs to bank-analysis/analyze/{documentId}', async () => {
+      const fetchMock = mockFetchSuccess({ analysis: {} });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await analyzeBankStatement('doc-bank-1');
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/bank-analysis/analyze/doc-bank-1`);
+      expect(opts.method).toBe('POST');
+    });
+  });
+
+  describe('getLargeDeposits', () => {
+    it('calls large-deposits/{loanId} without threshold', async () => {
+      const fetchMock = mockFetchSuccess({ deposits: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getLargeDeposits('loan-bank-1');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/bank-analysis/large-deposits/loan-bank-1`);
+    });
+
+    it('appends threshold query param when provided', async () => {
+      const fetchMock = mockFetchSuccess({ deposits: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getLargeDeposits('loan-bank-1', 5000);
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toContain('threshold=5000');
+    });
+  });
+
+  describe('getNsfOverdrafts', () => {
+    it('calls nsf-overdrafts/{loanId} endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ events: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getNsfOverdrafts('loan-bank-2');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/bank-analysis/nsf-overdrafts/loan-bank-2`);
+    });
+  });
+
+  describe('getRiskScore', () => {
+    it('calls risk-score/{loanId} endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ score: 42 });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await getRiskScore('loan-bank-3');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/bank-analysis/risk-score/loan-bank-3`);
+      expect(result).toEqual({ score: 42 });
+    });
+  });
+
+  describe('getBankSummary', () => {
+    it('calls summary/{loanId} endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ summary: {} });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getBankSummary('loan-bank-4');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/bank-analysis/summary/loan-bank-4`);
+    });
+  });
+
+  describe('sourceDeposit', () => {
+    it('POSTs sourcing details to source-deposit/{depositId}', async () => {
+      const sourcing = { source: 'payroll', amount: 3000 };
+      const fetchMock = mockFetchSuccess({ sourced: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await sourceDeposit('dep-99', sourcing);
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/bank-analysis/source-deposit/dep-99`);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual(sourcing);
+    });
+  });
+
+  describe('default export shape', () => {
+    it('docBankAnalysisAPI contains all functions', () => {
+      expect(typeof docBankAnalysisAPI.analyzeBankStatement).toBe('function');
+      expect(typeof docBankAnalysisAPI.getLargeDeposits).toBe('function');
+      expect(typeof docBankAnalysisAPI.getNsfOverdrafts).toBe('function');
+      expect(typeof docBankAnalysisAPI.getRiskScore).toBe('function');
+      expect(typeof docBankAnalysisAPI.getBankSummary).toBe('function');
+      expect(typeof docBankAnalysisAPI.sourceDeposit).toBe('function');
+    });
+  });
+});
+
+// ===========================================================================
+// docIncomeApi — Income tests
+// ===========================================================================
+
+describe('docIncomeApi', () => {
+  describe('calculateIncome', () => {
+    it('POSTs to income/calculate/{loanId} with options', async () => {
+      const fetchMock = mockFetchSuccess({ income: 8500 });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const opts = { include_rental: true };
+      const result = await calculateIncome('loan-inc-1', opts);
+
+      const [url, reqOpts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/income/calculate/loan-inc-1`);
+      expect(reqOpts.method).toBe('POST');
+      expect(JSON.parse(reqOpts.body)).toEqual(opts);
+      expect(result).toEqual({ income: 8500 });
+    });
+
+    it('sends empty object body when options omitted', async () => {
+      const fetchMock = mockFetchSuccess({});
+      vi.stubGlobal('fetch', fetchMock);
+
+      await calculateIncome('loan-inc-2');
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body).toEqual({});
+    });
+  });
+
+  describe('getIncomeHistory', () => {
+    it('calls income/history/{loanId} endpoint', async () => {
+      const fetchMock = mockFetchSuccess({ history: [] });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await getIncomeHistory('loan-inc-3');
+
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/income/history/loan-inc-3`);
+    });
+  });
+
+  describe('approveIncome', () => {
+    it('POSTs to income/approve/{loanId} with notes', async () => {
+      const fetchMock = mockFetchSuccess({ approved: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await approveIncome('loan-inc-4', 'Looks good');
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/income/approve/loan-inc-4`);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({ notes: 'Looks good' });
+    });
+  });
+
+  describe('rejectIncome', () => {
+    it('POSTs to income/reject/{loanId} with reason', async () => {
+      const fetchMock = mockFetchSuccess({ rejected: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await rejectIncome('loan-inc-5', 'Insufficient documentation');
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${BASE}/income/reject/loan-inc-5`);
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({ reason: 'Insufficient documentation' });
+    });
+  });
+
+  describe('default export shape', () => {
+    it('docIncomeAPI contains all functions', () => {
+      expect(typeof docIncomeAPI.calculateIncome).toBe('function');
+      expect(typeof docIncomeAPI.getIncomeHistory).toBe('function');
+      expect(typeof docIncomeAPI.approveIncome).toBe('function');
+      expect(typeof docIncomeAPI.rejectIncome).toBe('function');
+      expect(typeof docIncomeAPI.submitForApproval).toBe('function');
+      expect(typeof docIncomeAPI.overrideSource).toBe('function');
+      expect(typeof docIncomeAPI.getIncomeSources).toBe('function');
+    });
+  });
+});

--- a/frontend/src/services/docAnalyticsApi.js
+++ b/frontend/src/services/docAnalyticsApi.js
@@ -1,0 +1,196 @@
+/**
+ * Smart Docs Analytics API Service
+ *
+ * Client-side API functions for the doc analytics dashboard endpoints.
+ * All 12 endpoints are under /api/v1/smart-docs/doc-analytics/*.
+ */
+import { API_BASE_URL } from './api';
+
+const API_BASE = `${API_BASE_URL}/api/v1/smart-docs`;
+
+// =============================================================================
+// Shared helpers (same pattern as smartDocsApi.js)
+// =============================================================================
+
+async function handleResponse(response) {
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: 'Request failed' }));
+    throw new Error(error.detail || `HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function getHeaders() {
+  const token = localStorage.getItem('token');
+  return {
+    'Authorization': token ? `Bearer ${token}` : '',
+    'Content-Type': 'application/json',
+  };
+}
+
+// =============================================================================
+// Analytics endpoints
+// =============================================================================
+
+/**
+ * Get top-level analytics dashboard summary.
+ * @param {number} days - Lookback window in days (default 30)
+ */
+export async function getDashboard(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-analytics/dashboard?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get pipeline completeness data.
+ * @param {number} [minPct] - Optional minimum completeness percentage filter
+ * @param {number} [maxPct] - Optional maximum completeness percentage filter
+ */
+export async function getPipelineCompleteness(minPct, maxPct) {
+  const params = new URLSearchParams();
+  if (minPct !== undefined && minPct !== null) params.append('min_pct', minPct);
+  if (maxPct !== undefined && maxPct !== null) params.append('max_pct', maxPct);
+
+  const qs = params.toString();
+  const url = qs
+    ? `${API_BASE}/doc-analytics/pipeline-completeness?${qs}`
+    : `${API_BASE}/doc-analytics/pipeline-completeness`;
+
+  const response = await fetch(url, { headers: getHeaders() });
+  return handleResponse(response);
+}
+
+/**
+ * Get SLA compliance report.
+ * @param {number} days - Lookback window in days (default 30)
+ */
+export async function getSlaCompliance(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-analytics/sla-compliance?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get AI document classification performance metrics.
+ * @param {number} days - Lookback window in days (default 30)
+ */
+export async function getAiPerformance(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-analytics/ai-performance?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get follow-up effectiveness metrics.
+ * @param {number} days - Lookback window in days (default 30)
+ */
+export async function getFollowupEffectiveness(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-analytics/followup-effectiveness?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get income verification analysis summary.
+ * @param {number} days - Lookback window in days (default 30)
+ */
+export async function getIncomeSummary(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-analytics/income-summary?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get bank statement analysis summary.
+ * @param {number} days - Lookback window in days (default 30)
+ */
+export async function getBankAnalysisSummary(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-analytics/bank-analysis-summary?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get e-signature metrics.
+ * @param {number} days - Lookback window in days (default 30)
+ */
+export async function getEsignMetrics(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-analytics/esign-metrics?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get processor productivity report.
+ * @param {number} days - Lookback window in days (default 30)
+ */
+export async function getProcessorProductivity(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-analytics/processor-productivity?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get document collection timeline for a specific loan.
+ * @param {string} loanId - The loan identifier
+ */
+export async function getLoanTimeline(loanId) {
+  const response = await fetch(`${API_BASE}/doc-analytics/loan/${loanId}/timeline`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get trend data over time.
+ * @param {string} period - Aggregation period: 'daily', 'weekly', or 'monthly' (default 'weekly')
+ * @param {number} days  - Total lookback window in days (default 90)
+ */
+export async function getTrends(period = 'weekly', days = 90) {
+  const response = await fetch(
+    `${API_BASE}/doc-analytics/trends?period=${period}&days=${days}`,
+    { headers: getHeaders() },
+  );
+  return handleResponse(response);
+}
+
+/**
+ * Get pipeline bottleneck analysis.
+ * @param {number} days - Lookback window in days (default 30)
+ */
+export async function getBottlenecks(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-analytics/bottlenecks?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Default export — all functions grouped on one object
+// =============================================================================
+
+export const docAnalyticsAPI = {
+  getDashboard,
+  getPipelineCompleteness,
+  getSlaCompliance,
+  getAiPerformance,
+  getFollowupEffectiveness,
+  getIncomeSummary,
+  getBankAnalysisSummary,
+  getEsignMetrics,
+  getProcessorProductivity,
+  getLoanTimeline,
+  getTrends,
+  getBottlenecks,
+};
+
+export default docAnalyticsAPI;

--- a/frontend/src/services/docBankAnalysisApi.js
+++ b/frontend/src/services/docBankAnalysisApi.js
@@ -1,0 +1,149 @@
+/**
+ * Document Bank Analysis API Service
+ *
+ * Client-side API functions for bank statement analysis including large
+ * deposits, NSF/overdrafts, undisclosed debts, IRS payments, risk scoring,
+ * and deposit sourcing.
+ */
+import { API_BASE_URL } from './api';
+
+const API_BASE = `${API_BASE_URL}/api/v1/smart-docs`;
+
+/**
+ * Helper to handle API responses
+ */
+async function handleResponse(response) {
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: 'Request failed' }));
+    throw new Error(error.detail || `HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Get auth headers (assumes token in localStorage)
+ */
+function getHeaders() {
+  const token = localStorage.getItem('token');
+  return {
+    'Authorization': token ? `Bearer ${token}` : '',
+    'Content-Type': 'application/json',
+  };
+}
+
+// =============================================================================
+// Bank Statement Analysis
+// =============================================================================
+
+/**
+ * Analyze a bank statement document
+ * @param {string} documentId
+ */
+export async function analyzeBankStatement(documentId) {
+  const response = await fetch(`${API_BASE}/bank-analysis/analyze/${documentId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get large deposits for a loan
+ * @param {string} loanId
+ * @param {number} [threshold] - Optional minimum deposit amount
+ */
+export async function getLargeDeposits(loanId, threshold) {
+  const params = new URLSearchParams();
+  if (threshold !== undefined) params.append('threshold', threshold);
+  const query = params.toString() ? `?${params}` : '';
+  const response = await fetch(`${API_BASE}/bank-analysis/large-deposits/${loanId}${query}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get NSF and overdraft events for a loan
+ * @param {string} loanId
+ */
+export async function getNsfOverdrafts(loanId) {
+  const response = await fetch(`${API_BASE}/bank-analysis/nsf-overdrafts/${loanId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get undisclosed debt indicators for a loan
+ * @param {string} loanId
+ */
+export async function getUndisclosedDebts(loanId) {
+  const response = await fetch(`${API_BASE}/bank-analysis/undisclosed-debts/${loanId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get IRS payment activity for a loan
+ * @param {string} loanId
+ */
+export async function getIrsPayments(loanId) {
+  const response = await fetch(`${API_BASE}/bank-analysis/irs-payments/${loanId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get bank analysis risk score for a loan
+ * @param {string} loanId
+ */
+export async function getRiskScore(loanId) {
+  const response = await fetch(`${API_BASE}/bank-analysis/risk-score/${loanId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get bank analysis summary for a loan
+ * @param {string} loanId
+ */
+export async function getBankSummary(loanId) {
+  const response = await fetch(`${API_BASE}/bank-analysis/summary/${loanId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Source a specific deposit (document its origin)
+ * @param {string} depositId
+ * @param {Object} sourcing - Sourcing details
+ */
+export async function sourceDeposit(depositId, sourcing) {
+  const response = await fetch(`${API_BASE}/bank-analysis/source-deposit/${depositId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(sourcing),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Export all functions
+// =============================================================================
+
+export const docBankAnalysisAPI = {
+  analyzeBankStatement,
+  getLargeDeposits,
+  getNsfOverdrafts,
+  getUndisclosedDebts,
+  getIrsPayments,
+  getRiskScore,
+  getBankSummary,
+  sourceDeposit,
+};
+
+export default docBankAnalysisAPI;

--- a/frontend/src/services/docIncomeApi.js
+++ b/frontend/src/services/docIncomeApi.js
@@ -1,0 +1,145 @@
+/**
+ * Document Income API Service
+ *
+ * Client-side API functions for income calculation, history, source management,
+ * and approval workflows.
+ */
+import { API_BASE_URL } from './api';
+
+const API_BASE = `${API_BASE_URL}/api/v1/smart-docs`;
+
+/**
+ * Helper to handle API responses
+ */
+async function handleResponse(response) {
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: 'Request failed' }));
+    throw new Error(error.detail || `HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Get auth headers (assumes token in localStorage)
+ */
+function getHeaders() {
+  const token = localStorage.getItem('token');
+  return {
+    'Authorization': token ? `Bearer ${token}` : '',
+    'Content-Type': 'application/json',
+  };
+}
+
+// =============================================================================
+// Income Calculation
+// =============================================================================
+
+/**
+ * Calculate income for a loan
+ * @param {string} loanId
+ * @param {Object} [options={}] - Calculation options
+ */
+export async function calculateIncome(loanId, options = {}) {
+  const response = await fetch(`${API_BASE}/income/calculate/${loanId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(options),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get income calculation history for a loan
+ * @param {string} loanId
+ */
+export async function getIncomeHistory(loanId) {
+  const response = await fetch(`${API_BASE}/income/history/${loanId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get income sources for a loan
+ * @param {string} loanId
+ */
+export async function getIncomeSources(loanId) {
+  const response = await fetch(`${API_BASE}/income/sources/${loanId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Override an income source value
+ * @param {string} sourceId
+ * @param {Object} override - Override details
+ */
+export async function overrideSource(sourceId, override) {
+  const response = await fetch(`${API_BASE}/income/sources/${sourceId}/override`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(override),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Income Approval Workflow
+// =============================================================================
+
+/**
+ * Submit income calculation for approval
+ * @param {string} loanId
+ */
+export async function submitForApproval(loanId) {
+  const response = await fetch(`${API_BASE}/income/submit/${loanId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Approve income calculation
+ * @param {string} loanId
+ * @param {string} [notes] - Optional approval notes
+ */
+export async function approveIncome(loanId, notes) {
+  const response = await fetch(`${API_BASE}/income/approve/${loanId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify({ notes }),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Reject income calculation
+ * @param {string} loanId
+ * @param {string} reason - Rejection reason
+ */
+export async function rejectIncome(loanId, reason) {
+  const response = await fetch(`${API_BASE}/income/reject/${loanId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify({ reason }),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Export all functions
+// =============================================================================
+
+export const docIncomeAPI = {
+  calculateIncome,
+  getIncomeHistory,
+  getIncomeSources,
+  overrideSource,
+  submitForApproval,
+  approveIncome,
+  rejectIncome,
+};
+
+export default docIncomeAPI;

--- a/frontend/src/services/docReviewApi.js
+++ b/frontend/src/services/docReviewApi.js
@@ -1,0 +1,254 @@
+/**
+ * Document Review Queue API Service
+ *
+ * Client-side API functions for the AI document review and review queue system.
+ * Wraps 13 endpoints under /api/v1/smart-docs/doc-review/*
+ */
+import { API_BASE_URL } from './api';
+
+const API_BASE = `${API_BASE_URL}/api/v1/smart-docs/doc-review`;
+
+/**
+ * Handle API responses — parse JSON, throw on error using `detail` field.
+ */
+async function handleResponse(response) {
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: 'Request failed' }));
+    throw new Error(error.detail || `HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Build standard auth + content-type headers.
+ */
+function getHeaders() {
+  const token = localStorage.getItem('token');
+  return {
+    'Authorization': token ? `Bearer ${token}` : '',
+    'Content-Type': 'application/json',
+  };
+}
+
+// =============================================================================
+// Queue
+// =============================================================================
+
+/**
+ * Get the review queue, with optional filters.
+ *
+ * @param {object} opts
+ * @param {string} [opts.priority]  - Filter by priority: CRITICAL, HIGH, NORMAL, LOW
+ * @param {string} [opts.docType]   - Filter by document type
+ * @param {number} [opts.limit=50]  - Max items to return
+ * @param {number} [opts.offset=0]  - Pagination offset
+ */
+export async function getQueue({ priority, docType, limit = 50, offset = 0 } = {}) {
+  const params = new URLSearchParams({ limit, offset });
+  if (priority) params.append('priority', priority);
+  if (docType) params.append('doc_type', docType);
+
+  const response = await fetch(`${API_BASE}/queue?${params}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get review queue statistics for the current user's organization.
+ */
+export async function getQueueStats() {
+  const response = await fetch(`${API_BASE}/queue/stats`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Claim a document for review (prevents double-claiming).
+ *
+ * @param {number|string} documentId
+ * @param {string} [reviewerId]  - Optional reviewer ID (sent in request body)
+ */
+export async function claimDocument(documentId, reviewerId) {
+  const body = reviewerId ? JSON.stringify({ reviewer_id: reviewerId }) : JSON.stringify({});
+  const response = await fetch(`${API_BASE}/queue/${documentId}/claim`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body,
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Release a claimed document back to the review queue.
+ *
+ * @param {number|string} documentId
+ */
+export async function releaseDocument(documentId) {
+  const response = await fetch(`${API_BASE}/queue/${documentId}/release`, {
+    method: 'POST',
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// AI Review
+// =============================================================================
+
+/**
+ * Trigger AI review of a single document.
+ *
+ * @param {number|string} documentId
+ */
+export async function aiReview(documentId) {
+  const response = await fetch(`${API_BASE}/ai-review/${documentId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Batch AI review all unreviewed documents for a loan.
+ *
+ * @param {number|string} loanId
+ * @param {object} [options={}]  - Additional options sent in request body
+ */
+export async function batchAiReview(loanId, options = {}) {
+  const response = await fetch(`${API_BASE}/ai-review/batch/${loanId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(options),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Cross-Validation
+// =============================================================================
+
+/**
+ * Run cross-document consistency validation for a loan.
+ *
+ * @param {number|string} loanId
+ */
+export async function crossValidate(loanId) {
+  const response = await fetch(`${API_BASE}/cross-validate/${loanId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Review History
+// =============================================================================
+
+/**
+ * Get the review history for a document.
+ *
+ * @param {number|string} documentId
+ */
+export async function getReviewHistory(documentId) {
+  const response = await fetch(`${API_BASE}/document/${documentId}/review-history`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Auto-Review Settings
+// =============================================================================
+
+/**
+ * Get the auto-review settings for the current organization.
+ */
+export async function getAutoReviewSettings() {
+  const response = await fetch(`${API_BASE}/auto-review-settings`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Update auto-review settings.
+ *
+ * @param {object} settings  - Settings object (e.g. auto_approve_threshold, enabled_checks)
+ */
+export async function updateAutoReviewSettings(settings) {
+  const response = await fetch(`${API_BASE}/auto-review-settings`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(settings),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Stats & Completeness
+// =============================================================================
+
+/**
+ * Get review statistics over the given number of days.
+ *
+ * @param {number} [days=30]
+ */
+export async function getReviewStats(days = 30) {
+  const response = await fetch(`${API_BASE}/stats?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get document completeness for a loan.
+ *
+ * @param {number|string} loanId
+ */
+export async function getLoanCompleteness(loanId) {
+  const response = await fetch(`${API_BASE}/loan/${loanId}/completeness`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// AI Extract and Review
+// =============================================================================
+
+/**
+ * Run AI extraction and review on a document in a single call.
+ *
+ * @param {number|string} documentId
+ */
+export async function aiExtractAndReview(documentId) {
+  const response = await fetch(`${API_BASE}/document/${documentId}/ai-extract-and-review`, {
+    method: 'POST',
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Default export — all functions as properties of a single object
+// =============================================================================
+
+const docReviewApi = {
+  getQueue,
+  getQueueStats,
+  claimDocument,
+  releaseDocument,
+  aiReview,
+  batchAiReview,
+  crossValidate,
+  getReviewHistory,
+  getAutoReviewSettings,
+  updateAutoReviewSettings,
+  getReviewStats,
+  getLoanCompleteness,
+  aiExtractAndReview,
+};
+
+export default docReviewApi;

--- a/frontend/src/services/docSecurityApi.js
+++ b/frontend/src/services/docSecurityApi.js
@@ -1,0 +1,300 @@
+/**
+ * Document Security API Service
+ *
+ * Client-side API functions for document security, audit logging, integrity
+ * checks, fraud analysis, retention policies, watermarking, and encryption.
+ */
+import { API_BASE_URL } from './api';
+
+const API_BASE = `${API_BASE_URL}/api/v1/smart-docs`;
+
+/**
+ * Helper to handle API responses
+ */
+async function handleResponse(response) {
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: 'Request failed' }));
+    throw new Error(error.detail || `HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Get auth headers (assumes token in localStorage)
+ */
+function getHeaders() {
+  const token = localStorage.getItem('token');
+  return {
+    'Authorization': token ? `Bearer ${token}` : '',
+    'Content-Type': 'application/json',
+  };
+}
+
+// =============================================================================
+// Audit Log
+// =============================================================================
+
+/**
+ * Get audit log entries with optional filters
+ * @param {Object} params
+ * @param {number} [params.days=30]
+ * @param {string} [params.documentId]
+ * @param {string} [params.action]
+ * @param {number} [params.limit=100]
+ * @param {number} [params.offset=0]
+ */
+export async function getAuditLog({ days = 30, documentId, action, limit = 100, offset = 0 } = {}) {
+  const params = new URLSearchParams({ days, limit, offset });
+  if (documentId) params.append('document_id', documentId);
+  if (action) params.append('action', action);
+
+  const response = await fetch(`${API_BASE}/doc-security/audit-log?${params}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get audit log for a specific document
+ * @param {string} documentId
+ */
+export async function getDocumentAuditLog(documentId) {
+  const response = await fetch(`${API_BASE}/doc-security/audit-log/${documentId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Log an access event for a document
+ * @param {string} documentId
+ * @param {string} action
+ * @param {string} [details='']
+ */
+export async function logAccess(documentId, action, details = '') {
+  const response = await fetch(`${API_BASE}/doc-security/log-access`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify({ document_id: documentId, action, details }),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Integrity Checks
+// =============================================================================
+
+/**
+ * Run an integrity check on a document
+ * @param {string} documentId
+ */
+export async function checkIntegrity(documentId) {
+  const response = await fetch(`${API_BASE}/doc-security/integrity-check/${documentId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Run integrity checks on multiple documents
+ * @param {string[]} documentIds
+ */
+export async function batchIntegrityCheck(documentIds) {
+  const response = await fetch(`${API_BASE}/doc-security/integrity-check/batch`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify({ document_ids: documentIds }),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get integrity check history for a document
+ * @param {string} documentId
+ */
+export async function getIntegrityHistory(documentId) {
+  const response = await fetch(`${API_BASE}/doc-security/integrity-history/${documentId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Fraud Analysis
+// =============================================================================
+
+/**
+ * Get fraud analysis for a loan
+ * @param {string} loanId
+ */
+export async function getFraudAnalysis(loanId) {
+  const response = await fetch(`${API_BASE}/doc-security/fraud-analysis/${loanId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get fraud summary for a loan (or overall if no loanId)
+ * @param {string} [loanId]
+ */
+export async function getFraudSummary(loanId) {
+  const url = loanId
+    ? `${API_BASE}/doc-security/fraud/${loanId}/summary`
+    : `${API_BASE}/doc-security/fraud-summary`;
+  const response = await fetch(url, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Retention Policies
+// =============================================================================
+
+/**
+ * Get all retention policies
+ */
+export async function getRetentionPolicies() {
+  const response = await fetch(`${API_BASE}/doc-security/retention-policies`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Create a new retention policy
+ * @param {Object} policy
+ */
+export async function createRetentionPolicy(policy) {
+  const response = await fetch(`${API_BASE}/doc-security/retention-policies`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(policy),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Update an existing retention policy
+ * @param {string} policyId
+ * @param {Object} policy
+ */
+export async function updateRetentionPolicy(policyId, policy) {
+  const response = await fetch(`${API_BASE}/doc-security/retention-policies/${policyId}`, {
+    method: 'PUT',
+    headers: getHeaders(),
+    body: JSON.stringify(policy),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get documents with expiring retentions
+ * @param {number} [days=30]
+ */
+export async function getExpiringRetentions(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-security/retention-expiring?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Watermarking & Encryption
+// =============================================================================
+
+/**
+ * Watermark a document
+ * @param {string} documentId
+ * @param {Object} [options={}]
+ */
+export async function watermarkDocument(documentId, options = {}) {
+  const response = await fetch(`${API_BASE}/doc-security/watermark/${documentId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify(options),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get encryption status of a document
+ * @param {string} documentId
+ */
+export async function getEncryptionStatus(documentId) {
+  const response = await fetch(`${API_BASE}/doc-security/encryption-status/${documentId}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Encrypt a document
+ * @param {string} documentId
+ */
+export async function encryptDocument(documentId) {
+  const response = await fetch(`${API_BASE}/doc-security/encrypt/${documentId}`, {
+    method: 'POST',
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Compliance & Suspicious Activity
+// =============================================================================
+
+/**
+ * Get compliance report
+ * @param {number} [days=30]
+ */
+export async function getComplianceReport(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-security/compliance-report?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+/**
+ * Get suspicious activity report
+ * @param {number} [days=30]
+ */
+export async function getSuspiciousActivity(days = 30) {
+  const response = await fetch(`${API_BASE}/doc-security/suspicious-activity?days=${days}`, {
+    headers: getHeaders(),
+  });
+  return handleResponse(response);
+}
+
+// =============================================================================
+// Export all functions
+// =============================================================================
+
+export const docSecurityAPI = {
+  // Audit Log
+  getAuditLog,
+  getDocumentAuditLog,
+  logAccess,
+  // Integrity
+  checkIntegrity,
+  batchIntegrityCheck,
+  getIntegrityHistory,
+  // Fraud
+  getFraudAnalysis,
+  getFraudSummary,
+  // Retention
+  getRetentionPolicies,
+  createRetentionPolicy,
+  updateRetentionPolicy,
+  getExpiringRetentions,
+  // Watermark & Encryption
+  watermarkDocument,
+  getEncryptionStatus,
+  encryptDocument,
+  // Compliance
+  getComplianceReport,
+  getSuspiciousActivity,
+};
+
+export default docSecurityAPI;


### PR DESCRIPTION
## Summary

- **Smart Docs Enterprise Pages**: Review queue, bank statement analysis, income worksheet, security/compliance admin, analytics dashboard — all with maker-checker approval workflows
- **50-State Disclosure Database**: 239 seed entries across 51 jurisdictions replacing hardcoded 4-state dict, with admin CRUD and backward-compatible fallback
- **White-Label Email Briefings**: Morning briefing emails now inject per-org branding (logo, colors, company name) from WhiteLabelConfig
- **Aria CSS Polish**: Calculator and Calendar pages wired to `--aria-*` CSS variable system for white-label theming; WCAG 2.1 AA touch target fixes
- **Production Monitoring**: `/ready` health endpoint alias, comprehensive monitoring runbook with DataDog/Sentry thresholds and escalation procedures
- **Voice State Machine**: Tool handler rewired to state machine pattern
- **MorningBriefingCard**: Rich UI restored with collapsible sections

## Files Changed (49 files, +10,558 / -137)

### Backend
- `database/models/state_disclosure.py` — New StateDisclosure model
- `database/seed_state_disclosures.py` — 239 entries across 50 states + DC
- `routes/state_disclosure_routes.py` — Admin CRUD endpoints
- `agents/tools/compliance.py` — DB-first state requirements with fallback
- `templates/morning_briefing_email.py` — White-label branding injection
- `tasks/morning_briefing_tasks.py` — WhiteLabelConfig loading for emails
- `routes/health_routes.py` — `/ready` alias endpoint

### Frontend
- 6 Smart Docs pages with CSS + service layers + hooks
- 5 reusable Smart Docs components
- 8 test files (hooks, services, components)
- Aria CSS variable system applied to Calculator + Calendar

### Docs
- `docs/monitoring-runbook.md` — Operational monitoring guide

## Test plan
- [ ] Smart Docs pages render without errors
- [ ] State disclosure admin endpoints return correct data
- [ ] Morning briefing emails show org branding when WhiteLabelConfig exists
- [ ] Morning briefing emails show default Perennia branding when no config
- [ ] `/ready` endpoint returns 200 with health data
- [ ] Aria Calculator/Calendar pages render unchanged (CSS variables have matching fallbacks)
- [ ] Frontend tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)