### PR TITLE
feat: Platform completion P4 — white-labeling, custom domains, load testing

### DIFF
--- a/backend/database/models/white_label_config.py
+++ b/backend/database/models/white_label_config.py
@@ -92,6 +92,10 @@ class WhiteLabelConfig(Base):
 
     # --- Custom domain ---
     custom_domain = Column(String(255))  # Custom portal domain
+    ssl_status = Column(String(20), default="pending")  # pending, provisioning, active, failed
+    domain_verified = Column(Boolean, default=False)
+    domain_verification_token = Column(String(100))  # DNS TXT record value for verification
+    vercel_domain_id = Column(String(100))  # Vercel API domain ID for management
 
     # --- Status ---
     is_active = Column(Boolean, default=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1623,6 +1623,20 @@ except Exception as e:
     logger.warning(f"API V2 routes skipped: {e}")
 
 # ============================================================================
+# APP BRANDING ROUTES (per-org white-label config for the main React app)
+# ============================================================================
+try:
+    from routes.branding_routes import register_branding_routes
+    register_branding_routes(
+        app=app,
+        get_db_func=get_db,
+        get_current_user_flexible=get_current_user_flexible,
+    )
+    logger.info("App branding routes loaded")
+except Exception as e:
+    logger.warning(f"App branding routes skipped: {e}")
+
+# ============================================================================
 # DB MIGRATION ROUTES
 # DISABLED: Schema mutations must not be exposed via HTTP (security audit March 2026)
 # ============================================================================

--- a/backend/main.py
+++ b/backend/main.py
@@ -1637,6 +1637,20 @@ except Exception as e:
     logger.warning(f"App branding routes skipped: {e}")
 
 # ============================================================================
+# CUSTOM DOMAIN MANAGEMENT ROUTES
+# ============================================================================
+try:
+    from routes.custom_domain_routes import register_custom_domain_routes
+    register_custom_domain_routes(
+        app=app,
+        get_db_func=get_db,
+        get_current_user_flexible=get_current_user_flexible,
+    )
+    logger.info("Custom domain routes loaded")
+except Exception as e:
+    logger.warning(f"Custom domain routes skipped: {e}")
+
+# ============================================================================
 # DB MIGRATION ROUTES
 # DISABLED: Schema mutations must not be exposed via HTTP (security audit March 2026)
 # ============================================================================

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -90,6 +90,7 @@ factory-boy>=3.3.0
 faker>=22.0.0
 responses>=0.24.0
 freezegun>=1.2.0
+locust  # Load testing — dev dependency
 
 # Production Monitoring
 sentry-sdk[fastapi]>=1.38.0

--- a/backend/routes/branding_routes.py
+++ b/backend/routes/branding_routes.py
@@ -1,0 +1,94 @@
+"""
+App Branding Routes
+
+Provides the per-organization branding configuration to the main React app.
+The frontend BrandingProvider fetches this once on login and applies CSS
+custom properties, updates the favicon, and replaces hardcoded brand text.
+
+Endpoint (registered via register_branding_routes):
+  GET /api/v1/branding  — Returns org's WhiteLabelConfig or sensible defaults
+"""
+
+import logging
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# Default branding — returned when no WhiteLabelConfig exists for the org
+_DEFAULTS = {
+    "company_name": "Perennia AI",
+    "logo_url": None,
+    "favicon_url": None,
+    "primary_color": "#218d8d",
+    "secondary_color": "#7c3aed",
+    "accent_color": "#059669",
+    "header_bg_color": "#ffffff",
+    "font_family": "Inter, sans-serif",
+}
+
+
+def register_branding_routes(app, get_db_func, get_current_user_flexible):
+    """Register branding routes with the FastAPI app.
+
+    Called from main.py during startup. Receives auth/db dependencies as
+    arguments so we never import from main at module load time (avoids
+    circular imports).
+
+    Endpoint:
+      GET /api/v1/branding
+        - Requires JWT auth via get_current_user_flexible
+        - Returns org's WhiteLabelConfig or _DEFAULTS if none found
+        - Catches all exceptions (including missing table) and returns defaults
+    """
+    from fastapi import Depends
+
+    @app.get("/api/v1/branding", tags=["App Branding"])
+    async def get_app_branding(
+        db: Session = Depends(get_db_func),
+        current_user=Depends(get_current_user_flexible),
+    ):
+        """Return the authenticated user's org branding config.
+
+        Returns WhiteLabelConfig if one exists for the org (is_active=True),
+        otherwise returns Perennia AI defaults so the app renders correctly
+        for all orgs, including those without a white-label config.
+        """
+        organization_id = getattr(current_user, "organization_id", None)
+
+        if organization_id is None:
+            return _DEFAULTS.copy()
+
+        try:
+            from database.models.white_label_config import WhiteLabelConfig
+
+            config = (
+                db.query(WhiteLabelConfig)
+                .filter(
+                    WhiteLabelConfig.organization_id == organization_id,
+                    WhiteLabelConfig.is_active == True,
+                )
+                .first()
+            )
+
+            if config is None:
+                return _DEFAULTS.copy()
+
+            return {
+                "company_name": config.company_name or _DEFAULTS["company_name"],
+                "logo_url": config.logo_url,
+                "favicon_url": config.favicon_url,
+                "primary_color": config.primary_color or _DEFAULTS["primary_color"],
+                "secondary_color": config.secondary_color or _DEFAULTS["secondary_color"],
+                "accent_color": config.accent_color or _DEFAULTS["accent_color"],
+                "header_bg_color": config.header_bg_color or _DEFAULTS["header_bg_color"],
+                "font_family": config.font_family or _DEFAULTS["font_family"],
+            }
+
+        except Exception as e:
+            # Table may not exist yet in some environments — return defaults
+            logger.warning(
+                "Could not fetch WhiteLabelConfig for org %s: %s",
+                organization_id,
+                e,
+            )
+            return _DEFAULTS.copy()

--- a/backend/routes/custom_domain_routes.py
+++ b/backend/routes/custom_domain_routes.py
@@ -1,513 +1,409 @@
 """
-Custom Domain Routes
+Custom Domain SSL Routes — White-Label Portal Domains
 
-API endpoints for managing custom domains.
-Allows admins to add, remove, verify, and list custom domains.
+API endpoints for enterprise custom-domain provisioning. Stores domain state
+in WhiteLabelConfig (smart_docs_white_label_configs table) and optionally
+integrates with Vercel for automatic SSL cert issuance.
 
-Verification Flow:
-1. User adds domain via POST /api/admin/domains
-2. System generates verification token
-3. User adds TXT record to their DNS
-4. User calls POST /api/admin/domains/{domain}/verify-dns
-5. System checks TXT record and DNS configuration
-6. Domain is marked as verified if all checks pass
+Flow:
+  1. POST  /api/v1/admin/custom-domain/setup   — Register domain, get TXT token
+  2. Add TXT DNS record at registrar
+  3. POST  /api/v1/admin/custom-domain/verify   — DNS lookup; marks verified, calls Vercel
+  4. GET   /api/v1/admin/custom-domain/status   — Poll SSL status
+  5. DELETE /api/v1/admin/custom-domain          — Remove domain and revoke Vercel entry
+
+Registered via register_custom_domain_routes(app, get_db_func, get_current_user_flexible)
+from main.py — never imported at module load time to avoid circular imports.
+
+Requires admin / site_admin / platform_admin permission role.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
-from typing import Optional, List, Dict, Any
-from datetime import datetime
+import logging
+import uuid
 
-from database import get_db
-from sqlalchemy.orm import Session
-from sqlalchemy.exc import SQLAlchemyError
+logger = logging.getLogger(__name__)
+
+_ADMIN_ROLES = {"admin", "site_admin", "platform_admin"}
 
 
-def _get_current_user():
-    """Lazy import to avoid circular imports."""
-    import main
-    return main.get_current_user
+def register_custom_domain_routes(app, get_db_func, get_current_user_flexible):
+    """Register custom-domain endpoints with the FastAPI app.
 
+    Called from main.py during startup. All auth/DB dependencies are received
+    as arguments — no module-level imports from main.py.
 
-router = APIRouter(
-    prefix="/api/admin/domains",
-    tags=["Custom Domains"],
-    dependencies=[Depends(_get_current_user())],
-)
-
-
-# ============================================================================
-# Schemas
-# ============================================================================
-
-class DomainCreate(BaseModel):
-    domain: str  # e.g., "www.timloss.com" (without https://)
-    organization_id: Optional[int] = None
-    user_id: Optional[int] = None
-    notes: Optional[str] = None
-
-
-class DomainResponse(BaseModel):
-    id: int
-    domain: str
-    is_verified: bool
-    is_active: bool
-    ssl_status: str
-    verification_token: Optional[str] = None
-    organization_id: Optional[int]
-    user_id: Optional[int]
-    created_at: Optional[str]
-    verified_at: Optional[str] = None
-
-    class Config:
-        from_attributes = True
-
-
-class DomainListResponse(BaseModel):
-    domains: List[DomainResponse]
-    total: int
-
-
-class VerificationInstructions(BaseModel):
-    domain: str
-    verification_token: str
-    txt_record_name: str
-    txt_record_value: str
-    cname_target: str
-    a_record_ip: str
-    instructions: List[str]
-
-
-class VerificationResult(BaseModel):
-    domain: str
-    fully_verified: bool
-    ownership_verified: bool
-    dns_configured: bool
-    txt_verification: Dict[str, Any]
-    dns_verification: Dict[str, Any]
-    next_steps: List[Dict[str, Any]]
-
-
-# ============================================================================
-# Endpoints
-# ============================================================================
-
-@router.get("", response_model=DomainListResponse)
-async def list_domains(db: Session = Depends(get_db)):
+    Startup side-effect: runs ADD COLUMN IF NOT EXISTS migrations for the four
+    new SSL columns on smart_docs_white_label_configs.
     """
-    List all custom domains.
-
-    Returns all configured custom domains with their status.
-    """
-    try:
-        from services.custom_domain_service import get_domain_service
-        service = get_domain_service()
-        domains = service.list_domains()
-
-        return {
-            "domains": domains,
-            "total": len(domains)
-        }
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list domains"
-        )
-
-
-@router.post("", response_model=DomainResponse)
-async def add_domain(
-    domain_data: DomainCreate,
-    db: Session = Depends(get_db)
-):
-    """
-    Add a new custom domain.
-
-    This creates the domain entry with a verification token.
-    The domain is NOT immediately active - it must be verified first.
-
-    Steps after adding:
-    1. Get verification instructions via GET /api/admin/domains/{domain}/verification-instructions
-    2. Add TXT record to your DNS
-    3. Configure CNAME or A record
-    4. Verify via POST /api/admin/domains/{domain}/verify-dns
-    """
+    from fastapi import Depends, HTTPException, status
+    from pydantic import BaseModel
+    from sqlalchemy.orm import Session
     from sqlalchemy import text
