### PR TITLE
fix: calendar availability defaults + Outlook integration + mobile responsive CSS

### DIFF
--- a/backend/database/models/scheduler.py
+++ b/backend/database/models/scheduler.py
@@ -168,7 +168,16 @@ class SchedulerConfig(Base):
 
     # Working hours (JSON for flexibility)
     # Format: {"monday": {"start": "09:00", "end": "17:00", "enabled": true}, ...}
-    working_hours = Column(JSON, default=dict)
+    # Default: M-F 9am-5pm enabled; Sat/Sun disabled but with 9am-1pm as template
+    working_hours = Column(JSON, default=lambda: {
+        "monday": {"start": "09:00", "end": "17:00", "enabled": True},
+        "tuesday": {"start": "09:00", "end": "17:00", "enabled": True},
+        "wednesday": {"start": "09:00", "end": "17:00", "enabled": True},
+        "thursday": {"start": "09:00", "end": "17:00", "enabled": True},
+        "friday": {"start": "09:00", "end": "17:00", "enabled": True},
+        "saturday": {"start": "09:00", "end": "13:00", "enabled": False},
+        "sunday": {"start": "09:00", "end": "13:00", "enabled": False},
+    })
 
     # Meeting preferences
     preferred_meeting_modes = Column(JSON, default=lambda: ["video", "phone"])

--- a/backend/migrations/fix_empty_working_hours.py
+++ b/backend/migrations/fix_empty_working_hours.py
@@ -1,0 +1,95 @@
+"""
+Migration: Fix empty working_hours in scheduler_configs
+
+Finds all scheduler_configs rows with NULL or empty working_hours JSON
+and updates them to the sensible M-F 9am-5pm default schedule.
+
+This migration is idempotent — safe to run multiple times. It only
+updates rows where working_hours is NULL or an empty JSON object ({}).
+
+Usage:
+    cd backend && python migrations/fix_empty_working_hours.py
+"""
+
+import os
+import sys
+import json
+import logging
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DEFAULT_WORKING_HOURS = {
+    "monday": {"start": "09:00", "end": "17:00", "enabled": True},
+    "tuesday": {"start": "09:00", "end": "17:00", "enabled": True},
+    "wednesday": {"start": "09:00", "end": "17:00", "enabled": True},
+    "thursday": {"start": "09:00", "end": "17:00", "enabled": True},
+    "friday": {"start": "09:00", "end": "17:00", "enabled": True},
+    "saturday": {"start": "09:00", "end": "13:00", "enabled": False},
+    "sunday": {"start": "09:00", "end": "13:00", "enabled": False},
+}
+
+
+def run_migration():
+    from sqlalchemy import text
+    from db import SessionLocal
+
+    db = SessionLocal()
+    try:
+        # Find configs with NULL or empty working_hours
+        # PostgreSQL: '{}' is the JSON representation of an empty object
+        # Also handle NULL values
+        result = db.execute(text("""
+            SELECT id, user_id, organization_id, working_hours
+            FROM scheduler_configs
+            WHERE working_hours IS NULL
+               OR working_hours::text = '{}'
+               OR working_hours::text = 'null'
+        """))
+        rows = result.fetchall()
+
+        if not rows:
+            logger.info("No scheduler_configs with empty working_hours found. Nothing to update.")
+            return 0
+
+        logger.info(f"Found {len(rows)} scheduler_configs with empty working_hours")
+
+        # Update each row
+        default_json = json.dumps(DEFAULT_WORKING_HOURS)
+        updated_count = db.execute(text("""
+            UPDATE scheduler_configs
+            SET working_hours = :default_hours
+            WHERE working_hours IS NULL
+               OR working_hours::text = '{}'
+               OR working_hours::text = 'null'
+        """), {"default_hours": default_json})
+
+        db.commit()
+        count = updated_count.rowcount
+        logger.info(f"Updated {count} scheduler_configs with default M-F 9am-5pm working hours")
+
+        # Log details for audit trail
+        for row in rows:
+            logger.info(
+                f"  - config id={row[0]}, user_id={row[1]}, org_id={row[2]}, "
+                f"old_working_hours={row[3]!r}"
+            )
+
+        return count
+
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Migration failed: {e}")
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    logger.info("=" * 60)
+    logger.info("Migration: Fix empty working_hours in scheduler_configs")
+    logger.info("=" * 60)
+    count = run_migration()
+    logger.info(f"Migration complete. {count} configs updated.")

--- a/backend/routes/scheduler/_availability.py
+++ b/backend/routes/scheduler/_availability.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 import pytz
 import logging
 import time as time_mod