-    from services.dns_verification_service import dns_verification_service
 
-    # Clean domain (remove protocol if provided)
-    domain = domain_data.domain.lower().strip()
-    if domain.startswith("https://"):
-        domain = domain[8:]
-    if domain.startswith("http://"):
-        domain = domain[7:]
-
+    # ------------------------------------------------------------------ #
+    # Startup migration — idempotent, safe to run on every deploy          #
+    # ------------------------------------------------------------------ #
     try:
-        # Check if already exists
-        existing = db.execute(text(
-            "SELECT id FROM custom_domains WHERE domain = :domain"
-        ), {"domain": domain}).fetchone()
-
-        if existing:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"Domain {domain} already exists"
+        db_gen = get_db_func()
+        db = next(db_gen)
+        for col, col_type, default in [
+            ("ssl_status", "VARCHAR(20)", "'pending'"),
+            ("domain_verified", "BOOLEAN", "FALSE"),
+            ("domain_verification_token", "VARCHAR(100)", "NULL"),
+            ("vercel_domain_id", "VARCHAR(100)", "NULL"),
+        ]:
+            db.execute(
+                text(
+                    f"ALTER TABLE smart_docs_white_label_configs "
+                    f"ADD COLUMN IF NOT EXISTS {col} {col_type} DEFAULT {default}"
+                )
             )
-
-        # Generate verification token
-        verification_token = dns_verification_service.generate_verification_token(domain)
-
-        # Insert new domain with verification token (not verified yet)
-        db.execute(text("""
-            INSERT INTO custom_domains
-            (domain, user_id, organization_id, is_active, is_verified, verification_token, notes, created_at)
-            VALUES (:domain, :user_id, :org_id, true, false, :token, :notes, CURRENT_TIMESTAMP)
-        """), {
-            "domain": domain,
-            "user_id": domain_data.user_id,
-            "org_id": domain_data.organization_id,
-            "token": verification_token,
-            "notes": domain_data.notes
-        })
         db.commit()
+        logger.info("Custom domain columns migrated on smart_docs_white_label_configs")
+    except Exception as exc:
+        logger.warning("Custom domain column migration skipped: %s", exc)
 
-        # Get the inserted domain
-        result = db.execute(text("""
-            SELECT id, domain, is_verified, is_active, ssl_status, verification_token,
-                   organization_id, user_id, created_at, verified_at
-            FROM custom_domains WHERE domain = :domain
-        """), {"domain": domain}).fetchone()
+    # ------------------------------------------------------------------ #
+    # Pydantic schemas                                                      #
+    # ------------------------------------------------------------------ #
 
-        return {
-            "id": result[0],
-            "domain": result[1],
-            "is_verified": result[2],
-            "is_active": result[3],
-            "ssl_status": result[4],
-            "verification_token": result[5],
-            "organization_id": result[6],
-            "user_id": result[7],
-            "created_at": result[8].isoformat() if result[8] else None,
-            "verified_at": result[9].isoformat() if result[9] else None
-        }
+    class DomainSetupRequest(BaseModel):
+        domain: str  # e.g. "portal.acmemortgage.com"
 
-    except HTTPException:
-        raise
-    except Exception as e:
-        db.rollback()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to add domain"
-        )
+    # ------------------------------------------------------------------ #
+    # Helpers                                                               #
+    # ------------------------------------------------------------------ #
 
-
-@router.delete("/{domain}")
-async def remove_domain(domain: str, db: Session = Depends(get_db)):
-    """
-    Remove (deactivate) a custom domain.
-
-    The domain will no longer be allowed for CORS.
-    """
-    try:
-        from services.custom_domain_service import get_domain_service
-        service = get_domain_service()
-
-        success = service.remove_domain(domain)
-
-        if not success:
+    def _require_admin(current_user):
+        role = getattr(current_user, "permission_role", None) or ""
+        if role not in _ADMIN_ROLES:
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Domain {domain} not found"
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin role required for custom domain management.",
             )
 
-        return {"success": True, "message": f"Domain {domain} deactivated"}
+    def _get_white_label_config(db: Session, organization_id: int):
+        """Return the org's WhiteLabelConfig row or None."""
+        from database.models.white_label_config import WhiteLabelConfig
 
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to remove domain"
+        return (
+            db.query(WhiteLabelConfig)
+            .filter(
+                WhiteLabelConfig.organization_id == organization_id,
+                WhiteLabelConfig.is_active == True,
+            )
+            .first()
         )
 
+    def _clean_domain(raw: str) -> str:
+        """Strip protocol prefix and lowercase."""
+        domain = raw.lower().strip()
+        for prefix in ("https://", "http://"):
+            if domain.startswith(prefix):
+                domain = domain[len(prefix):]
+        return domain.rstrip("/")
 
-@router.get("/{domain}/verification-instructions", response_model=VerificationInstructions)
-async def get_verification_instructions(domain: str, db: Session = Depends(get_db)):
-    """
-    Get DNS verification instructions for a domain.
+    # ------------------------------------------------------------------ #
+    # POST /api/v1/admin/custom-domain/setup                               #
+    # ------------------------------------------------------------------ #
 
-    Returns the TXT record and CNAME/A record configuration needed
-    to verify domain ownership and configure routing.
-    """
-    from sqlalchemy import text
-    from services.dns_verification_service import dns_verification_service
+    @app.post("/api/v1/admin/custom-domain/setup", tags=["Custom Domain SSL"])
+    async def setup_custom_domain(
+        body: DomainSetupRequest,
+        db: Session = Depends(get_db_func),
+        current_user=Depends(get_current_user_flexible),
+    ):
+        """Initiate custom-domain setup for the caller's organisation.
 
-    try:
-        # Get domain and verification token
-        result = db.execute(text("""
-            SELECT domain, verification_token, is_verified
-            FROM custom_domains
-            WHERE domain = :domain
-        """), {"domain": domain}).fetchone()
+        Generates a verification token (UUID-based TXT record value), stores it
+        alongside the domain in WhiteLabelConfig, and returns DNS instructions.
 
-        if not result:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Domain {domain} not found"
-            )
+        The caller must:
+        1. Create a DNS TXT record ``_perennia-verify.<domain>`` with the
+           returned ``verification_token`` value.
+        2. Create a DNS CNAME record pointing the domain to
+           ``cname.vercel-dns.com``.
+        3. Call POST /api/v1/admin/custom-domain/verify once DNS has propagated.
+        """
+        _require_admin(current_user)
 
-        domain_name = result[0]
-        verification_token = result[1]
-        is_verified = result[2]
-
-        # If no token exists, generate one
-        if not verification_token:
-            verification_token = dns_verification_service.generate_verification_token(domain_name)
-            db.execute(text("""
-                UPDATE custom_domains
-                SET verification_token = :token
-                WHERE domain = :domain
-            """), {"token": verification_token, "domain": domain_name})
-            db.commit()
-
-        txt_record_name = dns_verification_service.get_txt_record_name(domain_name)
-
-        instructions = [
-            f"Step 1: Add a TXT record to verify domain ownership",
-            f"   Record Name: {txt_record_name}",
-            f"   Record Value: {verification_token}",
-            f"",
-            f"Step 2: Configure DNS to point to our servers (choose one):",
-            f"   Option A - CNAME Record (recommended):",
-            f"      Name: {domain_name}",
-            f"      Value: {dns_verification_service.EXPECTED_CNAME_TARGETS[0]}",
-            f"",
-            f"   Option B - A Record:",
-            f"      Name: {domain_name}",
-            f"      Value: {dns_verification_service.EXPECTED_A_RECORDS[0]}",
-            f"",
-            f"Step 3: Wait for DNS propagation (up to 48 hours, usually faster)",
-            f"",
-            f"Step 4: Verify your domain at POST /api/admin/domains/{domain_name}/verify-dns"
-        ]
-
-        if is_verified:
-            instructions.insert(0, "✓ This domain is already verified!")
-
-        return {
-            "domain": domain_name,
-            "verification_token": verification_token,
-            "txt_record_name": txt_record_name,
-            "txt_record_value": verification_token,
-            "cname_target": dns_verification_service.EXPECTED_CNAME_TARGETS[0],
-            "a_record_ip": dns_verification_service.EXPECTED_A_RECORDS[0],
-            "instructions": instructions
-        }
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to get verification instructions"
-        )
-
-
-@router.post("/{domain}/verify-dns", response_model=VerificationResult)
-async def verify_domain_dns(domain: str, db: Session = Depends(get_db)):
-    """
-    Perform DNS verification for a domain.
-
-    Checks:
-    1. TXT record for ownership verification
-    2. CNAME or A record for DNS configuration
-
-    If both pass, the domain is marked as verified.
-    """
-    from sqlalchemy import text
-    from services.dns_verification_service import dns_verification_service
-
-    try:
-        # Get domain and verification token
-        result = db.execute(text("""
-            SELECT domain, verification_token, is_verified
-            FROM custom_domains
-            WHERE domain = :domain
-        """), {"domain": domain}).fetchone()
-
-        if not result:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Domain {domain} not found"
-            )
-
-        domain_name = result[0]
-        verification_token = result[1]
-
-        if not verification_token:
+        organization_id = getattr(current_user, "organization_id", None)
+        if organization_id is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="No verification token found. Get instructions first."
+                detail="No organization associated with this user.",
             )
 
-        # Perform full verification
-        verification_result = dns_verification_service.perform_full_verification(
-            domain=domain_name,
-            verification_token=verification_token
-        )
+        domain = _clean_domain(body.domain)
+        if not domain:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Invalid domain value.",
+            )
 
-        # If fully verified, update database
-        if verification_result["fully_verified"]:
-            db.execute(text("""
-                UPDATE custom_domains
-                SET is_verified = true,
-                    verified_at = CURRENT_TIMESTAMP,
-                    ssl_status = 'pending'
-                WHERE domain = :domain
-            """), {"domain": domain_name})
-            db.commit()
+        config = _get_white_label_config(db, organization_id)
+        if config is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    "No active white-label configuration found for your organisation. "
+                    "Create one first via the White-Label settings."
+                ),
+            )
 
-            # Refresh the domain cache
-            from services.custom_domain_service import get_domain_service
-            get_domain_service()._refresh_cache()
+        # Generate a fresh verification token
+        verification_token = f"perennia-verify={uuid.uuid4().hex}"
 
-        return verification_result
-
-    except HTTPException:
-        raise
-    except SQLAlchemyError as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to verify domain"
-        )
-
-
-@router.post("/{domain}/verify")
-async def verify_domain_manual(domain: str, db: Session = Depends(get_db)):
-    """
-    Manually mark a domain as verified (admin override).
-
-    Use this only for domains that have been verified through
-    other means (e.g., direct communication with domain owner).
-    """
-    from sqlalchemy import text
-
-    try:
-        result = db.execute(text("""
-            UPDATE custom_domains
-            SET is_verified = true, verified_at = CURRENT_TIMESTAMP
-            WHERE domain = :domain
-        """), {"domain": domain})
+        config.custom_domain = domain
+        config.domain_verification_token = verification_token
+        config.domain_verified = False
+        config.ssl_status = "pending"
+        config.vercel_domain_id = None
         db.commit()
 
-        if result.rowcount == 0:
+        txt_record_name = f"_perennia-verify.{domain}"
+        return {
+            "domain": domain,
+            "verification_token": verification_token,
+            "dns_instructions": {
+                "txt_record": {
+                    "name": txt_record_name,
+                    "type": "TXT",
+                    "value": verification_token,
+                    "purpose": "Domain ownership verification",
+                },
+                "cname_record": {
+                    "name": domain,
+                    "type": "CNAME",
+                    "value": "cname.vercel-dns.com",
+                    "purpose": "Route traffic to Perennia portal",
+                },
+            },
+            "message": (
+                f"Add the TXT record {txt_record_name} = {verification_token} "
+                "to your DNS, then call /verify."
+            ),
+            "next_step": "POST /api/v1/admin/custom-domain/verify",
+        }
+
+    # ------------------------------------------------------------------ #
+    # POST /api/v1/admin/custom-domain/verify                              #
+    # ------------------------------------------------------------------ #
+
+    @app.post("/api/v1/admin/custom-domain/verify", tags=["Custom Domain SSL"])
+    async def verify_custom_domain(
+        db: Session = Depends(get_db_func),
+        current_user=Depends(get_current_user_flexible),
+    ):
+        """Verify domain ownership via DNS TXT lookup.
+
+        Performs a live DNS query for the TXT record placed by the client. On
+        success:
+        - Sets ``domain_verified = True`` and ``ssl_status = "provisioning"``
+        - Calls Vercel API to add the domain (triggers SSL cert issuance)
+        - Stores the Vercel domain ID for future management
+
+        Vercel integration is best-effort — if VERCEL_TOKEN / VERCEL_PROJECT_ID
+        are not set the domain is still marked verified and manual DNS works.
+        """
+        _require_admin(current_user)
+
+        organization_id = getattr(current_user, "organization_id", None)
+        if organization_id is None:
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Domain {domain} not found"
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No organization associated with this user.",
             )
 
-        # Refresh the domain cache
-        from services.custom_domain_service import get_domain_service
-        get_domain_service()._refresh_cache()
-
-        return {"success": True, "message": f"Domain {domain} manually verified"}
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to verify domain"
-        )
-
-
-@router.get("/{domain}/status")
-async def get_domain_status(domain: str, db: Session = Depends(get_db)):
-    """
-    Get detailed status of a domain including DNS verification status.
-
-    Performs real-time DNS checks to show current configuration.
-    """
-    from sqlalchemy import text
-    from services.dns_verification_service import dns_verification_service
-
-    try:
-        # Get domain from database
-        result = db.execute(text("""
-            SELECT id, domain, is_verified, is_active, ssl_status,
-                   verification_token, verified_at, created_at,
-                   organization_id, user_id
-            FROM custom_domains
-            WHERE domain = :domain
-        """), {"domain": domain}).fetchone()
-
-        if not result:
+        config = _get_white_label_config(db, organization_id)
+        if config is None or not config.custom_domain:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Domain {domain} not found"
+                detail="No custom domain configured. Call /setup first.",
             )
 
-        domain_info = {
-            "id": result[0],
-            "domain": result[1],
-            "is_verified": result[2],
-            "is_active": result[3],
-            "ssl_status": result[4],
-            "verification_token": result[5],
-            "verified_at": result[6].isoformat() if result[6] else None,
-            "created_at": result[7].isoformat() if result[7] else None,
-            "organization_id": result[8],
-            "user_id": result[9]
-        }
+        domain = config.custom_domain
+        expected_token = config.domain_verification_token
 
-        # Perform live DNS checks
-        dns_config = dns_verification_service.verify_dns_configuration(result[1])
-        reachability = dns_verification_service.check_domain_reachability(result[1])
+        if not expected_token:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No verification token found. Call /setup first.",
+            )
 
-        # Check TXT record if we have a token
-        txt_status = None
-        if result[5]:
-            txt_result = dns_verification_service.verify_txt_record(result[1], result[5])
-            txt_status = txt_result.to_dict()
+        # ---- DNS TXT lookup ------------------------------------------ #
+        txt_record_name = f"_perennia-verify.{domain}"
+        verified = False
+        dns_error = None
+
+        try:
+            import dns.resolver  # dnspython
+
+            answers = dns.resolver.resolve(txt_record_name, "TXT")
+            found_values = []
+            for rdata in answers:
+                for string in rdata.strings:
+                    found_values.append(string.decode("utf-8", errors="replace"))
+
+            if expected_token in found_values:
+                verified = True
+            else:
+                dns_error = (
+                    f"TXT record found but value did not match. "
+                    f"Expected '{expected_token}', found: {found_values}"
+                )
+        except Exception as exc:
+            dns_error = f"DNS lookup failed: {exc}"
+
+        if not verified:
+            return {
+                "verified": False,
+                "ssl_status": config.ssl_status,
+                "message": (
+                    dns_error
+                    or "Verification token not found in DNS. Check record and retry."
+                ),
+            }
+
+        # ---- Mark verified ------------------------------------------- #
+        config.domain_verified = True
+        config.ssl_status = "provisioning"
+
+        # ---- Vercel integration (best-effort) ------------------------- #
+        vercel_domain_id = None
+        try:
+            from services import vercel_domain_service
+
+            result = vercel_domain_service.add_domain(domain)
+            # Vercel returns {"name": domain, "apexName": ..., ...} on success
+            if result and not result.get("error") and not result.get("skipped"):
+                vercel_domain_id = result.get("name") or result.get("id") or domain
+                config.ssl_status = "provisioning"
+                logger.info("Vercel domain added: %s -> %s", domain, vercel_domain_id)
+        except Exception as exc:
+            logger.warning("Vercel add_domain failed for %s: %s", domain, exc)
+
+        config.vercel_domain_id = vercel_domain_id
+        db.commit()
 
         return {
-            "domain": domain_info,
-            "dns_configuration": dns_config.to_dict(),
-            "txt_verification": txt_status,
-            "reachability": reachability,
-            "ready_for_traffic": domain_info["is_verified"] and dns_config.success
+            "verified": True,
+            "ssl_status": config.ssl_status,
+            "vercel_domain_id": vercel_domain_id,
+            "message": (
+                "Domain ownership verified. SSL provisioning is underway — "
+                "check /status in a few minutes."
+            ),
         }
 
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to get domain status"
-        )
+    # ------------------------------------------------------------------ #
+    # GET /api/v1/admin/custom-domain/status                               #
+    # ------------------------------------------------------------------ #
 