+import requests
 
 from smart_scheduler_models import (
     AppointmentStatus, DayOfWeek, SlotPriority, DEFAULT_WORKING_HOURS,
@@ -163,6 +164,172 @@ def _cb_should_skip(provider: str, org_id: int = None) -> bool:
         state["open_until"] = None
         return False
     return True
+
+
+# ============================================================================
+# MICROSOFT OUTLOOK CALENDAR HELPER
+# ============================================================================
+
+# Module-level cache for Outlook calendar events to avoid duplicate API calls
+# within a single availability request window.
+# Key: (user_id, start_iso, end_iso) -> list of (start_dt, end_dt) tuples
+_outlook_cache: dict = {}
+_OUTLOOK_CACHE_TTL = 120  # 2 minutes
+
+
+def _fetch_outlook_calendar_events(user_id: int, start_dt: datetime, end_dt: datetime, db) -> list:
+    """Fetch busy periods from Microsoft Outlook calendar via Graph API.
+
+    Returns a list of (start, end) datetime tuples representing busy time blocks.
+    Uses MicrosoftOAuthToken for authentication, with automatic token refresh.
+    Results are cached for the request window to avoid hammering the API.
+
+    Returns an empty list (fail-open) if:
+    - No Microsoft OAuth token exists for the user
+    - Token refresh fails
+    - Graph API call fails
+
+    This is a synchronous function (the slot generator is sync).
+    """
+    # Check cache first
+    cache_key = (user_id, start_dt.isoformat(), end_dt.isoformat())
+    cached = _outlook_cache.get(cache_key)
+    if cached and time_mod.time() - cached["ts"] < _OUTLOOK_CACHE_TTL:
+        return cached["events"]
+
+    events = []
+
+    try:
+        from database.models.microsoft import MicrosoftOAuthToken
+        from services.dre_helpers import decrypt_token, encrypt_token
+
+        oauth_record = db.query(MicrosoftOAuthToken).filter(
+            MicrosoftOAuthToken.user_id == user_id,
+        ).first()
+
+        if not oauth_record or not oauth_record.access_token:
+            # No Microsoft token — skip silently
+            _outlook_cache[cache_key] = {"events": [], "ts": time_mod.time()}
+            return []
+
+        # Check if token needs refresh
+        access_token = None
+        if oauth_record.token_expires_at:
+            token_expiry = oauth_record.token_expires_at
+            if token_expiry.tzinfo is None:
+                token_expiry = token_expiry.replace(tzinfo=timezone.utc)
+            if token_expiry < datetime.now(timezone.utc) + timedelta(minutes=5):
+                # Token expired or expiring soon — try synchronous refresh
+                if not oauth_record.refresh_token:
+                    logger.debug(f"Outlook calendar: no refresh token for user {user_id}, skipping")
+                    _outlook_cache[cache_key] = {"events": [], "ts": time_mod.time()}
+                    return []
+
+                import os
+                client_id = os.getenv("MICROSOFT_CLIENT_ID")
+                client_secret = os.getenv("MICROSOFT_CLIENT_SECRET")
+                if not client_id or not client_secret:
+                    logger.debug("Outlook calendar: Microsoft OAuth credentials not configured, skipping")
+                    _outlook_cache[cache_key] = {"events": [], "ts": time_mod.time()}
+                    return []
+
+                try:
+                    refresh_token = decrypt_token(oauth_record.refresh_token)
+                    refresh_resp = requests.post(
+                        "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+                        data={
+                            "client_id": client_id,
+                            "client_secret": client_secret,
+                            "refresh_token": refresh_token,
+                            "grant_type": "refresh_token",
+                            "scope": "https://graph.microsoft.com/Calendars.Read offline_access",
+                        },
+                        timeout=10,
+                    )
+                    if refresh_resp.status_code == 200:
+                        token_data = refresh_resp.json()
+                        oauth_record.access_token = encrypt_token(token_data["access_token"])
+                        oauth_record.refresh_token = encrypt_token(token_data["refresh_token"])
+                        oauth_record.token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=token_data["expires_in"])
+                        oauth_record.updated_at = datetime.now(timezone.utc)
+                        db.commit()
+                        access_token = token_data["access_token"]
+                        logger.info(f"Outlook calendar: refreshed token for user {user_id}")
+                    else:
+                        logger.warning(f"Outlook calendar: token refresh failed for user {user_id}: {refresh_resp.status_code}")
+                        _outlook_cache[cache_key] = {"events": [], "ts": time_mod.time()}
+                        return []
+                except Exception as e:
+                    logger.warning(f"Outlook calendar: token refresh error for user {user_id}: {e}")
+                    _outlook_cache[cache_key] = {"events": [], "ts": time_mod.time()}
+                    return []
+
+        # Decrypt access token if we didn't just refresh it
+        if access_token is None:
+            try:
+                access_token = decrypt_token(oauth_record.access_token)
+            except Exception as e:
+                logger.warning(f"Outlook calendar: failed to decrypt token for user {user_id}: {e}")
+                _outlook_cache[cache_key] = {"events": [], "ts": time_mod.time()}
+                return []
+
+        # Query Microsoft Graph calendarView
+        # Format datetimes as ISO 8601 strings for the Graph API
+        start_iso = start_dt.strftime("%Y-%m-%dT%H:%M:%S")
+        end_iso = end_dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+        graph_resp = requests.get(
+            "https://graph.microsoft.com/v1.0/me/calendarView",
+            params={
+                "startDateTime": start_iso,
+                "endDateTime": end_iso,
+                "$select": "start,end,showAs,isCancelled",
+                "$top": 200,
+            },
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Prefer": 'outlook.timezone="UTC"',
+            },
+            timeout=15,
+        )
+
+        if graph_resp.status_code == 200:
+            data = graph_resp.json()
+            for event in data.get("value", []):
+                # Skip cancelled events and free/tentative time
+                if event.get("isCancelled"):
+                    continue
+                show_as = event.get("showAs", "busy")
+                if show_as in ("free", "unknown"):
+                    continue
+
+                # Parse start/end from Graph API response
+                try:
+                    evt_start_str = event.get("start", {}).get("dateTime", "")
+                    evt_end_str = event.get("end", {}).get("dateTime", "")
+                    if evt_start_str and evt_end_str:
+                        # Graph returns ISO format; strip trailing Z if present
+                        evt_start = datetime.fromisoformat(evt_start_str.rstrip("Z"))
+                        evt_end = datetime.fromisoformat(evt_end_str.rstrip("Z"))
+                        events.append((evt_start, evt_end))
+                except (ValueError, TypeError) as e:
+                    logger.debug(f"Outlook calendar: failed to parse event datetime: {e}")
+                    continue
+
+            logger.debug(f"Outlook calendar: fetched {len(events)} busy events for user {user_id}")
+        elif graph_resp.status_code == 401:
+            logger.warning(f"Outlook calendar: 401 Unauthorized for user {user_id} (token may be invalid)")
+        else:
+            logger.warning(f"Outlook calendar: Graph API returned {graph_resp.status_code} for user {user_id}")
+
+    except ImportError:
+        logger.debug("Outlook calendar: MicrosoftOAuthToken or dre_helpers not available, skipping")
+    except Exception as e:
+        logger.warning(f"Outlook calendar: unexpected error for user {user_id}: {e}")
+
+    # Cache result regardless of success/failure
+    _outlook_cache[cache_key] = {"events": events, "ts": time_mod.time()}
+    return events
 
 
 # ============================================================================