+    @app.get("/api/v1/admin/custom-domain/status", tags=["Custom Domain SSL"])
+    async def get_custom_domain_status(
+        db: Session = Depends(get_db_func),
+        current_user=Depends(get_current_user_flexible),
+    ):
+        """Return the current custom-domain state for the caller's organisation.
 
-@router.get("/check/{origin}")
-async def check_origin(origin: str):
-    """
-    Check if an origin is allowed (for debugging).
+        If Vercel credentials are present, also polls the Vercel API to refresh
+        the SSL status before returning.
+        """
+        _require_admin(current_user)
 
-    Pass the full origin (e.g., https://www.timloss.com).
-    """
-    try:
-        from services.custom_domain_service import get_domain_service
-        service = get_domain_service()
+        organization_id = getattr(current_user, "organization_id", None)
+        if organization_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No organization associated with this user.",
+            )
 
-        is_allowed = service.is_allowed_origin(origin)
+        config = _get_white_label_config(db, organization_id)
+        if config is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No active white-label configuration found.",
+            )
+
+        if not config.custom_domain:
+            return {
+                "domain": None,
+                "domain_verified": False,
+                "ssl_status": "pending",
+                "vercel_domain_id": None,
+                "message": "No custom domain configured yet.",
+            }
+
+        # Refresh SSL status from Vercel if we have credentials and a domain ID
+        if config.domain_verified and config.custom_domain:
+            try:
+                from services import vercel_domain_service
+
+                live_ssl = vercel_domain_service.check_ssl_status(config.custom_domain)
+                if live_ssl not in ("unknown", config.ssl_status):
+                    config.ssl_status = live_ssl
+                    db.commit()
+            except Exception as exc:
+                logger.warning("Vercel SSL status check failed: %s", exc)
 
         return {
-            "origin": origin,
-            "is_allowed": is_allowed
+            "domain": config.custom_domain,
+            "domain_verified": bool(config.domain_verified),
+            "ssl_status": config.ssl_status or "pending",
+            "vercel_domain_id": config.vercel_domain_id,
+            "verification_token": config.domain_verification_token,
         }
 
-    except Exception as e:
+    # ------------------------------------------------------------------ #
+    # DELETE /api/v1/admin/custom-domain                                   #
+    # ------------------------------------------------------------------ #
+
+    @app.delete("/api/v1/admin/custom-domain", tags=["Custom Domain SSL"])
+    async def remove_custom_domain(
+        db: Session = Depends(get_db_func),
+        current_user=Depends(get_current_user_flexible),
+    ):
+        """Remove the custom domain for the caller's organisation.
+
+        - Calls Vercel API to deregister the domain (best-effort)
+        - Clears all domain columns on WhiteLabelConfig
+        """
+        _require_admin(current_user)
+
+        organization_id = getattr(current_user, "organization_id", None)
+        if organization_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No organization associated with this user.",
+            )
+
+        config = _get_white_label_config(db, organization_id)
+        if config is None or not config.custom_domain:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No custom domain configured.",
+            )
+
+        domain = config.custom_domain
+
+        # Vercel removal (best-effort)
+        try:
+            from services import vercel_domain_service
+
+            vercel_domain_service.remove_domain(domain)
+        except Exception as exc:
+            logger.warning("Vercel remove_domain failed for %s: %s", domain, exc)
+
+        # Clear all domain columns
+        config.custom_domain = None
+        config.ssl_status = "pending"
+        config.domain_verified = False
+        config.domain_verification_token = None
+        config.vercel_domain_id = None
+        db.commit()
+
         return {
-            "origin": origin,
-            "is_allowed": False,
-            "error": "Internal server error"
+            "success": True,
+            "message": f"Custom domain '{domain}' removed successfully.",
         }

--- a/backend/services/vercel_domain_service.py
+++ b/backend/services/vercel_domain_service.py
@@ -1,0 +1,139 @@
+"""
+Vercel Domain Management Service
+
+Manages custom domain provisioning via Vercel API.
+Requires: VERCEL_TOKEN and VERCEL_PROJECT_ID environment variables.
+
+If env vars are not set, all methods return safe no-op defaults and log a
+warning — the rest of the custom-domain flow (DNS verification, DB updates)
+continues unaffected.
+
+API Reference: https://vercel.com/docs/rest-api/endpoints/projects/domains
+"""
+
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_VERCEL_API_BASE = "https://api.vercel.com"
+
+
+def _get_credentials() -> tuple[Optional[str], Optional[str]]:
+    """Return (token, project_id) from env vars, or (None, None) if missing."""
+    token = os.getenv("VERCEL_TOKEN")
+    project_id = os.getenv("VERCEL_PROJECT_ID")
+    if not token or not project_id:
+        logger.warning(
+            "VERCEL_TOKEN or VERCEL_PROJECT_ID not set — Vercel domain "
+            "operations will be skipped (manual DNS-only mode)."
+        )
+        return None, None
+    return token, project_id
+
+
+def _headers(token: str) -> dict:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+
+def add_domain(domain: str) -> dict:
+    """Add a custom domain to the Vercel project.
+
+    POST /v10/projects/{project_id}/domains
+
+    Returns the Vercel API response dict on success, or a dict with
+    ``{"error": "..."}`` on failure / missing credentials.
+    """
+    token, project_id = _get_credentials()
+    if not token:
+        return {"skipped": True, "reason": "Vercel credentials not configured"}
+
+    url = f"{_VERCEL_API_BASE}/v10/projects/{project_id}/domains"
+    try:
+        with httpx.Client(timeout=15) as client:
+            resp = client.post(url, headers=_headers(token), json={"name": domain})
+        if resp.status_code in (200, 201, 409):
+            # 409 = already exists in Vercel — treat as success
+            return resp.json()
+        logger.warning("Vercel add_domain returned %s: %s", resp.status_code, resp.text)
+        return {"error": f"Vercel API error {resp.status_code}", "detail": resp.text}
+    except httpx.RequestError as exc:
+        logger.exception("Vercel add_domain network error for %s", domain)
+        return {"error": str(exc)}
+
+
+def remove_domain(domain: str) -> bool:
+    """Remove a custom domain from the Vercel project.
+
+    DELETE /v10/projects/{project_id}/domains/{domain}
+
+    Returns True on success (including 404 — already gone), False on error.
+    """
+    token, project_id = _get_credentials()
+    if not token:
+        logger.info("Vercel credentials not configured — skipping domain removal for %s", domain)
+        return True  # Treat as success in manual mode
+
+    url = f"{_VERCEL_API_BASE}/v10/projects/{project_id}/domains/{domain}"
+    try:
+        with httpx.Client(timeout=15) as client:
+            resp = client.delete(url, headers=_headers(token))
+        if resp.status_code in (200, 204, 404):
+            return True
+        logger.warning("Vercel remove_domain returned %s: %s", resp.status_code, resp.text)
+        return False
+    except httpx.RequestError:
+        logger.exception("Vercel remove_domain network error for %s", domain)
+        return False
+
+
+def get_domain_config(domain: str) -> dict:
+    """Get Vercel's domain configuration record.
+
+    GET /v6/domains/{domain}/config
+
+    Returns the Vercel config dict, or ``{"error": "..."}`` on failure.
+    """
+    token, _ = _get_credentials()
+    if not token:
+        return {"skipped": True, "reason": "Vercel credentials not configured"}
+
+    url = f"{_VERCEL_API_BASE}/v6/domains/{domain}/config"
+    try:
+        with httpx.Client(timeout=15) as client:
+            resp = client.get(url, headers=_headers(token))
+        if resp.status_code == 200:
+            return resp.json()
+        logger.warning("Vercel get_domain_config returned %s for %s", resp.status_code, domain)
+        return {"error": f"Vercel API error {resp.status_code}"}
+    except httpx.RequestError:
+        logger.exception("Vercel get_domain_config network error for %s", domain)
+        return {"error": "network error"}
+
+
+def check_ssl_status(domain: str) -> str:
+    """Check whether Vercel has provisioned an SSL certificate for the domain.
+
+    Returns one of: ``"active"``, ``"provisioning"``, ``"pending"``, ``"failed"``,
+    or ``"unknown"`` if Vercel is not configured.
+    """
+    config = get_domain_config(domain)
+
+    if config.get("skipped") or config.get("error"):
+        return "unknown"
+
+    # Vercel returns misconfigured=false + certs array when SSL is live
+    misconfigured = config.get("misconfigured", True)
+    certs = config.get("certs", [])
+
+    if not misconfigured and certs:
+        return "active"
+    if not misconfigured:
+        return "provisioning"
+    return "pending"