@@ -336,6 +503,24 @@ def _get_cross_source_conflicts(db, target_user_id: int, start_dt, end_dt, org_i
                 degraded_sources.append("crm_calendar_event")
                 conflicts.append((start_dt, end_dt))
 
+    # Source 4: Microsoft Outlook calendar (via Graph API)
+    # Fail-open: if the token is missing or API fails, skip without blocking slots.
+    # Uses circuit breaker to avoid hammering a broken Graph API endpoint.
+    if _cb_should_skip("outlook_calendar", org_id=org_id):
+        logger.debug(f"Outlook calendar check skipped for user {target_user_id} — circuit breaker open")
+        degraded_sources.append("outlook_calendar")
+    else:
+        try:
+            outlook_events = _fetch_outlook_calendar_events(target_user_id, start_dt, end_dt, db)
+            if outlook_events:
+                conflicts.extend(outlook_events)
+            _cb_record_success("outlook_calendar", org_id=org_id)
+        except Exception as ex:
+            logger.warning(f"Outlook calendar cross-source check failed for user {target_user_id}: {ex}")
+            _cb_record_failure("outlook_calendar", org_id=org_id)
+            # Fail-open for Outlook: don't block all slots on Graph API failures
+            degraded_sources.append("outlook_calendar")
+
     return conflicts, degraded_sources
 
 
@@ -485,6 +670,32 @@ def _get_cross_source_conflicts_batch(db, user_ids: list, start_dt, end_dt, org_
                 logger.error(f"CRMCalendarEvent batch cross-source check FAILED — failing closed for all users: {ex}")
                 _cb_record_failure("crm_calendar_event", org_id=org_id)
                 _fail_closed_all_users("crm_calendar_event")
+
+    # Source 4: Microsoft Outlook calendar (via Graph API) — per-user fetch
+    # Fail-open: if the token is missing or API fails for a user, skip that user.
+    # Uses circuit breaker to avoid hammering a broken Graph API endpoint.
+    if _cb_should_skip("outlook_calendar", org_id=org_id):
+        logger.debug("Outlook calendar batch check skipped — circuit breaker open")
+        degraded_sources.append("outlook_calendar")
+    else:
+        any_success = False
+        any_failure = False
+        for uid in user_ids:
+            try:
+                outlook_events = _fetch_outlook_calendar_events(uid, start_dt, end_dt, db)
+                if outlook_events:
+                    conflicts_by_user[uid].extend(outlook_events)
+                    any_success = True
+            except Exception as ex:
+                logger.warning(f"Outlook calendar batch check failed for user {uid}: {ex}")
+                any_failure = True
+                # Fail-open per-user: don't block all slots for one user's failure
+
+        if any_success:
+            _cb_record_success("outlook_calendar", org_id=org_id)
+        elif any_failure:
+            _cb_record_failure("outlook_calendar", org_id=org_id)
+            degraded_sources.append("outlook_calendar")
 
     return conflicts_by_user, degraded_sources
 

--- a/backend/smart_scheduler_models.py
+++ b/backend/smart_scheduler_models.py
@@ -238,6 +238,6 @@ DEFAULT_WORKING_HOURS = {
     'wednesday': {'start': '09:00', 'end': '17:00', 'enabled': True},
     'thursday': {'start': '09:00', 'end': '17:00', 'enabled': True},
     'friday': {'start': '09:00', 'end': '17:00', 'enabled': True},
-    'saturday': {'start': '10:00', 'end': '14:00', 'enabled': False},
-    'sunday': {'start': '10:00', 'end': '14:00', 'enabled': False}
+    'saturday': {'start': '09:00', 'end': '13:00', 'enabled': False},
+    'sunday': {'start': '09:00', 'end': '13:00', 'enabled': False},
 }

--- a/frontend/src/components/AIReceptionist.css
+++ b/frontend/src/components/AIReceptionist.css
@@ -603,3 +603,121 @@
 .webhook-url button:hover {
   background: #1a7070;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .ai-receptionist-container {
+    padding: 16px;
+  }
+
+  .ai-receptionist-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 20px;
+    padding-bottom: 16px;
+  }
+
+  .header-title h2 {
+    font-size: 22px;
+  }
+
+  .phone-number {
+    font-size: 14px;
+    padding: 6px 12px;
+  }
+
+  .ai-receptionist-tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    margin-bottom: 20px;
+  }
+
+  .ai-receptionist-tabs button {
+    padding: 10px 16px;
+    font-size: 14px;
+    white-space: nowrap;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+
+  .stat-card {
+    padding: 14px;
+    gap: 10px;
+  }
+
+  .stat-value {
+    font-size: 24px;
+  }
+
+  .stat-icon {
+    font-size: 28px;
+  }
+
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .call-item {
+    flex-wrap: wrap;
+    gap: 10px;
+    padding: 12px;
+  }
+
+  .history-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .history-table {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .history-table th,
+  .history-table td {
+    white-space: nowrap;
+    padding: 10px 8px;
+  }
+
+  .settings-section h4 {
+    font-size: 16px;
+  }
+
+  .business-hours .form-row {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .make-call-form {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .ai-receptionist-container {
+    padding: 12px;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stat-value {
+    font-size: 20px;
+  }
+
+  .ai-receptionist-tabs button {
+    padding: 8px 12px;
+    font-size: 13px;
+  }
+
+  .call-info {
+    padding: 16px;
+  }
+}

--- a/frontend/src/components/AdminContracts.css
+++ b/frontend/src/components/AdminContracts.css
@@ -452,3 +452,103 @@
   font-size: 0.85rem;
   color: #6b7280;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .admin-contracts {
+    padding: 16px;
+  }
+
+  .admin-contracts-header h1 {
+    font-size: 1.35rem;
+  }
+
+  .contracts-summary-cards {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+
+  .summary-card {
+    padding: 14px;
+  }
+
+  .summary-card .card-value {
+    font-size: 1.35rem;
+  }
+
+  .contracts-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .contracts-toolbar .toolbar-left {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .contracts-search {
+    min-width: unset;
+    width: 100%;
+  }
+
+  .btn-create-contract {
+    width: 100%;
+    text-align: center;
+  }
+
+  .contracts-table-wrapper {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .contracts-table th,
+  .contracts-table td {
+    padding: 10px 12px;
+    font-size: 0.8rem;
+    white-space: nowrap;
+  }
+
+  .modal-content {
+    width: calc(100% - 32px);
+    max-height: calc(100vh - 32px);
+    padding: 20px;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .modal-actions {
+    flex-direction: column;
+  }
+
+  .modal-actions .btn-cancel,
+  .modal-actions .btn-submit {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .admin-contracts {
+    padding: 12px;
+  }
+
+  .contracts-summary-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .contracts-tabs .tab-btn {
+    padding: 8px 12px;
+    font-size: 0.8rem;
+  }
+
+  .modal-content {
+    padding: 16px;
+  }
+
+  .modal-content h2 {
+    font-size: 1.1rem;
+  }
+}

--- a/frontend/src/components/ClickToDialButton.css
+++ b/frontend/src/components/ClickToDialButton.css
@@ -115,3 +115,37 @@
 .click-to-dial-btn.inline.calling {
   background: #ffebee;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .click-to-dial-btn.small {
+    padding: 8px 12px;
+    font-size: 13px;
+    min-height: 44px;
+  }
+
+  .click-to-dial-btn.medium {
+    padding: 10px 16px;
+    font-size: 14px;
+    min-height: 44px;
+  }
+
+  .click-to-dial-btn.icon-only {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 10px;
+  }
+
+  .click-to-dial-btn.icon-only.small {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px;
+  }
+
+  .click-to-dial-btn.inline {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 10px;
+  }
+}

--- a/frontend/src/components/ClickableContact.css
+++ b/frontend/src/components/ClickableContact.css
@@ -189,3 +189,36 @@
   font-size: 12px;
   font-weight: normal;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .clickable-email,
+  .clickable-phone {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 0;
+  }
+
+  .phone-action-btn {
+    width: 44px;
+    height: 44px;
+    border-radius: 8px;
+    font-size: 18px;
+  }
+
+  .phone-with-actions {
+    gap: 12px;
+  }
+
+  .phone-action-buttons {
+    gap: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .phone-with-actions {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/components/DocumentDropModal.css
+++ b/frontend/src/components/DocumentDropModal.css
@@ -339,3 +339,77 @@
   background: #ccc;
   cursor: not-allowed;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .document-drop-modal {
+    width: calc(100% - 32px);
+    max-height: calc(100vh - 32px);
+    max-width: none;
+  }
+
+  .document-drop-modal .modal-header {
+    padding: 16px;
+  }
+
+  .document-drop-modal .modal-header h2 {
+    font-size: 18px;
+  }
+
+  .file-preview {
+    padding: 16px;
+  }
+
+  .form-section {
+    padding: 16px;
+  }
+
+  .search-box {
+    flex-direction: column;
+  }
+
+  .search-box button {
+    width: 100%;
+  }
+
+  .modal-actions {
+    padding: 16px;
+    flex-direction: column;
+  }
+
+  .modal-actions .btn-cancel,
+  .modal-actions .btn-upload {
+    width: 100%;
+    text-align: center;
+  }
+
+  .result-item {
+    flex-wrap: wrap;
+    gap: 6px;
+    min-height: 44px;
+  }
+
+  .result-email,
+  .result-number {
+    margin-left: 0;
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .document-drop-modal {
+    width: calc(100% - 16px);
+    border-radius: 8px;
+  }
+
+  .classification-result {
+    padding: 12px 16px;
+  }
+
+  .ai-suggestion {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+}

--- a/frontend/src/components/DocumentVisibilityControl.css
+++ b/frontend/src/components/DocumentVisibilityControl.css
@@ -362,3 +362,47 @@
   opacity: 1;
   visibility: visible;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .document-visibility-control {
+    padding: 12px;
+  }
+
+  .visibility-toggle-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 10px 0;
+  }
+
+  .toggle-switch {
+    min-width: 44px;
+    min-height: 24px;
+  }
+
+  .visibility-actions {
+    flex-direction: column;
+  }
+
+  .visibility-actions button {
+    min-height: 44px;
+  }
+
+  .visibility-inline-toggle {
+    gap: 16px;
+  }
+
+  .visibility-inline-toggle .toggle-item {
+    min-height: 44px;
+    min-width: 44px;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .lock-toggle {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/components/GuidelineNotificationBadge.css
+++ b/frontend/src/components/GuidelineNotificationBadge.css
@@ -39,3 +39,12 @@
     filter: drop-shadow(0 0 8px rgba(239, 68, 68, 0.8));
   }
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .notification-badge {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}

--- a/frontend/src/components/GuidelineUpdatesSidebar.css
+++ b/frontend/src/components/GuidelineUpdatesSidebar.css
@@ -193,3 +193,51 @@
     box-shadow: 0 0 0 5px rgba(239, 68, 68, 0.2);
   }
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .guideline-sidebar {
+    width: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+    padding: 16px;
+  }
+
+  .sidebar-header {
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+  }
+
+  .sidebar-header h3 {
+    font-size: 1rem;
+  }
+
+  .source-header {
+    padding: 10px 12px;
+    min-height: 44px;
+  }
+
+  .update-item {
+    padding: 10px;
+    min-height: 44px;
+  }
+}
+
+@media (max-width: 480px) {
+  .guideline-sidebar {
+    padding: 12px;
+  }
+
+  .source-title h4 {
+    font-size: 0.85rem;
+  }
+
+  .update-title {
+    font-size: 0.8rem;
+  }
+}

--- a/frontend/src/components/ImpersonationModal.css
+++ b/frontend/src/components/ImpersonationModal.css
@@ -322,3 +322,70 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .impersonation-modal {
+    width: calc(100% - 32px);
+    max-height: calc(100vh - 32px);
+  }
+
+  .modal-header {
+    padding: 16px 20px;
+  }
+
+  .modal-header h2 {
+    font-size: 20px;
+  }
+
+  .modal-body {
+    padding: 20px;
+  }
+
+  .employee-info {
+    flex-direction: column;
+    text-align: center;
+    gap: 12px;
+    padding: 14px;
+  }
+
+  .radio-option {
+    padding: 12px;
+  }
+
+  .modal-footer {
+    padding: 16px 20px;
+    flex-direction: column;
+  }
+
+  .btn-cancel,
+  .btn-start {
+    width: 100%;
+    text-align: center;
+    min-height: 44px;
+  }
+}
+
+@media (max-width: 480px) {
+  .impersonation-modal {
+    width: calc(100% - 16px);
+    border-radius: 8px;
+  }
+
+  .modal-body {
+    padding: 16px;
+  }
+
+  .modal-header {
+    padding: 14px 16px;
+  }
+
+  .modal-footer {
+    padding: 14px 16px;
+  }
+
+  .radio-content strong {
+    font-size: 14px;
+  }
+}

--- a/frontend/src/components/JobDescriptionSection.css
+++ b/frontend/src/components/JobDescriptionSection.css
@@ -142,3 +142,46 @@
   color: #7f8c8d;
   font-size: 15px;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .job-description-section {
+    padding: 16px;
+  }
+
+  .section-header-with-actions {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .section-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .btn-save-description {
+    min-height: 44px;
+  }
+
+  .rich-text-editor-wrapper .ql-container,
+  .rich-text-editor-wrapper .ql-editor {
+    min-height: 200px;
+  }
+
+  .editor-footer {
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .job-description-section {
+    padding: 12px;
+  }
+
+  .section-header-with-actions h3 {
+    font-size: 16px;
+  }
+}

--- a/frontend/src/components/MobileCallIntelligencePanel.css
+++ b/frontend/src/components/MobileCallIntelligencePanel.css
@@ -634,3 +634,64 @@
   cursor: pointer;
   min-height: 44px;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .mcip-agent-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 6px;
+  }
+
+  .mcip-header {
+    padding: 10px 12px;
+  }
+
+  .mcip-content {
+    padding: 10px 12px;
+  }
+
+  .mcip-tabs {
+    margin: 10px 12px 0;
+  }
+
+  .mcip-client-banner {
+    margin: 0 12px;
+  }
+
+  .mcip-record-area {
+    padding: 16px 12px;
+  }
+
+  .mcip-sheet {
+    max-height: 80vh;
+  }
+}
+
+@media (max-width: 480px) {
+  .mcip-agent-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .mcip-title {
+    font-size: 15px;
+  }
+
+  .mcip-record-btn {
+    width: 68px;
+    height: 68px;
+  }
+
+  .mcip-record-inner {
+    width: 40px;
+    height: 40px;
+  }
+
+  .mcip-agent-name {
+    font-size: 10px;
+  }
+
+  .mcip-agent-icon {
+    font-size: 20px;
+  }
+}

--- a/frontend/src/components/PermissionGate.css
+++ b/frontend/src/components/PermissionGate.css
@@ -87,3 +87,15 @@ button.readonly-disabled {
   margin-bottom: 2px;
   z-index: 1000;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  /* Disable hover-only tooltips on touch - they don't work well */
+  .permission-gate-disabled[title]:hover::before,
+  .permission-gate-readonly[title]:hover::before,
+  .permission-gate-disabled[title]:hover::after,
+  .permission-gate-readonly[title]:hover::after {
+    display: none;
+  }
+}

--- a/frontend/src/components/RateLockRecommendation.css
+++ b/frontend/src/components/RateLockRecommendation.css
@@ -335,3 +335,68 @@
   color: #dc3545;
   margin-bottom: 12px;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .rate-lock-compact {
+    padding: 6px 12px;
+    gap: 6px;
+  }
+
+  .compact-text {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  .rate-lock-widget .widget-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 10px 12px;
+  }
+
+  .rate-lock-widget .widget-content {
+    padding: 12px;
+  }
+
+  .recommendation-main {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .action-icon {
+    font-size: 24px;
+  }
+
+  .action-name {
+    font-size: 15px;
+  }
+
+  .quant-summary {
+    padding: 8px;
+  }
+
+  .summary-row,
+  .detail-row {
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 0;
+  }
+
+  .action-btn-primary {
+    min-height: 44px;
+  }
+}
+
+@media (max-width: 480px) {
+  .rate-lock-widget .widget-content {
+    padding: 10px;
+  }
+
+  .key-reasons li {
+    font-size: 11px;
+  }
+}

--- a/frontend/src/components/RolesResponsibilitiesTab.css
+++ b/frontend/src/components/RolesResponsibilitiesTab.css
@@ -97,3 +97,54 @@
 .placeholder-features li:last-child {
   margin-bottom: 0;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .roles-responsibilities-tab {
+    padding: 16px;
+  }
+
+  .section-header h2 {
+    font-size: 20px;
+  }
+
+  .section-tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    gap: 0;
+  }
+
+  .section-tab-btn {
+    padding: 10px 14px;
+    font-size: 13px;
+    white-space: nowrap;
+    min-height: 44px;
+  }
+
+  .section-content {
+    padding: 16px;
+  }
+
+  .placeholder-features {
+    padding: 12px 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .roles-responsibilities-tab {
+    padding: 12px;
+  }
+
+  .section-content {
+    padding: 12px;
+  }
+
+  .section-header h2 {
+    font-size: 18px;
+  }
+
+  .placeholder-section h3 {
+    font-size: 17px;
+  }
+}

--- a/frontend/src/components/WorkflowMilestonesTab.css
+++ b/frontend/src/components/WorkflowMilestonesTab.css
@@ -92,3 +92,50 @@
   font-size: 14px;
   line-height: 1.6;
 }
+
+/* ── Mobile Responsive ─────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .workflow-milestones-tab {
+    padding: 16px;
+  }
+
+  .section-header h2 {
+    font-size: 20px;
+  }
+
+  .placeholder-section {
+    padding: 20px;
+  }
+
+  .placeholder-features {
+    padding: 14px;
+  }
+
+  .placeholder-features h4 {
+    font-size: 15px;
+  }
+
+  .migration-notice {
+    padding: 12px 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .workflow-milestones-tab {
+    padding: 12px;
+  }
+
+  .placeholder-section {
+    padding: 16px;
+  }
+
+  .placeholder-section h3 {
+    font-size: 17px;
+  }
+
+  .placeholder-features li {
+    margin-bottom: 8px;
+    font-size: 14px;
+  }
+}

--- a/frontend/src/pages/ClientProfile.css
+++ b/frontend/src/pages/ClientProfile.css
@@ -209,3 +209,85 @@
   border-bottom: 2px solid #218D8D;
 }
 
+/* =============================================
+   MOBILE RESPONSIVE — CLIENT PROFILE
+   ============================================= */
+
+@media (max-width: 768px) {
+  .client-profile-page {
+    padding: 16px;
+  }
+
+  .profile-header {
+    flex-direction: column;
+    gap: 12px;
+    align-items: stretch;
+  }
+
+  .profile-content {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .profile-content.with-assistant {
+    margin-right: 0;
+  }
+
+  .assistant-sidebar {
+    position: fixed;
+    width: 100%;
+    left: 0;
+    right: 0;
+  }
+
+  .info-card,
+  .conversations-card {
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+
+  .info-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .smart-ai-section {
+    padding: 16px;
+  }
+
+  .conv-header {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .loading,
+  .error {
+    padding: 40px 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .client-profile-page {
+    padding: 12px;
+  }
+
+  .profile-header {
+    margin-bottom: 16px;
+  }
+
+  .info-card h2,
+  .conversations-card h2 {
+    font-size: 16px;
+    margin-bottom: 12px;
+  }
+
+  .info-item p {
+    font-size: 14px;
+  }
+
+  .btn-ai {
+    width: 100%;
+    text-align: center;
+  }
+}
+

--- a/frontend/src/pages/Coach.css
+++ b/frontend/src/pages/Coach.css
@@ -8,3 +8,23 @@
   max-width: 1200px;
   margin: 0 auto;
 }
+
+/* =============================================
+   MOBILE RESPONSIVE — COACH
+   ============================================= */
+
+@media (max-width: 768px) {
+  .coach-page {
+    padding: 20px 12px;
+  }
+
+  .coach-page-container {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .coach-page {
+    padding: 16px 8px;
+  }
+}

--- a/frontend/src/pages/EmailVerificationSent.css
+++ b/frontend/src/pages/EmailVerificationSent.css
@@ -103,3 +103,60 @@
 .btn-back-home:hover {
   background-color: #f9fafb;
 }
+
+/* =============================================
+   MOBILE RESPONSIVE — EMAIL VERIFICATION SENT
+   ============================================= */
+
+@media (max-width: 768px) {
+  .verification-sent-page {
+    padding: 16px;
+  }
+
+  .verification-card {
+    padding: 32px 20px;
+    max-width: 100%;
+    border-radius: 12px;
+  }
+
+  .verification-card h1 {
+    font-size: 24px;
+  }
+
+  .success-icon {
+    font-size: 48px;
+    margin-bottom: 16px;
+  }
+
+  .info-box {
+    padding: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .verification-card {
+    padding: 24px 16px;
+  }
+
+  .verification-card h1 {
+    font-size: 20px;
+  }
+
+  .main-message {
+    font-size: 14px;
+  }
+
+  .instructions {
+    font-size: 14px;
+  }
+
+  .btn-resend,
+  .btn-back-home {
+    width: 100%;
+    text-align: center;
+  }
+
+  .help-section p {
+    font-size: 13px;
+  }
+}

--- a/frontend/src/pages/ExperimentsDashboard.css
+++ b/frontend/src/pages/ExperimentsDashboard.css
@@ -696,3 +696,116 @@
   color: #dc2626;
   margin-bottom: 16px;
 }
+
+/* =============================================
+   MOBILE RESPONSIVE — EXPERIMENTS DASHBOARD
+   ============================================= */
+
+@media (max-width: 768px) {
+  .experiments-dashboard {
+    padding: 16px;
+  }
+
+  .experiments-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .btn-create {
+    width: 100%;
+    text-align: center;
+  }
+
+  .experiments-filters {
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px;
+  }
+
+  .experiments-count {
+    margin-left: 0;
+  }
+
+  .experiments-content {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .experiments-list {
+    max-height: none;
+  }
+
+  .experiment-details {
+    max-height: none;
+  }
+
+  .details-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .details-actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .details-actions button {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .analysis-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .modal-content {
+    max-width: 100%;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .variant-form-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .experiments-dashboard {
+    padding: 12px;
+  }
+
+  .header-title h2 {
+    font-size: 22px;
+  }
+
+  .experiment-card {
+    padding: 12px;
+  }
+
+  .experiment-details {
+    padding: 16px;
+  }
+
+  .analysis-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .modal-header {
+    padding: 16px;
+  }
+
+  .modal-body {
+    padding: 16px;
+  }
+
+  .modal-footer {
+    padding: 12px 16px;
+  }
+}

--- a/frontend/src/pages/MissionControl.css
+++ b/frontend/src/pages/MissionControl.css
@@ -509,3 +509,104 @@
   font-size: 16px;
   color: #666;
 }
+
+/* =============================================
+   MOBILE RESPONSIVE — MISSION CONTROL
+   ============================================= */
+
+@media (max-width: 768px) {
+  .mission-control-page {
+    padding: 16px;
+  }
+
+  .page-header {
+    flex-direction: column;
+    gap: 12px;
+    align-items: stretch;
+  }
+
+  .header-actions {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .status-strip {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .mc-section {
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+
+  .section-header {
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
+  }
+
+  .metrics-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .integrations-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .security-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .jobs-table {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .jobs-table th,
+  .jobs-table td {
+    padding: 10px 8px;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  .alert-header {
+    flex-direction: column;
+    gap: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .mission-control-page {
+    padding: 12px;
+  }
+
+  .page-header h1 {
+    font-size: 22px;
+  }
+
+  .status-card {
+    padding: 14px;
+  }
+
+  .status-value {
+    font-size: 20px;
+  }
+
+  .metric-card {
+    padding: 14px;
+  }
+
+  .metric-value {
+    font-size: 22px;
+  }
+
+  .security-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section-header h2 {
+    font-size: 17px;
+  }
+}

--- a/frontend/src/pages/OAuthCallback.css
+++ b/frontend/src/pages/OAuthCallback.css
@@ -99,3 +99,44 @@
 .oauth-close-btn:active {
   transform: translateY(0);
 }
+
+/* =============================================
+   MOBILE RESPONSIVE — OAUTH CALLBACK
+   ============================================= */
+
+@media (max-width: 768px) {
+  .oauth-callback-page {
+    padding: 16px;
+  }
+
+  .oauth-callback-card {
+    padding: 32px 20px;
+    max-width: 100%;
+  }
+
+  .oauth-callback-card h2 {
+    font-size: 20px;
+  }
+}
+
+@media (max-width: 480px) {
+  .oauth-callback-card {
+    padding: 24px 16px;
+    border-radius: 12px;
+  }
+
+  .oauth-icon {
+    width: 48px;
+    height: 48px;
+    font-size: 24px;
+  }
+
+  .oauth-callback-card h2 {
+    font-size: 18px;
+  }
+
+  .oauth-close-btn {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/frontend/src/pages/ProcessTemplates.css
+++ b/frontend/src/pages/ProcessTemplates.css
@@ -580,3 +580,117 @@
 .btn-save:hover {
   background-color: #059669;
 }
+
+/* =============================================
+   MOBILE RESPONSIVE — PROCESS TEMPLATES
+   ============================================= */
+
+@media (max-width: 768px) {
+  .process-templates-container {
+    padding: 16px;
+  }
+
+  .page-header {
+    flex-direction: column;
+    gap: 12px;
+    align-items: stretch;
+    margin-bottom: 20px;
+  }
+
+  .header-actions {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .header-actions button {
+    width: 100%;
+    text-align: center;
+  }
+
+  .role-tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    gap: 4px;
+    margin-bottom: 20px;
+  }
+
+  .role-tab {
+    padding: 10px 16px;
+    font-size: 14px;
+  }
+
+  .efficiency-analysis {
+    padding: 16px;
+    margin-bottom: 20px;
+  }
+
+  .analysis-summary {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .tasks-container {
+    padding: 16px;
+  }
+
+  .tasks-header {
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+  }
+
+  .task-card {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .task-meta {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .task-actions {
+    align-self: flex-end;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .modal-content {
+    width: 95%;
+  }
+
+  .suggestion-header {
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .process-templates-container {
+    padding: 12px;
+  }
+
+  .page-header h1 {
+    font-size: 22px;
+  }
+
+  .role-tab {
+    padding: 8px 12px;
+    font-size: 13px;
+  }
+
+  .summary-stat .value {
+    font-size: 20px;
+  }
+
+  .task-header h3 {
+    font-size: 14px;
+  }
+
+  .tasks-header h2 {
+    font-size: 18px;
+  }
+}

--- a/frontend/src/pages/ReferralPartners.css
+++ b/frontend/src/pages/ReferralPartners.css
@@ -494,3 +494,112 @@
 .form-actions .btn-primary:hover {
   background: #1a7070;
 }
+
+/* =============================================
+   MOBILE RESPONSIVE — REFERRAL PARTNERS
+   ============================================= */
+
+@media (max-width: 768px) {
+  .referral-partners-page {
+    padding: 16px;
+  }
+
+  .page-header {
+    flex-direction: column;
+    gap: 12px;
+    align-items: stretch;
+  }
+
+  .btn-add {
+    width: 100%;
+    text-align: center;
+  }
+
+  .category-toggle {
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px;
+  }
+
+  .category-toggle-btn {
+    padding: 12px 16px;
+    font-size: 14px;
+  }
+
+  .filter-bar {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 4px;
+  }
+
+  .filter-bar button {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .partners-list {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .partners-table {
+    min-width: 600px;
+  }
+
+  .partners-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .partner-details {
+    grid-template-columns: 1fr;
+  }
+
+  .partner-stats {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .form-row {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .form-row .form-group {
+    margin-bottom: 16px;
+  }
+
+  .radio-group {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .modal-content {
+    width: 95%;
+  }
+}
+
+@media (max-width: 480px) {
+  .referral-partners-page {
+    padding: 12px;
+  }
+
+  .page-header h1 {
+    font-size: 24px;
+  }
+
+  .partner-card {
+    padding: 16px;
+  }
+
+  .partner-header h3 {
+    font-size: 16px;
+  }
+
+  .stat-value {
+    font-size: 16px;
+  }
+
+  .modal-content {
+    padding: 16px;
+  }
+}


### PR DESCRIPTION
## Summary

Two independent fixes shipped together:

### Calendar Scheduler Fix
- **Default working hours**: `SchedulerConfig.working_hours` defaulted to `{}` (empty), causing zero available time slots. Now defaults to M-F 9am-5pm
- **Outlook calendar integration**: Wired Microsoft Graph API into the availability engine — Outlook busy times now block scheduler slots. Uses existing OAuth tokens, circuit breaker pattern, 2-minute cache
- **Backfill migration**: `fix_empty_working_hours.py` updates all existing configs with empty working hours to the M-F default

### Mobile Responsive CSS (24 files)
- **9 pages** missing `@media` queries: ClientProfile, Coach, EmailVerificationSent, ExperimentsDashboard, MissionControl, OAuthCallback, ProcessTemplates, ReferralPartners (CalendarSettings already covered via shared CSS)
- **15 components** missing `@media` queries: AdminContracts, AIReceptionist, ClickableContact, ClickToDialButton, DocumentDropModal, DocumentVisibilityControl, GuidelineNotificationBadge, GuidelineUpdatesSidebar, ImpersonationModal, JobDescriptionSection, MobileCallIntelligencePanel, PermissionGate, RateLockRecommendation, RolesResponsibilitiesTab, WorkflowMilestonesTab
- All use standard 768px/480px breakpoints, 44px touch targets, existing class names only

## Test Plan
- [x] Production build compiles clean
- [ ] Verify scheduler shows time slots for admin@perenniaai.com after migration
- [ ] Run migration: `python backend/migrations/fix_empty_working_hours.py`
- [ ] Spot-check mobile layouts on 3-4 pages (resize to 375px width)
- [ ] Verify Outlook integration gracefully skips when no Microsoft OAuth token exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)