--- a/backend/tests/load/README.md
+++ b/backend/tests/load/README.md
@@ -1,0 +1,159 @@
+# Perennia AI — Load Test Suite
+
+Locust-based load tests targeting key API endpoints.
+Validates performance of the 47 database indexes added during the enterprise hardening phase.
+
+## Prerequisites
+
+```bash
+pip install locust
+```
+
+Locust requires Python 3.8+. It is already included in `backend/requirements.txt` as a dev dependency.
+
+## Configuration
+
+Authentication is optional. When omitted, only the health-probe endpoints are tested in a meaningful way (all other endpoints will return 401/403, which the suite handles gracefully).
+
+```bash
+export LOCUST_EMAIL="your@email.com"
+export LOCUST_PASSWORD="yourpassword"
+```
+
+## Usage
+
+All commands are run from the `backend/` directory.
+
+### Headless (CI) mode
+
+#### Smoke — quick sanity check (1 minute)
+
+```bash
+locust -f tests/load/locustfile.py \
+  --host=https://api.perenniaai.com \
+  --headless \
+  --users 10 \
+  --spawn-rate 2 \
+  --run-time 1m \
+  --html=tests/load/smoke-report.html
+```
+
+#### Normal — sustained load (5 minutes)
+
+```bash
+locust -f tests/load/locustfile.py \
+  --host=https://api.perenniaai.com \
+  --headless \
+  --users 50 \
+  --spawn-rate 5 \
+  --run-time 5m \
+  --html=tests/load/normal-report.html
+```
+
+#### Stress — peak load (10 minutes)
+
+```bash
+locust -f tests/load/locustfile.py \
+  --host=https://api.perenniaai.com \
+  --headless \
+  --users 200 \
+  --spawn-rate 10 \
+  --run-time 10m \
+  --html=tests/load/stress-report.html
+```
+
+### Interactive (web UI) mode
+
+```bash
+locust -f tests/load/locustfile.py --host=https://api.perenniaai.com
+# Open http://localhost:8089 to configure and start the test
+```
+
+### Local development target
+
+```bash
+locust -f tests/load/locustfile.py --host=http://localhost:8000 --headless --users 10 --spawn-rate 2 --run-time 1m
+```
+
+## User classes and traffic weights
+
+| Class | Weight | Task set | Description |
+|---|---|---|---|
+| `HealthCheckUser` | 1 | `HealthCheckTasks` | `GET /health`, `GET /ready` — no auth required |
+| `PipelineUser` | 5 | `PipelineTasks` | Dashboard, leads, loans, tasks, search — primary LO workflow |
+| `CalendarUser` | 3 | `CalendarTasks` | Calendar events, slots, smart-scheduler availability |
+| `AdminUser` | 1 | `AdminTasks` | Admin user list, compliance dashboard |
+
+With 50 virtual users the weights resolve to approximately: 5 HealthCheck, 25 Pipeline, 15 Calendar, 5 Admin.
+
+## Endpoints under test
+
+| Endpoint | Method | Tag | Slow-warning threshold |
+|---|---|---|---|
+| `/health` | GET | health | 500 ms |
+| `/ready` | GET | health | 500 ms |
+| `/api/v1/dashboard/metrics` | GET | pipeline | 500 ms |
+| `/api/v1/leads?limit=50` | GET | pipeline | 500 ms |
+| `/api/v1/loans?limit=50` | GET | pipeline | 500 ms |
+| `/api/v1/loans?stage=PROCESSING` | GET | pipeline | 500 ms |
+| `/api/v1/tasks` | GET | pipeline | 500 ms |
+| `/api/v1/leads/search` | POST | pipeline | 1 000 ms |
+| `/api/v1/calendar/events` | GET | calendar | 500 ms |
+| `/api/v1/calendar/slots` | GET | calendar | 500 ms |
+| `/api/v1/smart-scheduler/available-slots` | GET | calendar | 500 ms |
+| `/api/v1/admin/users` | GET | admin | 500 ms |
+| `/api/v1/compliance/dashboard` | GET | admin | 500 ms |
+
+## How to read results
+
+After a headless run, open the generated HTML report in your browser. Key columns:
+
+- **RPS** — requests per second; higher is better.
+- **Failures** — any non-2xx/non-expected response that was explicitly marked as failure.
+- **Median / 95%ile / 99%ile** — response time percentiles in milliseconds.
+
+The suite also logs a plain-text summary at the end of each run (visible in `--headless` stdout).
+
+## Target thresholds
+
+| Metric | Warning | Critical |
+|---|---|---|
+| p95 latency (read endpoints) | > 500 ms | > 2 000 ms |
+| p95 latency (write endpoints) | > 1 000 ms | > 3 000 ms |
+| Error rate | > 0.1% | > 1% |
+| Throughput | < 50 RPS | < 20 RPS |
+
+The suite will exit with code `1` when the error rate exceeds the **Critical** threshold (1%).
+Slow-response warnings are logged to stdout but do not cause a non-zero exit — treat them as signals for investigation rather than hard failures.
+
+## Tags
+
+Use `--tags` to run a subset of tasks:
+
+```bash
+# Health probes only
+locust -f tests/load/locustfile.py --host=... --tags health
+
+# Pipeline workflow only
+locust -f tests/load/locustfile.py --host=... --tags pipeline
+
+# Calendar endpoints only
+locust -f tests/load/locustfile.py --host=... --tags calendar
+```
+
+## CI integration
+
+Add the smoke profile to your CI pipeline:
+
+```yaml
+- name: Smoke load test
+  env:
+    LOCUST_EMAIL: ${{ secrets.LOAD_TEST_EMAIL }}
+    LOCUST_PASSWORD: ${{ secrets.LOAD_TEST_PASSWORD }}
+  run: |
+    locust -f backend/tests/load/locustfile.py \
+      --host=${{ env.API_URL }} \
+      --headless --users 10 --spawn-rate 2 --run-time 1m
+```
+
+The non-zero exit code on critical error rate will fail the CI step automatically.

--- a/backend/tests/load/locustfile.py
+++ b/backend/tests/load/locustfile.py
@@ -1,0 +1,412 @@
+"""
+Perennia AI — Locust Load Test Suite
+
+Targets key API endpoints to validate performance under load.
+Tests the 47 indexes added in the enterprise hardening phase.
+
+Usage:
+    locust -f tests/load/locustfile.py --host=https://api.perenniaai.com
+    locust -f tests/load/locustfile.py --host=http://localhost:8000
+
+Profiles:
+    Smoke:    locust ... --users 10  --spawn-rate 2  --run-time 1m
+    Normal:   locust ... --users 50  --spawn-rate 5  --run-time 5m
+    Stress:   locust ... --users 200 --spawn-rate 10 --run-time 10m
+
+Environment variables:
+    LOCUST_EMAIL     — account email for authentication (optional)
+    LOCUST_PASSWORD  — account password for authentication (optional)
+
+When LOCUST_EMAIL / LOCUST_PASSWORD are not set the suite operates in
+anonymous mode: only unauthenticated endpoints (health probes) are tested.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+from locust import HttpUser, TaskSet, between, events, tag, task
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration — read credentials from environment
+# ---------------------------------------------------------------------------
+
+_EMAIL: Optional[str] = os.getenv("LOCUST_EMAIL")
+_PASSWORD: Optional[str] = os.getenv("LOCUST_PASSWORD")
+_AUTH_AVAILABLE: bool = bool(_EMAIL and _PASSWORD)
+
+# Warning threshold (ms) — Locust logs these but does not fail the test run.
+# Critical thresholds should be enforced via CI assertions on the HTML report.
+P95_READ_WARN_MS = 500
+P95_WRITE_WARN_MS = 1_000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _warn_slow(response, label: str, threshold_ms: int = P95_READ_WARN_MS) -> None:
+    """Log a warning when a single response exceeds the threshold."""
+    elapsed_ms = response.elapsed.total_seconds() * 1_000
+    if elapsed_ms > threshold_ms:
+        logger.warning(
+            "Slow response detected: %s took %.0f ms (threshold %d ms)",
+            label,
+            elapsed_ms,
+            threshold_ms,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task sets
+# ---------------------------------------------------------------------------
+
+
+class HealthCheckTasks(TaskSet):
+    """Lightweight health-probe tasks — run even without authentication."""
+
+    @tag("health", "read")
+    @task(3)
+    def health(self) -> None:
+        with self.client.get(
+            "/health",
+            name="GET /health",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code == 200:
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /health")
+
+    @tag("health", "read")
+    @task(1)
+    def ready(self) -> None:
+        with self.client.get(
+            "/ready",
+            name="GET /ready",
+            catch_response=True,
+        ) as resp:
+            # 200 = ready; 503 = not ready yet (not a load-test failure)
+            if resp.status_code in (200, 503):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /ready")
+
+
+class PipelineTasks(TaskSet):
+    """Main LO workflow — dashboard, leads, loans, tasks, search."""
+
+    @tag("pipeline", "read")
+    @task(4)
+    def dashboard_metrics(self) -> None:
+        with self.client.get(
+            "/api/v1/dashboard/metrics",
+            name="GET /api/v1/dashboard/metrics",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 304):
+                resp.success()
+            elif resp.status_code in (401, 403):
+                resp.success()  # auth issue, not a perf failure
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/dashboard/metrics")
+
+    @tag("pipeline", "read")
+    @task(5)
+    def list_leads(self) -> None:
+        with self.client.get(
+            "/api/v1/leads?limit=50",
+            name="GET /api/v1/leads",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 304, 401, 403):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/leads")
+
+    @tag("pipeline", "read")
+    @task(5)
+    def list_loans(self) -> None:
+        with self.client.get(
+            "/api/v1/loans?limit=50",
+            name="GET /api/v1/loans",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 304, 401, 403):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/loans")
+
+    @tag("pipeline", "read")
+    @task(4)
+    def list_loans_by_stage(self) -> None:
+        with self.client.get(
+            "/api/v1/loans?stage=PROCESSING",
+            name="GET /api/v1/loans?stage=PROCESSING",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 304, 401, 403):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/loans?stage=PROCESSING")
+
+    @tag("pipeline", "read")
+    @task(3)
+    def list_tasks(self) -> None:
+        with self.client.get(
+            "/api/v1/tasks",
+            name="GET /api/v1/tasks",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 304, 401, 403):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/tasks")
+
+    @tag("pipeline", "write")
+    @task(2)
+    def search_leads(self) -> None:
+        payload = {"query": "john"}
+        with self.client.post(
+            "/api/v1/leads/search",
+            json=payload,
+            name="POST /api/v1/leads/search",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 401, 403, 422):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "POST /api/v1/leads/search", P95_WRITE_WARN_MS)
+
+
+class CalendarTasks(TaskSet):
+    """Calendar-heavy workflow — events, slots, smart scheduler."""
+
+    @tag("calendar", "read")
+    @task(4)
+    def calendar_events(self) -> None:
+        with self.client.get(
+            "/api/v1/calendar/events",
+            name="GET /api/v1/calendar/events",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 304, 401, 403):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/calendar/events")
+
+    @tag("calendar", "read")
+    @task(3)
+    def calendar_slots(self) -> None:
+        with self.client.get(
+            "/api/v1/calendar/slots?date=2026-03-28",
+            name="GET /api/v1/calendar/slots",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 304, 401, 403):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/calendar/slots")
+
+    @tag("calendar", "read")
+    @task(3)
+    def smart_scheduler_slots(self) -> None:
+        with self.client.get(
+            "/api/v1/smart-scheduler/available-slots",
+            name="GET /api/v1/smart-scheduler/available-slots",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 304, 401, 403):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/smart-scheduler/available-slots")
+
+
+class AdminTasks(TaskSet):
+    """Admin/reporting workflow — users listing, compliance dashboard."""
+
+    @tag("admin", "read")
+    @task(2)
+    def admin_users(self) -> None:
+        with self.client.get(
+            "/api/v1/admin/users",
+            name="GET /api/v1/admin/users",
+            catch_response=True,
+        ) as resp:
+            # 403 is expected for non-admin users — not a load-test failure
+            if resp.status_code in (200, 304, 401, 403):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/admin/users")
+
+    @tag("admin", "read")
+    @task(2)
+    def compliance_dashboard(self) -> None:
+        with self.client.get(
+            "/api/v1/compliance/dashboard",
+            name="GET /api/v1/compliance/dashboard",
+            catch_response=True,
+        ) as resp:
+            if resp.status_code in (200, 304, 401, 403):
+                resp.success()
+            else:
+                resp.failure(f"Unexpected status: {resp.status_code}")
+            _warn_slow(resp, "GET /api/v1/compliance/dashboard")
+
+
+# ---------------------------------------------------------------------------
+# User classes
+# ---------------------------------------------------------------------------
+
+
+class HealthCheckUser(HttpUser):
+    """
+    Exercises health probes only.
+    Weight 1 — smallest share of virtual users.
+    Does NOT require authentication.
+    """
+
+    tasks = [HealthCheckTasks]
+    weight = 1
+    wait_time = between(1, 3)
+
+
+class PipelineUser(HttpUser):
+    """
+    Simulates a loan officer working through their daily pipeline:
+    dashboard, leads, loans, tasks, search.
+    Weight 5 — largest share of virtual users (most common workflow).
+    """
+
+    tasks = [PipelineTasks]
+    weight = 5
+    wait_time = between(1, 3)
+
+    def on_start(self) -> None:
+        """Authenticate if credentials are configured."""
+        _authenticate(self)
+
+
+class CalendarUser(HttpUser):
+    """
+    Simulates an LO focused on scheduling: calendar events and slot lookups.
+    Weight 3 — second-largest share.
+    """
+
+    tasks = [CalendarTasks]
+    weight = 3
+    wait_time = between(1, 3)
+
+    def on_start(self) -> None:
+        """Authenticate if credentials are configured."""
+        _authenticate(self)
+
+
+class AdminUser(HttpUser):
+    """
+    Simulates a platform admin reviewing compliance and user lists.
+    Weight 1 — smallest share (admin traffic is rare in production).
+    """
+
+    tasks = [AdminTasks]
+    weight = 1
+    wait_time = between(1, 3)
+
+    def on_start(self) -> None:
+        """Authenticate if credentials are configured."""
+        _authenticate(self)
+
+
+# ---------------------------------------------------------------------------
+# Authentication helper
+# ---------------------------------------------------------------------------
+
+
+def _authenticate(user: HttpUser) -> None:
+    """
+    Log in and attach the JWT token as a default Authorization header.
+
+    If LOCUST_EMAIL / LOCUST_PASSWORD are not set, authentication is skipped
+    and only unauthenticated endpoints will respond with useful data.
+    """
+    if not _AUTH_AVAILABLE:
+        logger.info(
+            "LOCUST_EMAIL / LOCUST_PASSWORD not set — running without auth. "
+            "Only health endpoints will return 200."
+        )
+        return
+
+    payload = {"email": _EMAIL, "password": _PASSWORD}
+    with user.client.post(
+        "/api/v1/auth/login",
+        json=payload,
+        name="POST /api/v1/auth/login (setup)",
+        catch_response=True,
+    ) as resp:
+        if resp.status_code == 200:
+            try:
+                data = resp.json()
+                token = data.get("access_token") or data.get("token")
+                if token:
+                    user.client.headers.update({"Authorization": f"Bearer {token}"})
+                    resp.success()
+                    logger.debug("Authentication succeeded")
+                else:
+                    resp.failure("Login response missing access_token field")
+                    logger.warning("Login response had no token: %s", data)
+            except Exception as exc:  # noqa: BLE001
+                resp.failure(f"Could not parse login response: {exc}")
+        else:
+            # Don't mark as failure — a bad credential is a config problem,
+            # not a latency/throughput problem.  Log and continue.
+            resp.success()
+            logger.warning(
+                "Login returned %d — subsequent authenticated requests may 401.",
+                resp.status_code,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Event hooks (optional — add per-run summary logging)
+# ---------------------------------------------------------------------------
+
+
+@events.quitting.add_listener
+def on_quitting(environment, **_kwargs) -> None:
+    """Log a summary of results when the test run ends."""
+    stats = environment.stats
+    total = stats.total
+    logger.info(
+        "Load test complete: %d requests, %.2f RPS, %.1f%% failures, "
+        "p50=%.0f ms, p95=%.0f ms, p99=%.0f ms",
+        total.num_requests,
+        total.current_rps,
+        total.fail_ratio * 100,
+        total.get_response_time_percentile(0.50) or 0,
+        total.get_response_time_percentile(0.95) or 0,
+        total.get_response_time_percentile(0.99) or 0,
+    )
+
+    # Exit with non-zero code if error rate exceeds 1% (critical threshold)
+    if total.fail_ratio > 0.01:
+        logger.error(
+            "CRITICAL: error rate %.2f%% exceeds 1%% threshold — marking run as failed.",
+            total.fail_ratio * 100,
+        )
+        environment.process_exit_code = 1

--- a/docs/custom-domain-setup.md
+++ b/docs/custom-domain-setup.md
@@ -1,0 +1,155 @@
+# Custom Domain Setup for White-Label Portals
+
+Enterprise clients can host their borrower portal at their own domain
+(e.g., `portal.acmemortgage.com`) instead of the default Perennia URL.
+SSL is provisioned automatically via Vercel once DNS verification passes.
+
+---
+
+## Prerequisites
+
+- An active white-label configuration (Admin → White-Label Settings).
+- Access to your domain's DNS records (usually through your registrar or
+  Cloudflare, Route 53, etc.).
+- Platform admin, site admin, or admin role in Perennia.
+
+---
+
+## Setup Steps
+
+### Step 1: Open White-Label Settings
+
+Go to **Admin → White-Label → Custom Domain** in the Perennia dashboard.
+
+### Step 2: Enter Your Domain
+
+Type the subdomain you want to use — for example, `portal.acmemortgage.com`.
+Do **not** include `https://`. Click **Setup Domain**.
+
+The API call made is:
+
+```
+POST /api/v1/admin/custom-domain/setup
+Body: { "domain": "portal.acmemortgage.com" }
+```
+
+You will receive a verification token such as:
+
+```
+perennia-verify=a1b2c3d4e5f6...
+```
+
+### Step 3: Add DNS Records
+
+Log in to your DNS provider and add **two** records:
+
+#### 3a. TXT Record (Ownership Verification)
+
+| Field  | Value                                          |
+|--------|------------------------------------------------|
+| Type   | `TXT`                                          |
+| Name   | `_perennia-verify.portal.acmemortgage.com`     |
+| Value  | `perennia-verify=a1b2c3d4e5f6...` (your token) |
+| TTL    | 300 (5 minutes) or your provider's default     |
+
+#### 3b. CNAME Record (Traffic Routing)
+
+| Field  | Value                    |
+|--------|--------------------------|
+| Type   | `CNAME`                  |
+| Name   | `portal.acmemortgage.com`|
+| Value  | `cname.vercel-dns.com`   |
+| TTL    | 300 or default           |
+
+> **Note:** Some DNS providers require you to enter only the subdomain
+> portion (`portal`) for the Name field rather than the fully qualified
+> domain name. Check your provider's documentation.
+
+### Step 4: Click Verify
+
+After adding the DNS records, return to Perennia and click **Verify Domain**.
+The API call made is:
+
+```
+POST /api/v1/admin/custom-domain/verify
+```
+
+DNS propagation typically takes **a few minutes** but can take up to 48 hours.
+If verification fails, wait a few minutes and try again.
+
+### Step 5: Wait for SSL Provisioning
+
+Once your domain is verified, SSL certificate provisioning begins automatically
+(usually **under 5 minutes**). You can monitor progress at:
+
+```
+GET /api/v1/admin/custom-domain/status
+```
+
+The `ssl_status` field progresses through: `pending` → `provisioning` → `active`.
+
+Once `ssl_status` is `active`, your borrower portal is live at your custom domain.
+
+---
+
+## Removing a Custom Domain
+
+To remove the custom domain:
+
+```
+DELETE /api/v1/admin/custom-domain
+```
+
+Or use **Admin → White-Label → Custom Domain → Remove Domain** in the dashboard.
+
+This clears the domain from Perennia and removes it from the SSL infrastructure.
+You can then delete the DNS records from your provider.
+
+---
+
+## Troubleshooting
+
+### Verification keeps failing
+
+- **Check the TXT record name.** It must be `_perennia-verify.` prepended to
+  your full domain. For `portal.acmemortgage.com` the name is
+  `_perennia-verify.portal.acmemortgage.com`.
+- **Check the TXT record value.** It must match exactly what was returned by
+  `/setup`, including the `perennia-verify=` prefix.
+- **Wait longer.** DNS propagation can take up to 48 hours in rare cases.
+  Use a tool like [dnschecker.org](https://dnschecker.org) to check global
+  propagation.
+
+### SSL status is stuck on `provisioning`
+
+- Confirm the CNAME record is pointing to `cname.vercel-dns.com` and has
+  propagated globally.
+- If you used an A record instead of a CNAME, SSL provisioning may fail.
+  Switch to a CNAME if possible.
+- Contact support if `provisioning` persists for more than 30 minutes after
+  the CNAME has propagated.
+
+### Domain shows `ssl_status: failed`
+
+- Remove the domain (`DELETE /api/v1/admin/custom-domain`) and re-run setup.
+- Ensure no conflicting DNS records exist (e.g., an A record and a CNAME for
+  the same name).
+
+### CNAME conflicts with root domain
+
+Bare/apex domains (e.g., `acmemortgage.com` with no subdomain) cannot use
+CNAME records per DNS standards. Use a subdomain instead
+(e.g., `portal.acmemortgage.com`).
+
+---
+
+## API Reference
+
+| Method   | Endpoint                                  | Description                          |
+|----------|-------------------------------------------|--------------------------------------|
+| `POST`   | `/api/v1/admin/custom-domain/setup`       | Register domain, receive TXT token   |
+| `POST`   | `/api/v1/admin/custom-domain/verify`      | Run DNS lookup, trigger SSL          |
+| `GET`    | `/api/v1/admin/custom-domain/status`      | Poll domain & SSL status             |
+| `DELETE` | `/api/v1/admin/custom-domain`             | Remove domain and revoke SSL         |
+
+All endpoints require an **admin**, **site_admin**, or **platform_admin** role.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import { isAuthenticatedSync as isAuthenticated } from './utils/auth';
 import { ImpersonationProvider } from './contexts/ImpersonationContext';
 import { PermissionProvider, usePermissions } from './contexts/PermissionContext';
 import { ModuleProvider, useModules } from './contexts/ModuleContext';
+import { BrandingProvider } from './contexts/BrandingContext';
 import { getUserEffectiveRole, getDefaultRouteForRole } from './config/roleConfig';
 import Navigation from './components/Navigation';
 import AIAssistant from './components/AIAssistant';
@@ -527,6 +528,7 @@ function App() {
         <ImpersonationProvider>
         <PermissionProvider>
         <ModuleProvider>
+        <BrandingProvider>
           <Router>
             <GlobalLayoutFix />
             <ImpersonationBanner />
@@ -4562,6 +4564,7 @@ function App() {
         <GlobalSearch />
         </div>
       </Router>
+        </BrandingProvider>
         </ModuleProvider>
         </PermissionProvider>
         </ImpersonationProvider>

--- a/frontend/src/components/Navigation.css
+++ b/frontend/src/components/Navigation.css
@@ -1,5 +1,34 @@
+/* ── Brand logo / name in nav ───────────────────────────────────────────── */
+.nav-brand {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-right: var(--space-md);
+  text-decoration: none;
+}
+
+.nav-brand-logo {
+  height: 28px;
+  width: auto;
+  object-fit: contain;
+}
+
+.nav-brand-text {
+  font-weight: var(--weight-semibold, 600);
+  font-size: var(--font-base);
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+
+.nav-brand-text:hover {
+  color: var(--brand-primary, var(--color-primary));
+  text-decoration: none;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────── */
+
 .navigation {
-  background: var(--color-bg-surface);
+  background: var(--brand-header-bg, var(--color-bg-surface));
   border-bottom: 1px solid var(--color-border-light);
   position: sticky;
   top: 0;
@@ -43,7 +72,7 @@
 }
 
 .nav-link.active {
-  background: var(--color-primary);
+  background: var(--brand-primary, var(--color-primary));
   color: var(--color-bg-base);
 }
 

--- a/frontend/src/components/Navigation.js
+++ b/frontend/src/components/Navigation.js
@@ -2,6 +2,7 @@ import React, { useMemo, useCallback, useState, useRef, useEffect } from 'react'
 import { Link, useLocation } from 'react-router-dom';
 import { usePermissions } from '../contexts/PermissionContext';
 import { useModules } from '../contexts/ModuleContext';
+import { useBranding } from '../contexts/BrandingContext';
 import { getNavigationForRole, roleHasDashboard, isMasterAdmin, getMasterAdminNavigation } from '../config/roleConfig';
 import { usePrefetch } from '../hooks/useQueries';
 import NotificationBell from './NotificationBell';
@@ -18,6 +19,7 @@ function Navigation({ onToggleAssistant, onToggleCoach, assistantOpen, coachOpen
   const location = useLocation();
   const { effectiveRole, userRole, viewAsRole, hasAnyPermission } = usePermissions();
   const { hasModule, getModule, loading: modulesLoading } = useModules();
+  const { brandName, logoUrl } = useBranding();
   const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
   const [selectedModule, setSelectedModule] = useState(null);
   const [openDropdown, setOpenDropdown] = useState(null);
@@ -311,6 +313,17 @@ function Navigation({ onToggleAssistant, onToggleCoach, assistantOpen, coachOpen
             <span className="hamburger-line" />
             <span className="hamburger-line" />
           </button>
+
+          {/* Brand logo / name — driven by per-org WhiteLabelConfig */}
+          {logoUrl ? (
+            <Link to="/" className="nav-brand" title={brandName}>
+              <img src={logoUrl} alt={brandName} className="nav-brand-logo" />
+            </Link>
+          ) : (
+            <Link to="/" className="nav-brand nav-brand-text" title={brandName}>
+              {brandName}
+            </Link>
+          )}
 
           <div className="nav-links">
             {navItems.map((item) => renderNavItem(item))}

--- a/frontend/src/contexts/BrandingContext.js
+++ b/frontend/src/contexts/BrandingContext.js
@@ -1,0 +1,171 @@
+/**
+ * BrandingContext
+ *
+ * Fetches per-organization branding from /api/v1/branding on mount (when the
+ * user is authenticated) and applies it as CSS custom properties on
+ * document.documentElement so every component can consume brand colors via
+ * var(--brand-primary) etc.
+ *
+ * It also keeps document.title and the favicon in sync with the org config.
+ *
+ * Usage:
+ *   const { brandName, primaryColor, logoUrl, loading } = useBranding();
+ */
+
+import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
+import { getAuthHeaders } from '../utils/auth';
+import { API_BASE_URL } from '../services/api';
+
+// ─── Defaults (match current Perennia AI branding so nothing changes for ────
+// orgs without a WhiteLabelConfig)
+const DEFAULTS = {
+  brandName: 'Perennia AI',
+  logoUrl: null,
+  faviconUrl: null,
+  primaryColor: '#218d8d',
+  secondaryColor: '#7c3aed',
+  accentColor: '#059669',
+  headerBgColor: '#ffffff',
+  fontFamily: 'Inter, sans-serif',
+};
+
+const BrandingContext = createContext(null);
+
+/**
+ * Apply CSS custom properties to :root so all components can use
+ * var(--brand-primary), var(--brand-secondary), etc.
+ */
+function applyCSSVars(config) {
+  const root = document.documentElement;
+  root.style.setProperty('--brand-primary', config.primaryColor);
+  root.style.setProperty('--brand-secondary', config.secondaryColor);
+  root.style.setProperty('--brand-accent', config.accentColor);
+  root.style.setProperty('--brand-header-bg', config.headerBgColor);
+  root.style.setProperty('--brand-font', config.fontFamily);
+}
+
+/**
+ * Update the favicon <link> element if a custom favicon URL was provided.
+ */
+function updateFavicon(faviconUrl) {
+  if (!faviconUrl) return;
+  let link = document.querySelector("link[rel~='icon']");
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = 'icon';
+    document.head.appendChild(link);
+  }
+  link.href = faviconUrl;
+}
+
+export const BrandingProvider = ({ children }) => {
+  const [branding, setBranding] = useState(DEFAULTS);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Only fetch when a token is present (authenticated session)
+    const token = localStorage.getItem('token');
+    if (!token) {
+      // Apply defaults so CSS vars are always defined
+      applyCSSVars(DEFAULTS);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchBranding = async () => {
+      try {
+        const response = await fetch(`${API_BASE_URL}/api/v1/branding`, {
+          headers: getAuthHeaders(),
+        });
+
+        if (cancelled) return;
+
+        if (!response.ok) {
+          // Non-2xx — silently use defaults (do NOT redirect; auth errors are
+          // handled by PermissionContext / ModuleContext already)
+          applyCSSVars(DEFAULTS);
+          setLoading(false);
+          return;
+        }
+
+        const data = await response.json();
+
+        const resolved = {
+          brandName: data.company_name || DEFAULTS.brandName,
+          logoUrl: data.logo_url || null,
+          faviconUrl: data.favicon_url || null,
+          primaryColor: data.primary_color || DEFAULTS.primaryColor,
+          secondaryColor: data.secondary_color || DEFAULTS.secondaryColor,
+          accentColor: data.accent_color || DEFAULTS.accentColor,
+          headerBgColor: data.header_bg_color || DEFAULTS.headerBgColor,
+          fontFamily: data.font_family || DEFAULTS.fontFamily,
+        };
+
+        setBranding(resolved);
+        applyCSSVars(resolved);
+        updateFavicon(resolved.faviconUrl);
+
+        // Update document title (e.g. "Acme Lending | Perennia AI")
+        if (resolved.brandName && resolved.brandName !== DEFAULTS.brandName) {
+          document.title = resolved.brandName;
+        }
+      } catch (err) {
+        if (!cancelled) {
+          // Network errors — fall back to defaults silently
+          console.warn('[BrandingContext] Could not fetch branding config:', err.message);
+          applyCSSVars(DEFAULTS);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchBranding();
+
+    // Re-fetch when the user logs in / out in the same tab
+    const handleAuthChange = (e) => {
+      if (e.detail?.type === 'login') {
+        fetchBranding();
+      } else if (e.detail?.type === 'logout') {
+        setBranding(DEFAULTS);
+        applyCSSVars(DEFAULTS);
+      }
+    };
+    window.addEventListener('authChange', handleAuthChange);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('authChange', handleAuthChange);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const value = useMemo(
+    () => ({ ...branding, loading }),
+    [branding, loading]
+  );
+
+  return (
+    <BrandingContext.Provider value={value}>
+      {children}
+    </BrandingContext.Provider>
+  );
+};
+
+/**
+ * Hook to consume branding values.
+ * Returns: { brandName, logoUrl, faviconUrl, primaryColor, secondaryColor,
+ *            accentColor, headerBgColor, fontFamily, loading }
+ */
+export const useBranding = () => {
+  const ctx = useContext(BrandingContext);
+  if (!ctx) {
+    throw new Error('useBranding must be used within a BrandingProvider');
+  }
+  return ctx;
+};
+
+export default BrandingContext;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,13 @@
 :root {
-  /* Color Palette */
-  --color-primary: #217F8D;
+  /* ── Brand custom properties (overridden at runtime by BrandingContext) ── */
+  --brand-primary: #218d8d;
+  --brand-secondary: #7c3aed;
+  --brand-accent: #059669;
+  --brand-header-bg: #ffffff;
+  --brand-font: Inter, sans-serif;
+
+  /* Color Palette — primary defers to brand color when set */
+  --color-primary: var(--brand-primary, #217F8D);
   --color-primary-hover: #1a6670;
   --color-success: #217F8D;
   --color-error: #C0152F;

--- a/frontend/src/utils/brand.js
+++ b/frontend/src/utils/brand.js
@@ -1,0 +1,11 @@
+/**
+ * Brand utility — static default brand name.
+ *
+ * For components that cannot access React context (utility files, non-component
+ * modules, etc.), import DEFAULT_BRAND_NAME from here.
+ *
+ * For React components, prefer useBranding() from BrandingContext which returns
+ * the per-org brandName dynamically fetched from the backend.
+ */
+
+export const DEFAULT_BRAND_NAME = 'Perennia AI';


### PR DESCRIPTION
## Summary

Completes Priority 4 (Nice to Have) items from the platform completion plan, bringing the platform to full enterprise readiness.

- **Main App White-Labeling** (Task 11): `GET /api/v1/branding` endpoint + `BrandingProvider` React context that applies per-org CSS custom properties (`--brand-primary`, etc.), updates favicon, and shows org logo in navigation bar
- **Custom Domain SSL** (Task 10): DNS verification + Vercel API integration for `portal.theircompany.com` — admin endpoints for setup, verify, status, and removal with automatic SSL provisioning
- **Locust Load Testing** (Task 12): 4 user classes (HealthCheck, Pipeline, Calendar, Admin) targeting key endpoints with smoke/normal/stress profiles and p95/p99 threshold assertions

## Files Changed (15 files, +1,564 / -442)

### Backend
- `routes/branding_routes.py` — New: GET /api/v1/branding (per-org WhiteLabelConfig)
- `routes/custom_domain_routes.py` — Rewritten: 4 admin endpoints for domain lifecycle
- `services/vercel_domain_service.py` — New: Vercel REST API client for domain provisioning
- `database/models/white_label_config.py` — Added: ssl_status, domain_verified, verification_token, vercel_domain_id columns
- `main.py` — Registered branding + custom domain routes
- `tests/load/locustfile.py` — New: Locust load test suite
- `tests/load/README.md` — New: Load testing documentation
- `requirements.txt` — Added: locust

### Frontend
- `contexts/BrandingContext.js` — New: BrandingProvider with CSS variable injection
- `utils/brand.js` — New: DEFAULT_BRAND_NAME constant
- `App.jsx` — Wrapped with BrandingProvider
- `components/Navigation.js` — Shows org logo/name from branding
- `components/Navigation.css` — Brand-aware nav styles
- `index.css` — Root-level --brand-* CSS custom properties

### Docs
- `docs/custom-domain-setup.md` — Client-facing DNS setup guide

## Test plan
- [ ] `/api/v1/branding` returns defaults for orgs without WhiteLabelConfig
- [ ] `/api/v1/branding` returns org branding when WhiteLabelConfig exists
- [ ] Navigation shows org logo when `logo_url` is configured
- [ ] CSS custom properties cascade (--brand-primary visible in dev tools)
- [ ] Custom domain setup generates verification token
- [ ] Custom domain verify checks DNS TXT record
- [ ] Locust smoke test runs: `locust -f tests/load/locustfile.py --host=http://localhost:8000 --users 10 --spawn-rate 2 --run-time 30s --headless`
- [ ] All fallback defaults match current Perennia AI branding (no visual change for unconfigured orgs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)