### PR TITLE
feat: briefing preferences, voice workflows, and demo data seeding

### DIFF
--- a/backend/agents/intent_router.py
+++ b/backend/agents/intent_router.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # Cache version — increment on any change to intent mappings, patterns, or LLM prompt.
 # This prefix is added to all cache keys so stale entries from previous deployments
 # are automatically bypassed without waiting for TTL expiration.
-INTENT_CACHE_VERSION = "v3"
+INTENT_CACHE_VERSION = "v4"
 
 
 # =============================================================================
@@ -75,6 +75,7 @@ class Intent(str, Enum):
     COACHING = "coaching"          # Team performance coaching
     CUSTOMER = "customer"          # Customer intelligence
     INTEGRATIONS = "integrations"  # LOS/vendor integrations
+    COMPOUND = "compound"          # Multi-action commands (e.g., "text X and schedule Y")
     GENERAL = "general"            # Default fallback
 
 
@@ -124,6 +125,7 @@ INTENT_TO_AGENTS: Dict[str, List[str]] = {
     "customer": ["customer_intelligence"],
     "integrations": ["integrations"],
     "operations": ["ops_manager"],
+    "compound": ["pipeline_analyst", "lead_nurturer", "smart_scheduler", "email_intelligence", "voice_os", "task_automation"],
     "general": ["pipeline_analyst", "task_automation"],  # Default
 }
 
@@ -150,6 +152,14 @@ INTENT_PATTERNS: Dict[str, List[str]] = {
         r"what (can|do) you do",
         r"help me",
         r"^(bye|goodbye|see you|later)",
+    ],
+    # Compound intents - MUST come before individual intents to catch multi-action commands
+    # e.g., "send a text and schedule a meeting" would also match "email" for "send"
+    "compound": [
+        r"(send|text|message|sms|email).{1,40}(and|then|also|plus).{1,40}(schedule|book|set up|arrange|calendar)",
+        r"(schedule|book|set up|arrange).{1,40}(and|then|also|plus).{1,40}(send|text|message|sms|email)",
+        r"(text|message|sms).{1,40}(and|then).{1,40}(schedule|book|set up|arrange|call|meet)",
+        r"(call|contact|reach out).{1,40}(and|then).{1,40}(schedule|book|set up|calendar)",
     ],
     # Historical comparisons - MUST come before pipeline to match Q3/Q4 queries
     "historical": [
@@ -387,7 +397,8 @@ Categories:
 - coaching: Team performance, training, metrics
 - customer: Customer 360, relationships, referrals
 - integrations: LOS sync, credit pulls, AUS
-- general: Unclear or multiple categories
+- compound: Multiple actions in one request (e.g., "text John and schedule a call")
+- general: Unclear or single ambiguous category
 
 Query: {query}
 
@@ -512,6 +523,19 @@ async def classify_intent(
         - elapsed_ms: Classification time in milliseconds
     """
     start = time.time()
+
+    # Guard against None/empty/non-string input
+    if not query or not isinstance(query, str):
+        return {
+            "intent": "general",
+            "confidence": 0.0,
+            "agents": INTENT_TO_AGENTS["general"],
+            "method": "fallback",
+            "matched_pattern": None,
+            "elapsed_ms": 0.0,
+        }
+    # Truncate long inputs to prevent regex DoS on adversarial strings
+    query = query[:1000]
 
     # Try fast pattern matching first
     intent, confidence, pattern = classify_intent_fast(query)

--- a/backend/database/models/__init__.py
+++ b/backend/database/models/__init__.py
@@ -616,8 +616,14 @@ from .compliance_log import ComplianceDecisionLog
 # SMS persistence models (campaign & scheduled job DB-backed state)
 from .sms_persistence import SMSCampaignRecord, ScheduledSMSJobRecord
 
+# SMS dead letter queue (persisted failed messages for retry/monitoring)
+from .sms_dead_letter import SMSDeadLetter
+
 # Morning Briefing (daily AI-generated briefings per user)
 from .morning_briefing import MorningBriefing
+
+# Voice Workflow (async multi-step voice command state machine)
+from .voice_workflow import VoiceWorkflow, VoiceWorkflowState, VoiceWorkflowType
 
 
 __all__ = [
@@ -1250,7 +1256,19 @@ __all__ = [
     "ScheduledSMSJobRecord",
 
     # =====================
+    # SMS Dead Letter Queue
+    # =====================
+    "SMSDeadLetter",
+
+    # =====================
     # Morning Briefing
     # =====================
     "MorningBriefing",
+
+    # =====================
+    # Voice Workflow (Async State Machine)
+    # =====================
+    "VoiceWorkflow",
+    "VoiceWorkflowState",
+    "VoiceWorkflowType",
 ]

--- a/backend/database/models/__init__.py
+++ b/backend/database/models/__init__.py
@@ -625,6 +625,9 @@ from .morning_briefing import MorningBriefing
 # Voice Workflow (async multi-step voice command state machine)
 from .voice_workflow import VoiceWorkflow, VoiceWorkflowState, VoiceWorkflowType
 
+# Demo Data (tracking seeded demo records for cleanup)
+from .demo_data import DemoDataRecord
+
 
 __all__ = [
     # =====================
@@ -1271,4 +1274,9 @@ __all__ = [
     "VoiceWorkflow",
     "VoiceWorkflowState",
     "VoiceWorkflowType",
+
+    # =====================
+    # Demo Data
+    # =====================
+    "DemoDataRecord",
 ]

--- a/backend/database/models/__init__.py
+++ b/backend/database/models/__init__.py
@@ -628,6 +628,9 @@ from .voice_workflow import VoiceWorkflow, VoiceWorkflowState, VoiceWorkflowType
 # Demo Data (tracking seeded demo records for cleanup)
 from .demo_data import DemoDataRecord
 
+# Security Training Records (SOC 2 CC1.4 training evidence)
+from .security_training import SecurityTrainingRecord
+
 
 __all__ = [
     # =====================
@@ -1279,4 +1282,9 @@ __all__ = [
     # Demo Data
     # =====================
     "DemoDataRecord",
+
+    # =====================
+    # Security Training (SOC 2 CC1.4)
+    # =====================
+    "SecurityTrainingRecord",
 ]

--- a/backend/database/models/demo_data.py
+++ b/backend/database/models/demo_data.py
@@ -1,0 +1,25 @@
+"""
+Demo Data Record Model
+
+Tracks which records were seeded as demo data so they can be
+cleanly removed without affecting real production data.
+"""
+from sqlalchemy import Column, Integer, String, DateTime, Index
+from sqlalchemy.sql import func
+
+from db import Base
+
+
+class DemoDataRecord(Base):
+    """Tracks demo-seeded entities for cleanup."""
+    __tablename__ = "demo_data_records"
+    __table_args__ = (
+        Index("ix_demo_data_org_id", "organization_id"),
+        Index("ix_demo_data_org_entity", "organization_id", "entity_type"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    organization_id = Column(Integer, nullable=False, index=True)
+    entity_type = Column(String, nullable=False)  # lead, loan, activity, appointment, compliance_alert, document, morning_briefing
+    entity_id = Column(Integer, nullable=False)
+    created_at = Column(DateTime, server_default=func.now())

--- a/backend/database/models/security_training.py
+++ b/backend/database/models/security_training.py
@@ -1,0 +1,62 @@
+"""
+Security Training Completion Records — SOC 2 CC1.4
+
+Tracks employee completion of security awareness training programs,
+attestations, and quiz scores for SOC 2 Type II audit evidence.
+
+Usage:
+    from database.models.security_training import SecurityTrainingRecord
+
+    record = db.query(SecurityTrainingRecord).filter(
+        SecurityTrainingRecord.user_id == user_id,
+        SecurityTrainingRecord.training_year == 2026,
+    ).first()
+"""
+
+from sqlalchemy import (
+    Column, Integer, String, Boolean, DateTime, Text, ForeignKey, JSON,
+    Index,
+)
+from sqlalchemy.sql import func
+
+# Import Base from the db module (renamed from database.py)
+from db import Base
+
+
+class SecurityTrainingRecord(Base):
+    """Employee security training completion record for SOC 2 CC1.4 evidence."""
+    __tablename__ = "security_training_records"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    organization_id = Column(Integer, ForeignKey("organizations.id"), nullable=True, index=True)
+
+    # Training details
+    training_type = Column(String, nullable=False)  # annual_security_awareness, onboarding, incident_response, data_handling
+    training_year = Column(Integer, nullable=False)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    # Assessment
+    score = Column(Integer, nullable=True)  # quiz score percentage (0-100)
+    passed = Column(Boolean, default=False)
+    passing_score = Column(Integer, default=80)
+
+    # Attestation
+    attestation_text = Column(Text, nullable=True)  # what the user acknowledged
+    attested_at = Column(DateTime(timezone=True), nullable=True)
+
+    # Certificate
+    certificate_id = Column(String, nullable=True)  # unique cert ID for auditor reference
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+
+    # Flexible metadata (training provider, module version, etc.)
+    metadata = Column(JSON, nullable=True)
+
+    # Timestamps
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        Index("ix_security_training_user_year", "user_id", "training_year"),
+        Index("ix_security_training_org_type_year", "organization_id", "training_type", "training_year"),
+    )

--- a/backend/deepgram_voice_agent.py
+++ b/backend/deepgram_voice_agent.py
@@ -26,24 +26,39 @@ router = APIRouter(prefix="/api/v1/voice-agent", tags=["voice-agent"])
 # Configuration
 DEEPGRAM_API_KEY = os.getenv("DEEPGRAM_API_KEY", "")
 
-# Aria system prompt for voice interactions
-ARIA_SYSTEM_PROMPT = """You are Aria, a warm and professional AI assistant for mortgage loan officers.
-You help them manage their pipeline, follow up with leads, schedule appointments, and answer questions.
+# White-label voice assistant name — configurable per deployment/tenant (H-1)
+DEFAULT_VOICE_ASSISTANT_NAME = os.getenv("VOICE_ASSISTANT_NAME", "Aria")
 
-Voice conversation guidelines:
-- Keep responses concise and conversational (under 50 words when possible)
-- Use natural speech patterns
-- Be warm, friendly, and professional
-- When asked to perform actions, confirm what you're doing
-- Ask clarifying questions when needed
+# Voice agent system prompt — uses {assistant_name} and {business_name} placeholders for white-label
+VOICE_AGENT_PROMPT_TEMPLATE = """You are {assistant_name}, an AI assistant for mortgage loan officers at {business_name}.
+
+You are warm, friendly, and professional. Keep responses concise — under 50 words when possible.
 
 You can help with:
-- Looking up leads and contacts
-- Checking pipeline status
-- Scheduling appointments
-- Sending text messages
-- Creating tasks and follow-ups
-- Providing loan and market information"""
+- Answering questions about leads, loans, and pipeline
+- Discussing scheduling options and availability
+- Composing text messages and emails (which the LO can review and send)
+- Planning tasks and follow-ups
+- Providing mortgage rate and market information
+
+IMPORTANT: You are a conversational assistant. You can discuss and plan actions, but
+you cannot directly send messages, book appointments, or modify CRM data. When the
+loan officer wants to take an action, confirm what they'd like to do and let them
+know it will be queued for execution through the voice assistant app.
+
+If unsure about something, say so. Don't make up loan details or rates."""
+
+
+def get_voice_agent_prompt(assistant_name: Optional[str] = None, business_name: str = "{business_name}") -> str:
+    """Get the voice agent system prompt with configurable assistant and business names.
+
+    Args:
+        assistant_name: Override assistant name. Defaults to DEFAULT_VOICE_ASSISTANT_NAME.
+        business_name: Business name to insert. Defaults to '{business_name}' placeholder
+                       for downstream formatting by the voice agent session.
+    """
+    name = assistant_name or DEFAULT_VOICE_ASSISTANT_NAME
+    return VOICE_AGENT_PROMPT_TEMPLATE.format(assistant_name=name, business_name=business_name)
 
 
 class DeepgramVoiceAgentSession:
@@ -118,7 +133,7 @@ class DeepgramVoiceAgentSession:
                         "type": "anthropic"
                     },
                     "model": "claude-3-haiku-20240307",
-                    "instructions": ARIA_SYSTEM_PROMPT
+                    "instructions": get_voice_agent_prompt()
                 },
                 "speak": {
                     "model": "aura-asteria-en"

--- a/backend/feature_tiers.py
+++ b/backend/feature_tiers.py
@@ -72,6 +72,7 @@ FEATURE_TIERS: Dict[str, FeatureTier] = {
     # PREMIUM - maintained when resources allow
     "microsite_builder": FeatureTier.PREMIUM,
     "video_meetings": FeatureTier.PREMIUM,
+    "voice_workflows": FeatureTier.PREMIUM,
     "scheduler_surveys": FeatureTier.PREMIUM,
     "scheduler_waitlist": FeatureTier.PREMIUM,
     # Deleted modules (Mar 2026): scheduler_labels, scheduler_booking_meta, scheduler_sitemap

--- a/backend/main.py
+++ b/backend/main.py
@@ -1518,6 +1518,14 @@ try:
 except Exception as e:
     logger.warning(f"SOC 2 Compliance admin routes skipped: {e}")
 
+# SOC 2 Security Training Tracking (CC1.4 evidence)
+try:
+    from routes.security_training_routes import router as security_training_router
+    app.include_router(security_training_router, tags=["SOC 2 Training"])
+    logger.info("Security training routes loaded")
+except Exception as e:
+    logger.warning(f"Security training routes skipped: {e}")
+
 # ============================================================================
 # PIPELINE APPOINTMENT TRIGGER ROUTES — Auto-schedule from stage changes
 # ============================================================================

--- a/backend/migrations/add_security_training_table.py
+++ b/backend/migrations/add_security_training_table.py
@@ -1,0 +1,136 @@
+"""
+Add Security Training Records Table — SOC 2 CC1.4
+
+Creates the security_training_records table for tracking employee
+security awareness training completions, attestations, and certificates.
+
+Usage:
+    python -m migrations.add_security_training_table
+    # or
+    from migrations.add_security_training_table import run_migration
+    run_migration()
+"""
+
+import os
+import logging
+from sqlalchemy import create_engine, text
+
+logger = logging.getLogger(__name__)
+
+
+def run_migration():
+    """Create the security_training_records table and indexes."""
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        logger.error("DATABASE_URL not set")
+        return False
+
+    if database_url.startswith("postgres://"):
+        database_url = database_url.replace("postgres://", "postgresql://", 1)
+
+    engine = create_engine(database_url)
+    is_sqlite = "sqlite" in database_url.lower()
+
+    with engine.connect() as conn:
+        logger.info("Creating security_training_records table...")
+
+        try:
+            if is_sqlite:
+                conn.execute(text("""
+                    CREATE TABLE IF NOT EXISTS security_training_records (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        user_id INTEGER NOT NULL,
+                        organization_id INTEGER,
+                        training_type VARCHAR NOT NULL,
+                        training_year INTEGER NOT NULL,
+                        completed_at TIMESTAMP,
+                        score INTEGER,
+                        passed BOOLEAN DEFAULT 0,
+                        passing_score INTEGER DEFAULT 80,
+                        attestation_text TEXT,
+                        attested_at TIMESTAMP,
+                        certificate_id VARCHAR,
+                        expires_at TIMESTAMP,
+                        metadata TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        FOREIGN KEY (user_id) REFERENCES users(id),
+                        FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                    )
+                """))
+            else:
+                conn.execute(text("""
+                    CREATE TABLE IF NOT EXISTS security_training_records (
+                        id SERIAL PRIMARY KEY,
+                        user_id INTEGER NOT NULL REFERENCES users(id),
+                        organization_id INTEGER REFERENCES organizations(id),
+                        training_type VARCHAR NOT NULL,
+                        training_year INTEGER NOT NULL,
+                        completed_at TIMESTAMPTZ,
+                        score INTEGER,
+                        passed BOOLEAN DEFAULT FALSE,
+                        passing_score INTEGER DEFAULT 80,
+                        attestation_text TEXT,
+                        attested_at TIMESTAMPTZ,
+                        certificate_id VARCHAR,
+                        expires_at TIMESTAMPTZ,
+                        metadata JSONB,
+                        created_at TIMESTAMPTZ DEFAULT NOW(),
+                        updated_at TIMESTAMPTZ DEFAULT NOW()
+                    )
+                """))
+
+            conn.commit()
+            logger.info("  security_training_records table created")
+        except Exception as e:
+            error_str = str(e).lower()
+            if "already exists" in error_str:
+                logger.info("  security_training_records table already exists")
+            else:
+                logger.error(f"Failed to create security_training_records table: {e}")
+                return False
+
+        # Create indexes
+        indexes = [
+            (
+                "ix_security_training_user_id",
+                "CREATE INDEX IF NOT EXISTS ix_security_training_user_id "
+                "ON security_training_records (user_id)",
+            ),
+            (
+                "ix_security_training_org_id",
+                "CREATE INDEX IF NOT EXISTS ix_security_training_org_id "
+                "ON security_training_records (organization_id)",
+            ),
+            (
+                "ix_security_training_user_year",
+                "CREATE INDEX IF NOT EXISTS ix_security_training_user_year "
+                "ON security_training_records (user_id, training_year)",
+            ),
+            (
+                "ix_security_training_org_type_year",
+                "CREATE INDEX IF NOT EXISTS ix_security_training_org_type_year "
+                "ON security_training_records (organization_id, training_type, training_year)",
+            ),
+        ]
+
+        for idx_name, idx_sql in indexes:
+            try:
+                conn.execute(text(idx_sql))
+                logger.info(f"  Created index {idx_name}")
+            except Exception as e:
+                error_str = str(e).lower()
+                if "already exists" in error_str:
+                    pass
+                else:
+                    logger.warning(f"Could not create index {idx_name}: {e}")
+
+        conn.commit()
+
+    logger.info("Security training migration complete")
+    return True
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    run_migration()

--- a/backend/mobile_voice_routes.py
+++ b/backend/mobile_voice_routes.py
@@ -42,8 +42,11 @@ GOOGLE_TTS_LANGUAGE = os.getenv("GOOGLE_TTS_LANGUAGE", "en-US")
 ELEVENLABS_VOICE_ID = os.getenv("ELEVENLABS_VOICE_ID", "21m00Tcm4TlvDq8ikWAM")  # Rachel - warm female voice
 TTS_MODEL = os.getenv("TTS_MODEL", "eleven_turbo_v2_5")  # Fast model for low latency
 
-# Aria system prompt for voice interactions
-ARIA_VOICE_PROMPT = """You are Aria, a warm and professional AI assistant for mortgage loan officers.
+# White-label voice assistant name — configurable per deployment/tenant (H-1)
+DEFAULT_VOICE_ASSISTANT_NAME = os.getenv("VOICE_ASSISTANT_NAME", "Aria")
+
+# Voice assistant system prompt — uses {assistant_name} placeholder for white-label support
+VOICE_ASSISTANT_PROMPT_TEMPLATE = """You are {assistant_name}, a warm and professional AI assistant for mortgage loan officers.
 You help them manage their pipeline, follow up with leads, schedule appointments, and answer questions.
 
 Voice conversation guidelines:
@@ -61,6 +64,22 @@ You have access to the CRM system and can:
 - Send text messages
 - Create tasks and follow-ups
 - Provide loan and market information"""
+
+
+def get_voice_assistant_name(organization_id: Optional[int] = None) -> str:
+    """Get the voice assistant name, potentially per-organization.
+
+    Currently returns the global default. In the future, this can be extended
+    to look up per-org branding from the database.
+    """
+    # TODO: Look up org-specific assistant name from organization settings table
+    return DEFAULT_VOICE_ASSISTANT_NAME
+
+
+def get_voice_assistant_prompt(assistant_name: Optional[str] = None) -> str:
+    """Get the voice assistant system prompt with the configured name."""
+    name = assistant_name or DEFAULT_VOICE_ASSISTANT_NAME
+    return VOICE_ASSISTANT_PROMPT_TEMPLATE.format(assistant_name=name)
 
 
 class DeepgramSTTClient:
@@ -300,7 +319,7 @@ class AriaVoiceAgent:
         import traceback
         try:
             # Use the AIAgentService which connects to the full LangGraph orchestrator
-            # This gives Aria access to all 160+ tools including:
+            # This gives the voice agent access to all 160+ tools including:
             # - Pipeline analysis (bottlenecks, metrics, aging)
             # - Lead management (scoring, follow-ups, outreach)
             # - Document tracking
@@ -400,10 +419,11 @@ class AriaVoiceAgent:
                 # Simple direct response for voice
                 voice_messages = self.conversation_history[-6:]  # Keep last 3 exchanges
 
+                assistant_name = get_voice_assistant_name()
                 ai_response = client.messages.create(
                     model="claude-sonnet-4-20250514",
                     max_tokens=200,
-                    system="""You are Aria, a helpful mortgage assistant. Keep responses brief (under 50 words) and conversational for voice. Be warm and professional.
+                    system=f"""You are {assistant_name}, a helpful mortgage assistant. Keep responses brief (under 50 words) and conversational for voice. Be warm and professional.
 
 Note: I'm currently unable to access the CRM system. Please let the user know that database features are temporarily unavailable and suggest they try again shortly.""",
                     messages=voice_messages
@@ -648,7 +668,7 @@ async def mobile_voice_websocket(
     db: Session = Depends(get_db)
 ):
     """
-    WebSocket endpoint for real-time voice conversation with Aria.
+    WebSocket endpoint for real-time voice conversation with the voice assistant.
 
     Protocol:
     - Client sends audio chunks as base64-encoded data
@@ -877,7 +897,7 @@ async def get_user_voice_preference(
     current_user: "User" = Depends(get_current_user_lazy),
     db: Session = Depends(get_db)
 ):
-    """Get user's saved voice preference for Aria conversations"""
+    """Get user's saved voice preference for voice assistant conversations"""
     try:
         # Check user_settings table for tts_voice and tts_provider
         result = db.execute(
@@ -911,7 +931,7 @@ async def save_user_voice_preference(
     current_user: "User" = Depends(get_current_user_lazy),
     db: Session = Depends(get_db)
 ):
-    """Save user's voice preference for Aria conversations"""
+    """Save user's voice preference for voice assistant conversations"""
     voice_id = request.get("voice_id")
     provider = request.get("provider")
 

--- a/backend/routes/admin_ops_routes.py
+++ b/backend/routes/admin_ops_routes.py
@@ -2879,6 +2879,63 @@ def register_admin_ops_routes(app, get_db, get_current_user, get_current_user_fl
             logger.error(f"Error clearing all CRM data: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail="Internal server error")
 
+    # ========================================================================
+    # DEMO DATA SEEDING & CLEANUP
+    # ========================================================================
+
+    @app.post("/api/v1/admin/seed-demo-data")
+    async def seed_demo_data_endpoint(
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+    ):
+        """Seed realistic demo data into the current user's organization.
+        Admin/site_admin/platform_admin only.
+        """
+        if not hasattr(current_user, 'role') or current_user.role not in ('admin', 'site_admin', 'platform_admin'):
+            raise HTTPException(status_code=403, detail="Admin role required to seed demo data")
+
+        try:
+            from scripts.seed_demo_org import seed_demo_data
+            result = seed_demo_data(
+                db,
+                organization_id=current_user.organization_id,
+                user_id=current_user.id,
+            )
+            return {
+                "status": "ok",
+                "message": f"Seeded {result['total']} demo entities",
+                **result,
+            }
+        except Exception as e:
+            logger.exception("Demo data seeding failed")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    @app.delete("/api/v1/admin/seed-demo-data")
+    async def clear_demo_data_endpoint(
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+    ):
+        """Remove all demo-seeded data from the current user's organization.
+        Admin/site_admin/platform_admin only.
+        """
+        if not hasattr(current_user, 'role') or current_user.role not in ('admin', 'site_admin', 'platform_admin'):
+            raise HTTPException(status_code=403, detail="Admin role required to clear demo data")
+
+        try:
+            from scripts.seed_demo_org import clear_demo_data
+            result = clear_demo_data(
+                db,
+                organization_id=current_user.organization_id,
+            )
+            return {
+                "status": "ok",
+                "message": f"Removed {result['total']} demo entities",
+                **result,
+            }
+        except Exception as e:
+            logger.exception("Demo data cleanup failed")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
     @app.get("/api/v1/admin/crm-data-counts")
     async def get_crm_data_counts(
         admin_key: str = Query(None),

--- a/backend/routes/security_training_routes.py
+++ b/backend/routes/security_training_routes.py
@@ -1,0 +1,560 @@
+"""
+Security Training Tracking Routes — SOC 2 CC1.4
+================================================
+
+Admin and self-service endpoints for recording, querying, and generating
+evidence of employee security awareness training completions.
+
+Prefix: /api/v1
+Tags:   ["Security Training"]
+
+Endpoints:
+    POST /api/v1/admin/soc2/training/record  — Record training completion for a user
+    GET  /api/v1/admin/soc2/training/status   — Training compliance status (who has/hasn't completed)
+    GET  /api/v1/admin/soc2/training/user/{user_id} — Specific user's training history
+    GET  /api/v1/admin/soc2/training/evidence — Generate training evidence for SOC 2 auditor
+    POST /api/v1/soc2/training/attest         — User self-service attestation
+
+All admin endpoints require admin, site_admin, or platform_admin permission_role.
+The self-service attestation endpoint only requires an authenticated user.
+
+Registration pattern: APIRouter (auto-included by FastAPI app discovery).
+Uses lazy runtime imports from main to avoid circular dependencies, following
+the same pattern as routes/soc2_compliance_routes.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Path
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+from sqlalchemy import func as sa_func
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# ROUTER
+# ============================================================================
+
+router = APIRouter(
+    prefix="/api/v1",
+    tags=["Security Training"],
+)
+
+# ============================================================================
+# ADMIN ROLES — mirrors routes/soc2_compliance_routes.py
+# ============================================================================
+
+_ADMIN_ROLES = ("admin", "site_admin", "platform_admin")
+
+
+# ============================================================================
+# RUNTIME DEPENDENCY HELPERS
+# (Lazy imports to avoid circular import at module load time)
+# ============================================================================
+
+def _get_current_user_dep():
+    """Return get_current_user from main at request time."""
+    import main  # noqa: PLC0415
+    return main.get_current_user
+
+
+def _get_db_dep():
+    """Return get_db from database at request time."""
+    from database import get_db  # noqa: PLC0415
+    return get_db
+
+
+# ============================================================================
+# HELPERS
+# ============================================================================
+
+def _require_admin(current_user: Any) -> None:
+    """Raise HTTP 403 if the user is not an admin role."""
+    role = getattr(current_user, "permission_role", "")
+    if role not in _ADMIN_ROLES:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"Access denied. Required role: {_ADMIN_ROLES}. "
+                f"Your role: '{role}'."
+            ),
+        )
+
+
+def _ensure_table(db: Session) -> None:
+    """Create the security_training_records table if it doesn't exist.
+
+    Uses checkfirst=True so it's safe to call on every request.
+    Production tables should already exist via the migration script.
+    """
+    try:
+        from database.models.security_training import SecurityTrainingRecord
+        SecurityTrainingRecord.__table__.create(db.get_bind(), checkfirst=True)
+    except Exception as e:
+        logger.debug(f"Table ensure check (non-fatal): {e}")
+
+
+# ============================================================================
+# PYDANTIC SCHEMAS
+# ============================================================================
+
+class TrainingRecordCreate(BaseModel):
+    """Request body for recording a training completion."""
+    user_id: int
+    training_type: str = Field(
+        ...,
+        description="Type of training: annual_security_awareness, onboarding, incident_response, data_handling",
+    )
+    training_year: int = Field(..., description="Year the training applies to (e.g. 2026)")
+    score: Optional[int] = Field(None, ge=0, le=100, description="Quiz score percentage")
+    passing_score: int = Field(80, ge=0, le=100, description="Minimum passing score")
+    completed_at: Optional[str] = Field(None, description="ISO datetime of completion (defaults to now)")
+    metadata: Optional[Dict[str, Any]] = Field(None, description="Extra info (provider, module version, etc.)")
+
+
+class AttestationCreate(BaseModel):
+    """Request body for self-service attestation."""
+    training_type: str = Field(
+        ...,
+        description="Type of training being attested to",
+    )
+    training_year: int = Field(..., description="Year the training applies to")
+    attestation_text: str = Field(
+        ...,
+        description="The security policy text the user is acknowledging",
+    )
+
+
+# ============================================================================
+# ADMIN ENDPOINTS
+# ============================================================================
+
+@router.post(
+    "/admin/soc2/training/record",
+    summary="Record Training Completion",
+    response_description="The newly created training record.",
+)
+async def record_training_completion(
+    body: TrainingRecordCreate,
+    current_user=Depends(_get_current_user_dep()),
+    db: Session = Depends(_get_db_dep()),
+) -> Dict[str, Any]:
+    """
+    Record a user's security training completion.
+
+    Creates a SecurityTrainingRecord with quiz score, pass/fail status,
+    and a unique certificate ID for auditor reference.
+
+    **Required role:** admin, site_admin, or platform_admin
+    """
+    _require_admin(current_user)
+    _ensure_table(db)
+
+    from database.models.security_training import SecurityTrainingRecord
+    from database.models.core import User
+
+    # Verify user exists
+    user = db.query(User).filter(User.id == body.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User {body.user_id} not found")
+
+    completed_at = (
+        datetime.fromisoformat(body.completed_at)
+        if body.completed_at
+        else datetime.now(timezone.utc)
+    )
+    passed = (body.score or 0) >= body.passing_score if body.score is not None else False
+    certificate_id = f"CERT-{uuid.uuid4().hex[:8].upper()}" if passed else None
+
+    record = SecurityTrainingRecord(
+        user_id=body.user_id,
+        organization_id=getattr(user, "organization_id", None),
+        training_type=body.training_type,
+        training_year=body.training_year,
+        completed_at=completed_at,
+        score=body.score,
+        passed=passed,
+        passing_score=body.passing_score,
+        certificate_id=certificate_id,
+        expires_at=completed_at + timedelta(days=365) if passed else None,
+        metadata=body.metadata,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+
+    logger.info(
+        "Training record created: user_id=%s type=%s year=%s passed=%s by=%s",
+        body.user_id, body.training_type, body.training_year, passed,
+        getattr(current_user, "email", "unknown"),
+    )
+
+    return {
+        "id": record.id,
+        "user_id": record.user_id,
+        "training_type": record.training_type,
+        "training_year": record.training_year,
+        "score": record.score,
+        "passed": record.passed,
+        "certificate_id": record.certificate_id,
+        "completed_at": record.completed_at.isoformat() if record.completed_at else None,
+        "expires_at": record.expires_at.isoformat() if record.expires_at else None,
+        "created_at": record.created_at.isoformat() if record.created_at else None,
+    }
+
+
+@router.get(
+    "/admin/soc2/training/status",
+    summary="Training Compliance Status",
+    response_description="Compliance overview: who has and hasn't completed training.",
+)
+async def get_training_status(
+    training_type: str = Query(
+        "annual_security_awareness",
+        description="Training type to check status for",
+    ),
+    training_year: int = Query(
+        None,
+        description="Year to check (defaults to current year)",
+    ),
+    organization_id: Optional[int] = Query(
+        None,
+        description="Filter to a specific organization",
+    ),
+    current_user=Depends(_get_current_user_dep()),
+    db: Session = Depends(_get_db_dep()),
+) -> Dict[str, Any]:
+    """
+    Get training compliance status showing which users have and haven't
+    completed the specified training for the given year.
+
+    Returns counts and lists of compliant/non-compliant users.
+
+    **Required role:** admin, site_admin, or platform_admin
+    """
+    _require_admin(current_user)
+    _ensure_table(db)
+
+    from database.models.security_training import SecurityTrainingRecord
+    from database.models.core import User
+
+    if training_year is None:
+        training_year = datetime.now(timezone.utc).year
+
+    # Get all active users
+    user_query = db.query(User).filter(User.is_active == True)  # noqa: E712
+    if organization_id:
+        user_query = user_query.filter(User.organization_id == organization_id)
+    all_users = user_query.all()
+
+    # Get completed training records for this type/year
+    record_query = db.query(SecurityTrainingRecord).filter(
+        SecurityTrainingRecord.training_type == training_type,
+        SecurityTrainingRecord.training_year == training_year,
+        SecurityTrainingRecord.passed == True,  # noqa: E712
+    )
+    if organization_id:
+        record_query = record_query.filter(
+            SecurityTrainingRecord.organization_id == organization_id,
+        )
+    completed_records = record_query.all()
+    completed_user_ids = {r.user_id for r in completed_records}
+
+    compliant = []
+    non_compliant = []
+    for user in all_users:
+        user_info = {
+            "user_id": user.id,
+            "email": getattr(user, "email", ""),
+            "name": f"{getattr(user, 'first_name', '')} {getattr(user, 'last_name', '')}".strip(),
+        }
+        if user.id in completed_user_ids:
+            record = next(r for r in completed_records if r.user_id == user.id)
+            user_info["completed_at"] = record.completed_at.isoformat() if record.completed_at else None
+            user_info["score"] = record.score
+            user_info["certificate_id"] = record.certificate_id
+            compliant.append(user_info)
+        else:
+            non_compliant.append(user_info)
+
+    total = len(all_users)
+    compliant_count = len(compliant)
+    compliance_rate = round((compliant_count / max(total, 1)) * 100, 1)
+
+    return {
+        "training_type": training_type,
+        "training_year": training_year,
+        "organization_id": organization_id,
+        "total_users": total,
+        "compliant_count": compliant_count,
+        "non_compliant_count": len(non_compliant),
+        "compliance_rate_pct": compliance_rate,
+        "compliant_users": compliant,
+        "non_compliant_users": non_compliant,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get(
+    "/admin/soc2/training/user/{user_id}",
+    summary="User Training History",
+    response_description="All training records for a specific user.",
+)
+async def get_user_training_history(
+    user_id: int = Path(..., description="User ID to look up"),
+    current_user=Depends(_get_current_user_dep()),
+    db: Session = Depends(_get_db_dep()),
+) -> Dict[str, Any]:
+    """
+    Get a specific user's complete training history across all types and years.
+
+    **Required role:** admin, site_admin, or platform_admin
+    """
+    _require_admin(current_user)
+    _ensure_table(db)
+
+    from database.models.security_training import SecurityTrainingRecord
+    from database.models.core import User
+
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User {user_id} not found")
+
+    records = (
+        db.query(SecurityTrainingRecord)
+        .filter(SecurityTrainingRecord.user_id == user_id)
+        .order_by(SecurityTrainingRecord.training_year.desc(), SecurityTrainingRecord.created_at.desc())
+        .all()
+    )
+
+    return {
+        "user_id": user_id,
+        "email": getattr(user, "email", ""),
+        "name": f"{getattr(user, 'first_name', '')} {getattr(user, 'last_name', '')}".strip(),
+        "total_records": len(records),
+        "records": [
+            {
+                "id": r.id,
+                "training_type": r.training_type,
+                "training_year": r.training_year,
+                "completed_at": r.completed_at.isoformat() if r.completed_at else None,
+                "score": r.score,
+                "passed": r.passed,
+                "passing_score": r.passing_score,
+                "certificate_id": r.certificate_id,
+                "attested_at": r.attested_at.isoformat() if r.attested_at else None,
+                "expires_at": r.expires_at.isoformat() if r.expires_at else None,
+                "metadata": r.metadata,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in records
+        ],
+    }
+
+
+@router.get(
+    "/admin/soc2/training/evidence",
+    summary="Generate Training Evidence for SOC 2 Auditor",
+    response_description="Structured evidence package for SOC 2 CC1.4 training control.",
+)
+async def get_training_evidence(
+    training_year: int = Query(
+        None,
+        description="Year to generate evidence for (defaults to current year)",
+    ),
+    organization_id: Optional[int] = Query(
+        None,
+        description="Filter to a specific organization",
+    ),
+    current_user=Depends(_get_current_user_dep()),
+    db: Session = Depends(_get_db_dep()),
+) -> Dict[str, Any]:
+    """
+    Generate a structured training evidence package for SOC 2 auditors.
+
+    Includes:
+    - Overall completion rates by training type
+    - Per-user completion matrix
+    - Certificate listing
+    - Attestation summary
+    - Gap analysis (who still needs training)
+
+    **Required role:** admin, site_admin, or platform_admin
+    """
+    _require_admin(current_user)
+    _ensure_table(db)
+
+    from database.models.security_training import SecurityTrainingRecord
+    from database.models.core import User
+
+    if training_year is None:
+        training_year = datetime.now(timezone.utc).year
+
+    # Get all active users
+    user_query = db.query(User).filter(User.is_active == True)  # noqa: E712
+    if organization_id:
+        user_query = user_query.filter(User.organization_id == organization_id)
+    all_users = user_query.all()
+    user_map = {u.id: u for u in all_users}
+
+    # Get all records for the year
+    record_query = db.query(SecurityTrainingRecord).filter(
+        SecurityTrainingRecord.training_year == training_year,
+    )
+    if organization_id:
+        record_query = record_query.filter(
+            SecurityTrainingRecord.organization_id == organization_id,
+        )
+    records = record_query.all()
+
+    # Completion rates by training type
+    training_types = set(r.training_type for r in records)
+    training_types.add("annual_security_awareness")  # Always include the primary type
+
+    by_type = {}
+    for tt in sorted(training_types):
+        type_records = [r for r in records if r.training_type == tt and r.passed]
+        completed_user_ids = {r.user_id for r in type_records}
+        total_users = len(all_users)
+        completed_count = len(completed_user_ids)
+        by_type[tt] = {
+            "total_users": total_users,
+            "completed": completed_count,
+            "completion_rate_pct": round((completed_count / max(total_users, 1)) * 100, 1),
+            "missing_users": [
+                {
+                    "user_id": u.id,
+                    "email": getattr(u, "email", ""),
+                    "name": f"{getattr(u, 'first_name', '')} {getattr(u, 'last_name', '')}".strip(),
+                }
+                for u in all_users
+                if u.id not in completed_user_ids
+            ],
+        }
+
+    # Certificate listing
+    certificates = [
+        {
+            "certificate_id": r.certificate_id,
+            "user_id": r.user_id,
+            "email": getattr(user_map.get(r.user_id), "email", "unknown"),
+            "training_type": r.training_type,
+            "completed_at": r.completed_at.isoformat() if r.completed_at else None,
+            "score": r.score,
+            "expires_at": r.expires_at.isoformat() if r.expires_at else None,
+        }
+        for r in records
+        if r.certificate_id
+    ]
+
+    # Attestation summary
+    attested_records = [r for r in records if r.attested_at is not None]
+
+    return {
+        "evidence_type": "SOC2_CC1.4_Security_Training",
+        "training_year": training_year,
+        "organization_id": organization_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_by": getattr(current_user, "email", "unknown"),
+        "summary": {
+            "total_active_users": len(all_users),
+            "total_training_records": len(records),
+            "total_certificates_issued": len(certificates),
+            "total_attestations": len(attested_records),
+            "training_types_tracked": sorted(training_types),
+        },
+        "completion_by_type": by_type,
+        "certificates": certificates,
+        "attestation_count": len(attested_records),
+        "control_reference": "CC1.4 — The entity has established and is maintaining training programs for employees.",
+    }
+
+
+# ============================================================================
+# SELF-SERVICE ENDPOINTS
+# ============================================================================
+
+@router.post(
+    "/soc2/training/attest",
+    summary="Self-Service Training Attestation",
+    response_description="Attestation confirmation.",
+)
+async def self_attest_training(
+    body: AttestationCreate,
+    current_user=Depends(_get_current_user_dep()),
+    db: Session = Depends(_get_db_dep()),
+) -> Dict[str, Any]:
+    """
+    User self-service endpoint to attest that they have read and understood
+    the security training material.
+
+    Creates or updates a SecurityTrainingRecord with the attestation text
+    and timestamp. If no prior completion record exists for this user/type/year,
+    creates one with passed=False (score will need to be recorded separately
+    by an admin if a quiz is required).
+
+    **Required:** Authenticated user (any role).
+    """
+    _ensure_table(db)
+
+    from database.models.security_training import SecurityTrainingRecord
+
+    user_id = getattr(current_user, "id", None)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Could not identify current user")
+
+    now = datetime.now(timezone.utc)
+
+    # Look for an existing record for this user/type/year
+    record = (
+        db.query(SecurityTrainingRecord)
+        .filter(
+            SecurityTrainingRecord.user_id == user_id,
+            SecurityTrainingRecord.training_type == body.training_type,
+            SecurityTrainingRecord.training_year == body.training_year,
+        )
+        .first()
+    )
+
+    if record:
+        # Update existing record with attestation
+        record.attestation_text = body.attestation_text
+        record.attested_at = now
+        record.updated_at = now
+    else:
+        # Create a new record for the attestation
+        record = SecurityTrainingRecord(
+            user_id=user_id,
+            organization_id=getattr(current_user, "organization_id", None),
+            training_type=body.training_type,
+            training_year=body.training_year,
+            attestation_text=body.attestation_text,
+            attested_at=now,
+            passed=False,  # Attestation alone does not count as passing
+        )
+        db.add(record)
+
+    db.commit()
+    db.refresh(record)
+
+    logger.info(
+        "Training attestation recorded: user_id=%s type=%s year=%s",
+        user_id, body.training_type, body.training_year,
+    )
+
+    return {
+        "id": record.id,
+        "user_id": record.user_id,
+        "training_type": record.training_type,
+        "training_year": record.training_year,
+        "attestation_text": record.attestation_text,
+        "attested_at": record.attested_at.isoformat() if record.attested_at else None,
+        "passed": record.passed,
+        "message": "Attestation recorded successfully.",
+    }

--- a/backend/routes/telnyx_webhook_routes.py
+++ b/backend/routes/telnyx_webhook_routes.py
@@ -396,6 +396,114 @@ async def handle_inbound_sms(event: TelnyxSMSEvent, db: Session):
     logger.info(f"Inbound SMS from {from_number}: {message_body[:50]}...")
 
     # ======================================================================
+    # Voice Workflow Scheduling Intercept
+    # Check if this SMS belongs to an active voice-commanded scheduling
+    # workflow BEFORE other intercepts. These are time-sensitive
+    # availability negotiation conversations.
+    # ======================================================================
+    _vw_intercept_workflow_id = None
+    try:
+        from services.voice_scheduling_workflow_service import VoiceSchedulingWorkflowService
+        from services.scheduling_conversation_service import SchedulingConversationService
+
+        # --- Tenant isolation: derive org_id from the receiving Telnyx number ---
+        # VerifiedCallerId maps phone_number -> organization_id.
+        # If the receiving number is not in verified_caller_ids, we fall back to
+        # querying without an org filter but log a warning so this gap is visible.
+        _vw_org_id = None
+        try:
+            org_row = db.execute(sa_text("""
+                SELECT organization_id FROM verified_caller_ids
+                WHERE phone_number = :to_phone AND organization_id IS NOT NULL
+                LIMIT 1
+            """), {"to_phone": normalized_to}).fetchone()
+            if org_row:
+                _vw_org_id = org_row[0]
+            else:
+                logger.warning(
+                    "voice_scheduling_intercept: no org mapping for receiving number %s "
+                    "(last4=%s) — querying workflows without tenant filter",
+                    normalized_to, normalized_to[-4:],
+                )
+        except Exception as e:
+            logger.warning("voice_scheduling_intercept: org lookup failed, proceeding without tenant filter: %s", e)
+
+        vw_service = VoiceSchedulingWorkflowService(db)
+
+        # Tenant-isolated lookup: org_id is required by the service
+        if _vw_org_id is not None:
+            active_workflow = vw_service.find_active_workflow_by_phone(normalized_from, organization_id=_vw_org_id)
+        else:
+            # No org mapping found — cannot safely query without tenant filter
+            logger.warning(
+                "voice_scheduling_intercept: skipping workflow lookup — no org_id resolved for receiving number ...%s",
+                normalized_to[-4:] if normalized_to else "????",
+            )
+            active_workflow = None
+
+        if active_workflow:
+            _vw_intercept_workflow_id = active_workflow.id
+            logger.info(
+                "voice_scheduling_intercept: matched workflow_id=%d, phone=...%s, org_id=%s",
+                active_workflow.id, normalized_from[-4:], active_workflow.organization_id,
+            )
+
+            sched_service = SchedulingConversationService(db)
+            logger.info(
+                "voice_scheduling_intercept: delegating to handle_reply, "
+                "workflow_id=%d, message_preview='%s'",
+                active_workflow.id, (message_body or "")[:50],
+            )
+            sched_result = sched_service.handle_reply(
+                workflow_id=active_workflow.id,
+                sender_phone=normalized_from,
+                message_body=message_body,
+                organization_id=_vw_org_id,
+            )
+            if sched_result is not None:
+                # Store SMS in sms_messages for compliance audit trail.
+                # Note: the message body is ALSO recorded in the workflow's
+                # conversation_history via workflow.add_message("contact", ...)
+                # inside handle_reply, so audit coverage is dual-path.
+                try:
+                    db.execute(sa_text("""
+                        INSERT INTO sms_messages (
+                            direction, from_number, to_number, body,
+                            provider, provider_message_id, status, created_at
+                        ) VALUES (
+                            'inbound', :from_number, :to_number, :body,
+                            'telnyx', :message_id, 'received', NOW()
+                        )
+                    """), {
+                        "from_number": from_number,
+                        "to_number": to_number,
+                        "body": message_body,
+                        "message_id": event.message_id,
+                    })
+                    db.commit()
+                except Exception as e:
+                    logger.error(
+                        "voice_scheduling_intercept: failed to store SMS audit record, "
+                        "workflow_id=%d: %s", active_workflow.id, e,
+                    )
+                logger.info(
+                    "voice_scheduling_intercept: completed, workflow_id=%d, result_status=%s",
+                    active_workflow.id, sched_result.get("action", "unknown"),
+                )
+                return {"status": "received", "handler": "voice_scheduling", "result": sched_result}
+        else:
+            logger.debug(
+                "voice_scheduling_intercept: no active workflow for phone=...%s",
+                normalized_from[-4:],
+            )
+    except Exception as e:
+        logger.exception(
+            "voice_scheduling_intercept: error (falling through to next handler), "
+            "workflow_id=%s, from=...%s",
+            _vw_intercept_workflow_id, normalized_from[-4:],
+        )
+
+    # ======================================================================
     # AI Prospect Re-Engagement Intercept
     # Check if this SMS belongs to an active AI conversation BEFORE
     # normal SMS intelligence processing. If handled, still store the

--- a/backend/routes/voice/browser_ws.py
+++ b/backend/routes/voice/browser_ws.py
@@ -190,8 +190,9 @@ async def browser_voice_websocket(websocket: WebSocket):
         "needs_flush": False,     # HIGH-4: Flag for early flush when buffer exceeds cap
     }
 
+    # P2: Periodic transcript flush coroutine
     async def _flush_transcript_periodically():
-        """P2: Flush accumulated transcript to DB every 30 seconds."""
+        """Flush accumulated transcript to DB every 30 seconds."""
         FLUSH_INTERVAL = 30
         while True:
             await asyncio.sleep(FLUSH_INTERVAL)
@@ -203,7 +204,6 @@ async def browser_voice_websocket(websocket: WebSocket):
                 if not sid or (flushed >= len(parts) and not needs_flush):
                     continue
                 new_parts = parts[flushed:]
-                ci_state["flushed_index"] = len(parts)
                 ci_state["needs_flush"] = False
             chunk = "\n".join(f"[{role}]: {txt}" for role, txt in new_parts)
             try:
@@ -211,6 +211,9 @@ async def browser_voice_websocket(websocket: WebSocket):
                 bridge = VoiceCIBridgeService(db, ws_organization_id, ws_user_id)
                 await bridge.append_transcript_chunk(sid, chunk)
                 db.commit()
+                async with ci_lock:
+                    ci_state["flushed_index"] = len(parts)
+                logger.debug(f"CI transcript flushed: {len(new_parts)} parts for session {sid[:8]}")
             except Exception as flush_err:
                 logger.warning(f"Periodic transcript flush failed: {flush_err}")
                 try:
@@ -418,17 +421,22 @@ async def browser_voice_websocket(websocket: WebSocket):
                                             ci_state["transcript_parts"] = []
                                             ci_state["flushed_index"] = 0
                                             ci_state["needs_flush"] = False
-                                        # P2: Start periodic transcript flush task
-                                        if ci_state.get("flush_task") is None:
-                                            ci_state["flush_task"] = asyncio.create_task(
-                                                _flush_transcript_periodically()
-                                            )
+                                        # P2: Cancel existing flush task before starting new one
+                                        if ci_state.get("flush_task"):
+                                            ci_state["flush_task"].cancel()
+                                        ci_state["flush_task"] = asyncio.create_task(
+                                            _flush_transcript_periodically()
+                                        )
                                         logger.info(f"CI transcript accumulation started for session {ci_session_id}")
                                         await websocket.send_json({
                                             "type": "ci_session_started",
                                             "session_id": ci_session_id,
                                         })
                                     elif func_name == "stop_call_recording":
+                                        # P2: Stop periodic flush
+                                        if ci_state.get("flush_task"):
+                                            ci_state["flush_task"].cancel()
+                                            ci_state["flush_task"] = None
                                         # Save accumulated transcript before session closes
                                         async with ci_lock:
                                             ci_sid = ci_state["session_id"] or result.get("session_id")
@@ -530,11 +538,10 @@ async def browser_voice_websocket(websocket: WebSocket):
             logger.error(f"Error in browser_voice_session (send error to client): {e}")
             pass  # Client may have disconnected
     finally:
-        # P2: Cancel periodic flush task
+        # P2: Cancel periodic flush task on disconnect
         if ci_state.get("flush_task"):
             ci_state["flush_task"].cancel()
             ci_state["flush_task"] = None
-
         # Save any unsaved CI transcript before tearing down
         async with ci_lock:
             disconnect_sid = ci_state["session_id"]

--- a/backend/routes/voice/openai_realtime.py
+++ b/backend/routes/voice/openai_realtime.py
@@ -244,10 +244,8 @@ async def connect_to_openai_realtime_browser():
                             "client_name": {"type": "string", "description": "Name of the person on the call, if known"},
                             "client_phone": {"type": "string", "description": "Phone number of the person, if known"},
                             "context": {"type": "string", "description": "Brief context like 'rate inquiry' or 'application follow-up'"},
-                            "call_control_id": {"type": "string", "description": "Telephony call control ID to link CI session to a live call"},
-                            "call_provider": {"type": "string", "description": "Telephony provider (telnyx, twilio, etc.)"},
-                            "call_control_id": {"type": "string", "description": "Telephony call control ID to link CI session to a live call"},
-                            "call_provider": {"type": "string", "description": "Telephony provider (telnyx, twilio, etc.)"}
+                            "call_control_id": {"type": "string", "description": "Telnyx call control ID or Twilio call SID to link this CI session to an active telephony call"},
+                            "call_provider": {"type": "string", "enum": ["telnyx", "twilio"], "description": "Telephony provider for the linked call"}
                         }
                     }
                 },

--- a/backend/routes/voice/tool_handlers.py
+++ b/backend/routes/voice/tool_handlers.py
@@ -508,71 +508,43 @@ async def handle_browser_function_call(
             return {"success": False, "message": "Contact name and phone number are required."}
 
         try:
-            # Get next 3 available slots to include in the SMS
-            today = datetime.now()
-            available_slots = []
-            for day_offset in range(1, 8):
-                check_date = today + timedelta(days=day_offset)
-                if check_date.weekday() >= 5:
-                    continue
-                date_str = check_date.strftime("%Y-%m-%d")
+            from services.voice_scheduling_workflow_service import VoiceSchedulingWorkflowService
+            from services.scheduling_conversation_service import SchedulingConversationService
 
-                # CRIT-2: Tenant-scoped appointment lookup
-                sched_params = {"check_date": date_str}
-                sched_org_filter = ""
-                if organization_id:
-                    sched_org_filter = "AND organization_id = :org_id"
-                    sched_params["org_id"] = organization_id
-                existing = db.execute(text(f"""
-                    SELECT appointment_datetime
-                    FROM appointments
-                    WHERE DATE(appointment_datetime) = :check_date
-                        AND status != 'cancelled'
-                        {sched_org_filter}
-                """), sched_params).fetchall()
-
-                booked_hours = {row.appointment_datetime.hour for row in existing} if existing else set()
-
-                for hour in [10, 14, 11, 15, 9, 13, 16]:
-                    if hour not in booked_hours and len(available_slots) < 3:
-                        slot_dt = check_date.replace(hour=hour, minute=0, second=0)
-                        available_slots.append(slot_dt.strftime("%A %m/%d at %I:%M %p"))
-
-                if len(available_slots) >= 3:
-                    break
-
-            # Build the SMS message
-            context_part = f" to {message_context}" if message_context else ""
-            slots_text = "\n".join(f"  {i+1}. {slot}" for i, slot in enumerate(available_slots))
-            sms_text = (
-                f"Hi {contact_name}, this is from your loan officer's office. "
-                f"We'd like to schedule a quick call{context_part}. "
-                f"Here are some available times:\n{slots_text}\n"
-                f"Reply with a number or suggest another time!"
+            vw_service = VoiceSchedulingWorkflowService(db)
+            workflow = vw_service.create_workflow(
+                organization_id=organization_id or 0,
+                user_id=user_id or 0,
+                workflow_type="voice_schedule",
+                contact_name=contact_name,
+                contact_phone=contact_phone,
+                meeting_type=meeting_type,
+                message_context=message_context,
             )
 
-            # Send the SMS via Telnyx
-            from telephony.sms import send_sms as telnyx_send_sms
-            telnyx_api_key = os.getenv("TELNYX_API_KEY")
-            telnyx_from_number = os.getenv("TELNYX_FROM_NUMBER", os.getenv("TELNYX_PHONE_NUMBER", ""))
-            messaging_profile_id = os.getenv("TELNYX_MESSAGING_PROFILE_ID", "")
-
-            if not telnyx_api_key or not telnyx_from_number:
-                return {"success": False, "message": "SMS not configured. Missing Telnyx credentials."}
-
-            telnyx_send_sms(
-                to=contact_phone,
-                from_=telnyx_from_number,
-                text=sms_text,
-                messaging_profile_id=messaging_profile_id or None,
-                api_key=telnyx_api_key,
+            sched_service = SchedulingConversationService(db)
+            result = sched_service.initiate_scheduling(
+                workflow_id=workflow.id,
+                user_id=user_id or 0,
+                organization_id=organization_id or 0,
+                contact_name=contact_name,
+                contact_phone=contact_phone,
+                meeting_type=meeting_type,
+                message_context=message_context,
             )
 
-            logger.info(f"Scheduling workflow started for {contact_name[:1]}*** at {mask_phone(contact_phone)}" if contact_name else f"Scheduling workflow started at {mask_phone(contact_phone)}")
+            logger.info(
+                "Scheduling workflow started via voice tool",
+                extra={
+                    "workflow_id": str(workflow.id),
+                    "contact_phone": mask_phone(contact_phone),
+                },
+            )
 
             return {
                 "success": True,
-                "message": f"Scheduling workflow started! SMS sent to {contact_name} with {len(available_slots)} available time slots. They can reply to pick a time."
+                "workflow_id": workflow.id,
+                "message": f"Scheduling workflow started! SMS sent to {contact_name} with available time slots. They can reply to pick a time.",
             }
 
         except Exception as e:

--- a/backend/routes/voice/tool_handlers.py
+++ b/backend/routes/voice/tool_handlers.py
@@ -789,6 +789,9 @@ async def handle_browser_function_call(
         client_name = args.get("client_name", "")
         client_phone = args.get("client_phone", "")
         context_note = args.get("context", "")
+        # P1/P7: Accept telephony call ID to link CI session to actual phone call
+        telephony_call_id = args.get("call_control_id", "") or args.get("telephony_call_id", "")
+        call_provider = args.get("call_provider", "")
 
         try:
             session_uuid = uuid_mod.uuid4()
@@ -803,6 +806,7 @@ async def handle_browser_function_call(
                 call_meta["client_phone"] = client_phone
             if context_note:
                 call_meta["context"] = context_note
+            # P7: Store telephony call link
             if telephony_call_id:
                 call_meta["telephony_call_id"] = telephony_call_id
             if call_provider:

--- a/backend/scripts/seed_demo_org.py
+++ b/backend/scripts/seed_demo_org.py
@@ -1,0 +1,698 @@
+"""
+Demo Data Seeder for Sales Demos
+
+Seeds an organization with realistic mortgage CRM data for demo purposes.
+Every created entity is tracked via DemoDataRecord for clean removal.
+
+Usage:
+    from scripts.seed_demo_org import seed_demo_data, clear_demo_data
+
+    # Seed
+    result = seed_demo_data(db, organization_id=1, user_id=1)
+
+    # Cleanup
+    result = clear_demo_data(db, organization_id=1)
+"""
+from __future__ import annotations
+
+import logging
+import random
+from datetime import datetime, date, timedelta, timezone
+from decimal import Decimal
+from typing import Dict, Any, List
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Name pools — clearly fictional but realistic-sounding
+# ---------------------------------------------------------------------------
+
+FIRST_NAMES = [
+    "Avery", "Jordan", "Morgan", "Taylor", "Casey",
+    "Riley", "Quinn", "Harper", "Sage", "Emery",
+    "Dakota", "Finley", "Rowan", "Cameron", "Reese",
+    "Blake", "Skyler", "Kendall", "Peyton", "Sawyer",
+    "Parker", "Ellis", "Wren", "Marley", "Haven",
+]
+
+LAST_NAMES = [
+    "Demoworth", "Sampleson", "Testfield", "Showcroft", "Trialton",
+    "Demosky", "Mockwell", "Previewson", "Sandbox", "Trialhaven",
+    "Demova", "Showcrest", "Sampleford", "Testworth", "Mockridge",
+    "Preville", "Trialworth", "Demohart", "Samplecrest", "Testbrook",
+    "Mockton", "Showcroft", "Demofield", "Sandford", "Trialmere",
+]
+
+STREETS = [
+    "123 Oak Lane", "456 Maple Drive", "789 Elm Street",
+    "321 Pine Avenue", "654 Cedar Court", "987 Birch Boulevard",
+    "111 Willow Way", "222 Spruce Circle", "333 Aspen Place",
+    "444 Hickory Road", "555 Walnut Terrace", "666 Chestnut Lane",
+    "777 Redwood Drive", "888 Sycamore Path", "999 Magnolia Court",
+]
+
+CITIES_STATES = [
+    ("Austin", "TX", "78701"), ("Denver", "CO", "80202"),
+    ("Charlotte", "NC", "28202"), ("Phoenix", "AZ", "85001"),
+    ("Nashville", "TN", "37201"), ("Tampa", "FL", "33602"),
+    ("Raleigh", "NC", "27601"), ("Dallas", "TX", "75201"),
+    ("Orlando", "FL", "32801"), ("Atlanta", "GA", "30301"),
+    ("San Antonio", "TX", "78201"), ("Scottsdale", "AZ", "85251"),
+    ("Boise", "ID", "83702"), ("Savannah", "GA", "31401"),
+    ("Charleston", "SC", "29401"),
+]
+
+LEAD_SOURCES = ["website", "referral", "zillow", "realtor.com", "rate_quote"]
+LEAD_STAGES = ["New", "Attempted Contact", "Pre-Qualified", "Long-Term Nurture", "Disclosed"]
+LOAN_TYPES = ["conventional", "fha", "va"]
+PROPERTY_TYPES = ["single_family", "condo", "townhouse"]
+LOAN_PURPOSES = ["purchase", "refinance", "cash_out_refinance"]
+
+ACTIVITY_CONTENTS = {
+    "Call": [
+        "Called borrower to discuss pre-approval timeline. Left voicemail.",
+        "Spoke with borrower — confirmed employment details and income docs needed.",
+        "Follow-up call re: rate lock decision. Borrower wants to float for now.",
+        "Discussed DTI ratio and potential loan programs. Borrower interested in FHA.",
+        "Checked in on document collection progress. Missing bank statements.",
+        "Called to confirm closing date and final walk-through schedule.",
+        "Discussed appraisal results with borrower. Value came in at ask price.",
+        "Quick call to answer borrower questions about PMI removal timeline.",
+    ],
+    "Email": [
+        "Sent pre-approval letter and next steps checklist.",
+        "Emailed rate comparison worksheet — conventional vs FHA vs VA options.",
+        "Followed up on missing W-2 documents. Deadline approaching.",
+        "Sent closing disclosure for review — 3-day waiting period starts.",
+        "Emailed updated loan estimate after rate lock confirmation.",
+        "Sent welcome packet with borrower portal login instructions.",
+        "Provided market update and current rate snapshot.",
+        "Sent document upload reminder — 2 items still outstanding.",
+    ],
+    "Meeting": [
+        "Initial consultation — reviewed borrower goals, timeline, and budget.",
+        "Pre-approval review meeting. Discussed credit improvement strategies.",
+        "Application walkthrough — completed 1003 together on screen share.",
+        "Closing prep meeting — reviewed CD, wiring instructions, and timeline.",
+    ],
+    "Note": [
+        "Borrower mentioned potential co-signer if DTI is too high.",
+        "Realtor confirmed seller willing to extend closing by 5 days if needed.",
+        "Processor flagged gap in employment history — need explanation letter.",
+        "Underwriter requesting additional asset documentation — 60-day statements.",
+        "Title company reported clean title search — no liens or encumbrances.",
+        "Appraisal ordered through AMC — scheduled for next Tuesday.",
+    ],
+    "SMS": [
+        "Hi! Just a reminder to upload your bank statements by Friday. Let me know if you need help!",
+        "Great news — your rate lock is confirmed at 6.25%! I'll send details via email.",
+        "Quick update: appraisal came in at value. We're on track for closing!",
+        "Don't forget our call tomorrow at 10am to review your loan options.",
+    ],
+}
+
+# Loan stages for the pipeline distribution
+LOAN_STAGE_DISTRIBUTION = [
+    ("APPLICATION", 3),
+    ("PROCESSING", 2),
+    ("SUBMITTED", 2),
+    ("UNDERWRITING", 2),
+    ("APPROVED", 2),
+    ("CTC", 2),
+    ("CLEAR_TO_CLOSE", 1),
+    ("DOCS_OUT", 1),
+]
+
+
+def _random_phone() -> str:
+    return f"+1555{random.randint(1000000, 9999999)}"
+
+
+def _random_email(first: str, last: str) -> str:
+    return f"{first.lower()}.{last.lower()}@demo-example.com"
+
+
+def _past_date(max_days_ago: int = 30) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=random.randint(1, max_days_ago))
+
+
+def _future_date(max_days_ahead: int = 7) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(
+        days=random.randint(1, max_days_ahead),
+        hours=random.choice([9, 10, 11, 13, 14, 15, 16]),
+    )
+
+
+def _track(db: Session, org_id: int, entity_type: str, entity_id: int) -> None:
+    """Record a demo entity for cleanup tracking."""
+    from database.models.demo_data import DemoDataRecord
+    db.add(DemoDataRecord(
+        organization_id=org_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+    ))
+
+
+# ===========================================================================
+# MAIN SEEDER
+# ===========================================================================
+
+def seed_demo_data(db: Session, organization_id: int, user_id: int) -> Dict[str, Any]:
+    """
+    Seed realistic demo data into the given organization.
+
+    Returns a summary dict with counts of created entities.
+    """
+    from database.models.lead_loan import Lead, Loan
+    from database.models.communication import Activity
+    from database.models.compliance import ComplianceAlert
+    from database.models.document import Document
+    from database.models.morning_briefing import MorningBriefing
+    from database.models.demo_data import DemoDataRecord
+    from database.models.scheduler import Appointment as SchedulerAppointment
+    from database.enums import ActivityType, DocumentType, DocumentCategory
+
+    counts: Dict[str, int] = {}
+    year = datetime.now().year
+
+    # Ensure the demo_data_records table exists
+    from db import engine as _engine
+    DemoDataRecord.__table__.create(_engine, checkfirst=True)
+
+    # ------------------------------------------------------------------
+    # 1. LEADS (25)
+    # ------------------------------------------------------------------
+    lead_ids: List[int] = []
+    try:
+        savepoint = db.begin_nested()
+        for i in range(25):
+            first = FIRST_NAMES[i]
+            last = LAST_NAMES[i]
+            stage = LEAD_STAGES[i % len(LEAD_STAGES)]
+            source = LEAD_SOURCES[i % len(LEAD_SOURCES)]
+            city, state, zipcode = CITIES_STATES[i % len(CITIES_STATES)]
+
+            lead = Lead(
+                organization_id=organization_id,
+                name=f"{first} {last}",
+                first_name=first,
+                last_name=last,
+                email=_random_email(first, last),
+                phone=_random_phone(),
+                stage=stage,
+                source=source,
+                owner_id=user_id,
+                ai_score=random.randint(30, 95),
+                loan_amount=Decimal(random.randrange(150000, 750000, 25000)),
+                credit_score=random.randint(620, 800),
+                loan_purpose=random.choice(LOAN_PURPOSES),
+                property_type=random.choice(PROPERTY_TYPES),
+                city=city,
+                state=state,
+                zip_code=zipcode,
+                address=random.choice(STREETS),
+                created_at=_past_date(60),
+                last_contact=_past_date(10),
+            )
+            db.add(lead)
+            db.flush()
+            lead_ids.append(lead.id)
+            _track(db, organization_id, "lead", lead.id)
+        savepoint.commit()
+        counts["leads"] = len(lead_ids)
+        logger.info("Seeded %d demo leads", len(lead_ids))
+    except Exception:
+        logger.exception("Failed to seed leads")
+        savepoint.rollback()
+        counts["leads"] = 0
+
+    # ------------------------------------------------------------------
+    # 2. LOANS (15)
+    # ------------------------------------------------------------------
+    loan_ids: List[int] = []
+    try:
+        savepoint = db.begin_nested()
+        loan_seq = 0
+        for stage, count in LOAN_STAGE_DISTRIBUTION:
+            for _ in range(count):
+                loan_seq += 1
+                first = FIRST_NAMES[loan_seq % len(FIRST_NAMES)]
+                last = LAST_NAMES[loan_seq % len(LAST_NAMES)]
+                city, state_code, zipcode = CITIES_STATES[loan_seq % len(CITIES_STATES)]
+                amount = Decimal(random.randrange(200000, 800000, 25000))
+                rate = Decimal(str(round(random.uniform(5.5, 7.5), 3)))
+                loan_type = random.choice(LOAN_TYPES)
+
+                # Calculate SLA dates based on stage progression
+                app_date = _past_date(45)
+                sla_dates: Dict[str, Any] = {"application_date": app_date}
+
+                stage_order = [
+                    "APPLICATION", "PROCESSING", "SUBMITTED",
+                    "UNDERWRITING", "APPROVED", "CTC",
+                    "CLEAR_TO_CLOSE", "DOCS_OUT",
+                ]
+                current_idx = stage_order.index(stage)
+
+                if current_idx >= 1:  # PROCESSING
+                    sla_dates["initial_disclosures_sent_date"] = app_date + timedelta(days=2)
+                    sla_dates["initial_disclosures_signed_date"] = app_date + timedelta(days=4)
+                if current_idx >= 2:  # SUBMITTED
+                    sla_dates["uw_received_date"] = app_date + timedelta(days=10)
+                if current_idx >= 4:  # APPROVED
+                    sla_dates["loan_approved_date"] = app_date + timedelta(days=18)
+                if current_idx >= 6:  # CLEAR_TO_CLOSE
+                    sla_dates["clear_to_close_date"] = app_date + timedelta(days=22)
+                    sla_dates["cd_sent_to_borrower_date"] = app_date + timedelta(days=21)
+                if current_idx >= 7:  # DOCS_OUT
+                    sla_dates["docs_out_date"] = app_date + timedelta(days=25)
+
+                loan = Loan(
+                    organization_id=organization_id,
+                    loan_number=f"DEMO-{year}-{loan_seq:04d}",
+                    borrower_name=f"{first} {last}",
+                    borrower_email=_random_email(first, last),
+                    borrower_phone=_random_phone(),
+                    amount=amount,
+                    rate=rate,
+                    loan_type=loan_type,
+                    stage=stage,
+                    property_address=f"{random.choice(STREETS)}, {city}, {state_code} {zipcode}",
+                    property_city=city,
+                    property_state=state_code,
+                    property_zip=zipcode,
+                    loan_officer_id=user_id,
+                    loan_purpose=random.choice(LOAN_PURPOSES),
+                    property_type=random.choice(PROPERTY_TYPES),
+                    stage_changed_at=_past_date(5),
+                    closing_date=datetime.now(timezone.utc) + timedelta(days=random.randint(10, 45)),
+                    lock_expiration_date=datetime.now(timezone.utc) + timedelta(days=random.randint(15, 60)),
+                    created_at=app_date,
+                    **sla_dates,
+                )
+                db.add(loan)
+                db.flush()
+                loan_ids.append(loan.id)
+                _track(db, organization_id, "loan", loan.id)
+        savepoint.commit()
+        counts["loans"] = len(loan_ids)
+        logger.info("Seeded %d demo loans", len(loan_ids))
+    except Exception:
+        logger.exception("Failed to seed loans")
+        savepoint.rollback()
+        counts["loans"] = 0
+
+    # ------------------------------------------------------------------
+    # 3. ACTIVITIES (50)
+    # ------------------------------------------------------------------
+    try:
+        savepoint = db.begin_nested()
+        activity_count = 0
+        activity_type_map = {
+            "Call": ActivityType.CALL,
+            "Email": ActivityType.EMAIL,
+            "Meeting": ActivityType.MEETING,
+            "Note": ActivityType.NOTE,
+            "SMS": ActivityType.SMS,
+        }
+        for i in range(50):
+            atype_name = random.choice(list(ACTIVITY_CONTENTS.keys()))
+            content = random.choice(ACTIVITY_CONTENTS[atype_name])
+            target_lead_id = random.choice(lead_ids) if lead_ids else None
+
+            activity = Activity(
+                organization_id=organization_id,
+                user_id=user_id,
+                type=activity_type_map[atype_name],
+                content=content,
+                lead_id=target_lead_id,
+                created_at=_past_date(30),
+            )
+            db.add(activity)
+            db.flush()
+            _track(db, organization_id, "activity", activity.id)
+            activity_count += 1
+        savepoint.commit()
+        counts["activities"] = activity_count
+        logger.info("Seeded %d demo activities", activity_count)
+    except Exception:
+        logger.exception("Failed to seed activities")
+        savepoint.rollback()
+        counts["activities"] = 0
+
+    # ------------------------------------------------------------------
+    # 4. APPOINTMENTS (8)
+    # ------------------------------------------------------------------
+    try:
+        savepoint = db.begin_nested()
+        appt_count = 0
+        meeting_configs = [
+            ("Discovery Call — {name}", "discovery_call", 30),
+            ("Pre-Approval Review — {name}", "pre_approval_review", 45),
+            ("Application Walkthrough — {name}", "application_walkthrough", 60),
+            ("Document Review — {name}", "document_review", 30),
+            ("Rate Lock Discussion — {name}", "rate_lock_discussion", 30),
+            ("Closing Prep — {name}", "closing_prep", 45),
+            ("Discovery Call — {name}", "discovery_call", 30),
+            ("Pre-Approval Review — {name}", "pre_approval_review", 45),
+        ]
+        for i in range(8):
+            title_tpl, mtype, duration = meeting_configs[i]
+            first = FIRST_NAMES[i]
+            last = LAST_NAMES[i]
+            name = f"{first} {last}"
+            start = _future_date(7)
+            # Ensure business hours (9am-4pm)
+            start = start.replace(hour=random.choice([9, 10, 11, 13, 14, 15, 16]), minute=0, second=0, microsecond=0)
+            end = start + timedelta(minutes=duration)
+
+            appt = SchedulerAppointment(
+                organization_id=organization_id,
+                assigned_user_id=user_id,
+                created_by_user_id=user_id,
+                title=title_tpl.format(name=name),
+                description=f"Scheduled {mtype.replace('_', ' ')} with {name}",
+                scheduled_start=start,
+                scheduled_end=end,
+                duration_minutes=duration,
+                attendee_name=name,
+                attendee_email=_random_email(first, last),
+                attendee_phone=_random_phone(),
+                status="booked",
+                lead_id=lead_ids[i] if i < len(lead_ids) else None,
+            )
+            db.add(appt)
+            db.flush()
+            _track(db, organization_id, "appointment", appt.id)
+            appt_count += 1
+        savepoint.commit()
+        counts["appointments"] = appt_count
+        logger.info("Seeded %d demo appointments", appt_count)
+    except Exception:
+        logger.exception("Failed to seed appointments")
+        savepoint.rollback()
+        counts["appointments"] = 0
+
+    # ------------------------------------------------------------------
+    # 5. COMPLIANCE ALERTS (5)
+    # ------------------------------------------------------------------
+    try:
+        savepoint = db.begin_nested()
+        alert_count = 0
+        alert_defs = [
+            # 2 open
+            {
+                "alert_type": "trid_le_deadline",
+                "severity": "critical",
+                "title": "LE Delivery Deadline Approaching",
+                "description": "Initial Loan Estimate must be delivered within 3 business days of application.",
+                "status": "open",
+                "deadline_date": date.today() + timedelta(days=1),
+                "days_remaining": 1,
+            },
+            {
+                "alert_type": "tolerance_violation",
+                "severity": "medium",
+                "title": "Fee Tolerance Warning — Title Insurance",
+                "description": "Title insurance fee increased 8% from LE to CD. Approaching 10% aggregate threshold.",
+                "status": "open",
+                "deadline_date": date.today() + timedelta(days=5),
+                "days_remaining": 5,
+            },
+            # 3 resolved
+            {
+                "alert_type": "adverse_action_deadline",
+                "severity": "high",
+                "title": "Adverse Action Notice Deadline",
+                "description": "ECOA requires adverse action notice within 30 days of denial.",
+                "status": "resolved",
+                "resolved_at": _past_date(5),
+                "resolution_notes": "Notice sent via certified mail on time.",
+            },
+            {
+                "alert_type": "trid_le_deadline",
+                "severity": "critical",
+                "title": "LE Delivery Deadline — Resolved",
+                "description": "Initial LE delivered within deadline window.",
+                "status": "resolved",
+                "resolved_at": _past_date(10),
+                "resolution_notes": "LE sent day 2 of 3-day window.",
+            },
+            {
+                "alert_type": "tolerance_violation",
+                "severity": "medium",
+                "title": "Origination Fee Tolerance Resolved",
+                "description": "Origination fee corrected. Lender credit applied.",
+                "status": "resolved",
+                "resolved_at": _past_date(15),
+                "resolution_notes": "Cure amount of $125 credited at closing.",
+            },
+        ]
+
+        for i, adef in enumerate(alert_defs):
+            target_loan_id = loan_ids[i] if i < len(loan_ids) else (loan_ids[0] if loan_ids else None)
+            alert = ComplianceAlert(
+                organization_id=organization_id,
+                loan_id=target_loan_id,
+                **adef,
+            )
+            db.add(alert)
+            db.flush()
+            _track(db, organization_id, "compliance_alert", alert.id)
+            alert_count += 1
+        savepoint.commit()
+        counts["compliance_alerts"] = alert_count
+        logger.info("Seeded %d demo compliance alerts", alert_count)
+    except Exception:
+        logger.exception("Failed to seed compliance alerts")
+        savepoint.rollback()
+        counts["compliance_alerts"] = 0
+
+    # ------------------------------------------------------------------
+    # 6. DOCUMENTS (3 per active loan)
+    # ------------------------------------------------------------------
+    try:
+        savepoint = db.begin_nested()
+        doc_count = 0
+        doc_templates = [
+            (DocumentType.PAYSTUB, DocumentCategory.INCOME, "paystubs_jan2026.pdf"),
+            (DocumentType.W2, DocumentCategory.INCOME, "w2_2025.pdf"),
+            (DocumentType.BANK_STATEMENT, DocumentCategory.ASSETS, "bank_stmt_q1_2026.pdf"),
+            (DocumentType.CREDIT_REPORT, DocumentCategory.CREDIT, "credit_report.pdf"),
+            (DocumentType.APPRAISAL, DocumentCategory.PROPERTY, "appraisal_report.pdf"),
+        ]
+        for loan_id in loan_ids:
+            selected_docs = random.sample(doc_templates, 3)
+            for dtype, dcat, fname in selected_docs:
+                doc = Document(
+                    organization_id=organization_id,
+                    loan_id=loan_id,
+                    doc_type=dtype,
+                    doc_category=dcat,
+                    filename=fname,
+                    original_filename=fname,
+                    file_location=f"demo://documents/{loan_id}/{fname}",
+                    source="MANUAL_UPLOAD",
+                    status="active",
+                    uploaded_at=_past_date(20),
+                    uploaded_by_user_id=user_id,
+                )
+                db.add(doc)
+                db.flush()
+                _track(db, organization_id, "document", doc.id)
+                doc_count += 1
+        savepoint.commit()
+        counts["documents"] = doc_count
+        logger.info("Seeded %d demo documents", doc_count)
+    except Exception:
+        logger.exception("Failed to seed documents")
+        savepoint.rollback()
+        counts["documents"] = 0
+
+    # ------------------------------------------------------------------
+    # 7. MORNING BRIEFING (1 for today)
+    # ------------------------------------------------------------------
+    try:
+        savepoint = db.begin_nested()
+        briefing_data = {
+            "pipeline_snapshot": {
+                "active_loans": len(loan_ids),
+                "total_volume": 4_250_000,
+                "closing_this_week": 2,
+                "avg_days_in_stage": 4.2,
+            },
+            "urgent_items": [
+                {"type": "lock_expiring", "loan": "DEMO-2026-0012", "days_remaining": 2},
+                {"type": "condition_due", "loan": "DEMO-2026-0005", "description": "Bank statements needed"},
+            ],
+            "todays_appointments": [
+                {"time": "10:00 AM", "type": "Discovery Call", "contact": "Avery Demoworth"},
+                {"time": "2:00 PM", "type": "Pre-Approval Review", "contact": "Jordan Sampleson"},
+            ],
+            "compliance_alerts": {
+                "open": 2,
+                "critical": 1,
+            },
+            "lead_activity": {
+                "new_leads_24h": 3,
+                "follow_ups_due": 5,
+                "hot_leads": 2,
+            },
+        }
+        briefing = MorningBriefing(
+            organization_id=organization_id,
+            user_id=user_id,
+            briefing_date=date.today(),
+            briefing_level="individual",
+            status="delivered",
+            briefing_data=briefing_data,
+            ai_narrative=(
+                "Good morning! You have 15 active loans in your pipeline totaling $4.25M. "
+                "Two loans are approaching closing this week. A rate lock on DEMO-2026-0012 "
+                "expires in 2 days — consider discussing extension options with the borrower. "
+                "You have 2 appointments today and 5 follow-up calls due. "
+                "There is 1 critical compliance alert requiring immediate attention: "
+                "an LE delivery deadline on a recent application."
+            ),
+            created_at=datetime.now(timezone.utc),
+        )
+        db.add(briefing)
+        db.flush()
+        _track(db, organization_id, "morning_briefing", briefing.id)
+        savepoint.commit()
+        counts["morning_briefings"] = 1
+        logger.info("Seeded 1 demo morning briefing")
+    except Exception:
+        logger.exception("Failed to seed morning briefing")
+        savepoint.rollback()
+        counts["morning_briefings"] = 0
+
+    # ------------------------------------------------------------------
+    # Commit everything
+    # ------------------------------------------------------------------
+    db.commit()
+
+    total = sum(counts.values())
+    logger.info("Demo data seeding complete: %d total entities for org %d", total, organization_id)
+    return {
+        "organization_id": organization_id,
+        "seeded_by_user_id": user_id,
+        "counts": counts,
+        "total": total,
+    }
+
+
+# ===========================================================================
+# CLEANUP
+# ===========================================================================
+
+# Map entity_type -> (model_class_import_path, table)
+_ENTITY_MODEL_MAP = {
+    "lead": ("database.models.lead_loan", "Lead"),
+    "loan": ("database.models.lead_loan", "Loan"),
+    "activity": ("database.models.communication", "Activity"),
+    "appointment": ("database.models.scheduler", "Appointment"),
+    "compliance_alert": ("database.models.compliance", "ComplianceAlert"),
+    "document": ("database.models.document", "Document"),
+    "morning_briefing": ("database.models.morning_briefing", "MorningBriefing"),
+}
+
+
+def clear_demo_data(db: Session, organization_id: int) -> Dict[str, Any]:
+    """
+    Remove all demo-seeded data for an organization by looking up
+    DemoDataRecord tracking entries.
+
+    Returns a summary dict with counts of deleted entities.
+    """
+    from database.models.demo_data import DemoDataRecord
+    from database.models.lead_loan import Lead, Loan
+    from database.models.communication import Activity
+    from database.models.compliance import ComplianceAlert
+    from database.models.document import Document
+    from database.models.morning_briefing import MorningBriefing
+    from database.models.scheduler import Appointment as SchedulerAppointment
+
+    model_map = {
+        "lead": Lead,
+        "loan": Loan,
+        "activity": Activity,
+        "appointment": SchedulerAppointment,
+        "compliance_alert": ComplianceAlert,
+        "document": Document,
+        "morning_briefing": MorningBriefing,
+    }
+
+    # Get all tracking records for this org
+    records = (
+        db.query(DemoDataRecord)
+        .filter(DemoDataRecord.organization_id == organization_id)
+        .all()
+    )
+
+    if not records:
+        return {
+            "organization_id": organization_id,
+            "counts": {},
+            "total": 0,
+            "message": "No demo data found for this organization",
+        }
+
+    # Group by entity type
+    by_type: Dict[str, list] = {}
+    for rec in records:
+        by_type.setdefault(rec.entity_type, []).append(rec.entity_id)
+
+    counts: Dict[str, int] = {}
+
+    # Delete in dependency order: documents/activities first, then loans/leads last
+    delete_order = [
+        "morning_briefing", "document", "compliance_alert",
+        "appointment", "activity", "loan", "lead",
+    ]
+
+    for entity_type in delete_order:
+        entity_ids = by_type.get(entity_type, [])
+        if not entity_ids:
+            continue
+
+        model_cls = model_map.get(entity_type)
+        if model_cls is None:
+            logger.warning("Unknown entity type in demo data: %s", entity_type)
+            continue
+
+        try:
+            deleted = (
+                db.query(model_cls)
+                .filter(model_cls.id.in_(entity_ids))
+                .delete(synchronize_session="fetch")
+            )
+            counts[entity_type] = deleted
+            logger.info("Deleted %d demo %s records", deleted, entity_type)
+        except Exception:
+            logger.exception("Failed to delete demo %s records", entity_type)
+            db.rollback()
+            counts[entity_type] = 0
+
+    # Remove all tracking records
+    tracking_deleted = (
+        db.query(DemoDataRecord)
+        .filter(DemoDataRecord.organization_id == organization_id)
+        .delete(synchronize_session="fetch")
+    )
+
+    db.commit()
+
+    total = sum(counts.values())
+    logger.info(
+        "Demo data cleanup complete: %d entities + %d tracking records deleted for org %d",
+        total, tracking_deleted, organization_id,
+    )
+    return {
+        "organization_id": organization_id,
+        "counts": counts,
+        "total": total,
+        "tracking_records_removed": tracking_deleted,
+    }

--- a/backend/services/call_monitoring/orchestrator_service.py
+++ b/backend/services/call_monitoring/orchestrator_service.py
@@ -440,6 +440,8 @@ class CallMonitoringOrchestrator:
             session_id: Call session ID
             trigger: What triggered the run (end_of_call, manual, periodic)
             agent_types: Specific agents to run, or None for all
+            on_agent_complete: Optional callback(agent_type, result) called
+                when each individual agent finishes (P4: progressive streaming)
 
         Returns:
             Processing results from all agents
@@ -497,16 +499,17 @@ class CallMonitoringOrchestrator:
         context = await self._enrich_context(context)
 
         # P8: Inject per-agent feedback from approval patterns
+        agent_feedback = {}
         try:
             from services.call_monitoring.feedback_service import AgentFeedbackService
             feedback_svc = AgentFeedbackService(self.db, self.organization_id)
-            agent_feedback = {}
             for agent_type in agents_to_run:
                 prompt_feedback = feedback_svc.generate_feedback_prompt(agent_type)
                 if prompt_feedback:
                     agent_feedback[agent_type] = prompt_feedback
             if agent_feedback:
                 context['agent_feedback'] = agent_feedback
+                logger.info(f"Feedback injected for {len(agent_feedback)} agents")
         except Exception as fb_err:
             logger.warning(f"Failed to load agent feedback (non-blocking): {fb_err}")
 
@@ -588,6 +591,16 @@ class CallMonitoringOrchestrator:
                         await on_agent_complete(agent_type, results[i])
                     except Exception as cb_err:
                         logger.warning(f"on_agent_complete callback failed for {agent_type}: {cb_err}")
+
+            # P4: Notify caller as each agent completes (progressive streaming)
+            if on_agent_complete:
+                try:
+                    callback_result = on_agent_complete(agent_type, result_map[agent_type])
+                    # Support async callbacks
+                    if asyncio.iscoroutine(callback_result):
+                        await callback_result
+                except Exception as cb_err:
+                    logger.warning(f"on_agent_complete callback failed for {agent_type}: {cb_err}")
 
         return result_map
 

--- a/backend/services/voice_ci_bridge_service.py
+++ b/backend/services/voice_ci_bridge_service.py
@@ -71,59 +71,6 @@ class VoiceCIBridgeService:
         )
         return session_id
 
-    async def append_transcript_chunk(
-        self, session_id: str, chunk_text: str
-    ) -> Dict[str, Any]:
-        """Append a transcript chunk to an active CI session (P2: periodic flush)."""
-        if not session_id or not chunk_text or not chunk_text.strip():
-            return {"success": False, "error": "session_id and non-empty chunk required"}
-        chunk_words = len(chunk_text.split())
-        result = self.db.execute(text("""
-            UPDATE call_sessions
-            SET full_transcript = COALESCE(full_transcript, '') || :chunk,
-                transcript_word_count = COALESCE(transcript_word_count, 0) + :chunk_words,
-                last_flush_at = NOW(), updated_at = NOW()
-            WHERE id = :session_id AND organization_id = :org_id AND status = 'active'
-            RETURNING id
-        """), {
-            "chunk": chr(10) + chunk_text if chunk_text else "",
-            "chunk_words": chunk_words,
-            "session_id": session_id,
-            "org_id": self.organization_id,
-        }).fetchone()
-        self.db.flush()
-        if not result:
-            return {"success": False, "error": f"Active session {session_id} not found"}
-        logger.info("CI transcript chunk appended", extra={"session_id": session_id, "chunk_words": chunk_words})
-        return {"success": True, "session_id": session_id, "chunk_words": chunk_words}
-
-    async def append_transcript_chunk(
-        self, session_id: str, chunk_text: str
-    ) -> Dict[str, Any]:
-        """Append a transcript chunk to an active CI session (P2: periodic flush)."""
-        if not session_id or not chunk_text or not chunk_text.strip():
-            return {"success": False, "error": "session_id and non-empty chunk required"}
-        chunk_words = len(chunk_text.split())
-        newline_prefix = chr(10)  # newline character
-        result = self.db.execute(text("""
-            UPDATE call_sessions
-            SET full_transcript = COALESCE(full_transcript, '') || :chunk,
-                transcript_word_count = COALESCE(transcript_word_count, 0) + :chunk_words,
-                last_flush_at = NOW(), updated_at = NOW()
-            WHERE id = :session_id AND organization_id = :org_id AND status = 'active'
-            RETURNING id
-        """), {
-            "chunk": newline_prefix + chunk_text if chunk_text else "",
-            "chunk_words": chunk_words,
-            "session_id": session_id,
-            "org_id": self.organization_id,
-        }).fetchone()
-        self.db.flush()
-        if not result:
-            return {"success": False, "error": f"Active session {session_id} not found"}
-        logger.info("CI transcript chunk appended", extra={"session_id": session_id, "chunk_words": chunk_words})
-        return {"success": True, "session_id": session_id, "chunk_words": chunk_words}
-
     async def stop_ci_session(
         self, session_id: Optional[str] = None, run_agents: bool = True
     ) -> Dict[str, Any]:
@@ -592,6 +539,46 @@ class VoiceCIBridgeService:
         )
         return {"success": True, "session_id": session_id, "word_count": word_count}
 
+    async def append_transcript_chunk(
+        self, session_id: str, chunk_text: str
+    ) -> Dict[str, Any]:
+        """Append a transcript chunk to an active CI session (P2: periodic flush).
+
+        Unlike update_session_transcript which overwrites, this APPENDS to the
+        existing full_transcript and updates word count incrementally.
+        """
+        if not session_id or not chunk_text or not chunk_text.strip():
+            return {"success": False, "error": "session_id and non-empty chunk required"}
+
+        chunk_words = len(chunk_text.split())
+
+        result = self.db.execute(text("""
+            UPDATE call_sessions
+            SET full_transcript = COALESCE(full_transcript, '') || :chunk,
+                transcript_word_count = COALESCE(transcript_word_count, 0) + :chunk_words,
+                last_flush_at = NOW(),
+                updated_at = NOW()
+            WHERE id = :session_id
+                AND organization_id = :org_id
+                AND status = 'active'
+            RETURNING id
+        """), {
+            "chunk": "\n" + chunk_text if chunk_text else "",
+            "chunk_words": chunk_words,
+            "session_id": session_id,
+            "org_id": self.organization_id,
+        }).fetchone()
+        self.db.flush()
+
+        if not result:
+            return {"success": False, "error": f"Active session {session_id} not found"}
+
+        logger.info(
+            "CI transcript chunk appended",
+            extra={"session_id": session_id, "chunk_words": chunk_words},
+        )
+        return {"success": True, "session_id": session_id, "chunk_words": chunk_words}
+
     # -------------------------------------------------------------------------
     # Private helpers
     # -------------------------------------------------------------------------
@@ -609,18 +596,27 @@ class VoiceCIBridgeService:
         }).fetchone()
         return str(row.id) if row else None
 
-    async def _execute_single_artifact(self, artifact, session_id: Optional[str] = None) -> Dict[str, Any]:
+    async def _execute_single_artifact(
+        self, artifact, session_id: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Execute a single artifact using SmartTaskExecutor (P5) with fallback."""
         artifact_type = artifact.artifact_type
+
+        # P3: Intake fields use the IntakeFieldApplier
         if artifact_type == "intake_field":
             try:
                 from services.call_monitoring.intake_field_applier import IntakeFieldApplier
                 applier = IntakeFieldApplier(self.db, self.organization_id)
                 sid = session_id or await self._get_latest_session_id()
-                return await applier.apply_intake_fields(session_id=sid or "", user_id=self.user_id)
+                return await applier.apply_intake_fields(
+                    session_id=sid or "",
+                    user_id=self.user_id,
+                )
             except Exception as e:
                 logger.error(f"IntakeFieldApplier failed: {e}")
                 return {"type": "intake_field_error", "title": artifact.title, "error": str(e)}
+
+        # P5: Use SmartTaskExecutor for tasks and appointments
         try:
             from services.call_monitoring.smart_task_executor import SmartTaskExecutor
             executor = SmartTaskExecutor(self.db, self.organization_id, self.user_id)
@@ -631,30 +627,25 @@ class VoiceCIBridgeService:
             return await self._execute_single_artifact_fallback(artifact)
 
     async def _execute_single_artifact_fallback(self, artifact) -> Dict[str, Any]:
-        """Fallback artifact execution when SmartTaskExecutor is unavailable."""
+        """Fallback execution when SmartTaskExecutor is unavailable."""
         artifact_type = artifact.artifact_type
         content = artifact.content if isinstance(artifact.content, dict) else {}
-        if artifact_type == "action_item":
+
+        if artifact_type in ("action_item", "document_request", "task", "risk_flag"):
+            title = artifact.title
+            if artifact_type == "document_request":
+                title = f"Request: {title}"
             self.db.execute(text("""
                 INSERT INTO tasks (id, title, description, priority, status, created_at, organization_id)
                 VALUES (gen_random_uuid(), :title, :description, :priority, 'pending', NOW(), :org_id)
             """), {
-                "title": artifact.title,
+                "title": title,
                 "description": content.get("details", str(artifact.content or "")),
                 "priority": artifact.priority or "medium",
                 "org_id": self.organization_id,
             })
             return {"type": "task_created", "title": artifact.title}
-        elif artifact_type == "document_request":
-            self.db.execute(text("""
-                INSERT INTO tasks (id, title, description, priority, status, created_at, organization_id)
-                VALUES (gen_random_uuid(), :title, :description, 'high', 'pending', NOW(), :org_id)
-            """), {
-                "title": f"Request: {artifact.title}",
-                "description": f"Document needed: {content.get('details', artifact.title)}",
-                "org_id": self.organization_id,
-            })
-            return {"type": "doc_request_task_created", "title": artifact.title}
+
         elif artifact_type in ("scheduled_appointment", "follow_up_call"):
             self.db.execute(text("""
                 INSERT INTO appointments (id, caller_name, reason, status, created_at, organization_id, notes)

--- a/backend/soc2_compliance/migrations/add_vendor_agreements_table.sql
+++ b/backend/soc2_compliance/migrations/add_vendor_agreements_table.sql
@@ -1,0 +1,80 @@
+-- ============================================================================
+-- SOC 2 Vendor BAA/DPA Agreement Tracking
+-- Maps to: CC9 (Risk Mitigation), C1 (Confidentiality), P1-P8 (Privacy)
+--
+-- Run: psql $DATABASE_URL -f migrations/add_vendor_agreements_table.sql
+-- ============================================================================
+
+BEGIN;
+
+-- ============================================================================
+-- VENDOR AGREEMENTS — Track BAA/DPA status per vendor
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS soc2_vendor_agreements (
+    id              SERIAL PRIMARY KEY,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- FK to vendor registry
+    vendor_id       INTEGER NOT NULL REFERENCES soc2_vendor_registry(id) ON DELETE CASCADE,
+
+    -- Agreement classification
+    agreement_type  VARCHAR(20) NOT NULL,    -- baa, dpa, baa_and_dpa
+    status          VARCHAR(20) NOT NULL DEFAULT 'pending',  -- pending, signed, expired, not_required, under_review
+
+    -- Execution details
+    signed_date     DATE,
+    effective_date  DATE,
+    expiry_date     DATE,
+    signed_by       VARCHAR(255),            -- Perennia signer name
+    vendor_signer   VARCHAR(255),            -- Vendor-side signer name
+    vendor_signer_title VARCHAR(255),        -- Vendor-side signer title
+
+    -- Document reference
+    document_url    TEXT,                     -- Link to signed document (S3, GDrive, etc.)
+    document_hash   VARCHAR(128),            -- SHA-256 hash of signed PDF for integrity
+
+    -- Scope
+    data_categories TEXT[],                  -- e.g., {'PII', 'PHI', 'financial'}
+    processing_purposes TEXT[],             -- e.g., {'email_delivery', 'voice_calls'}
+    sub_processors  TEXT[],                 -- Known sub-processors listed in agreement
+
+    -- Renewal / review
+    auto_renew      BOOLEAN DEFAULT FALSE,
+    renewal_notice_days INTEGER DEFAULT 90,  -- Days before expiry to alert
+    last_review_date DATE,
+    next_review_date DATE,
+
+    -- Audit trail
+    notes           TEXT,
+    reviewed_by     VARCHAR(255),            -- Who last reviewed this agreement
+
+    -- Ensure one agreement type per vendor (can have separate BAA and DPA)
+    UNIQUE(vendor_id, agreement_type)
+);
+
+CREATE INDEX idx_vendor_agreements_vendor ON soc2_vendor_agreements(vendor_id);
+CREATE INDEX idx_vendor_agreements_status ON soc2_vendor_agreements(status);
+CREATE INDEX idx_vendor_agreements_expiry ON soc2_vendor_agreements(expiry_date)
+    WHERE status = 'signed';
+
+-- Auto-update timestamp trigger
+CREATE TRIGGER update_vendor_agreements_timestamp
+    BEFORE UPDATE ON soc2_vendor_agreements
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+COMMIT;
+
+-- ============================================================================
+-- VERIFICATION
+-- ============================================================================
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_name = 'soc2_vendor_agreements'
+    ) THEN
+        RAISE EXCEPTION 'Table soc2_vendor_agreements was not created';
+    END IF;
+    RAISE NOTICE 'soc2_vendor_agreements table created successfully.';
+END $$;

--- a/backend/soc2_compliance/policies/disaster_recovery_plan.md
+++ b/backend/soc2_compliance/policies/disaster_recovery_plan.md
@@ -1,0 +1,995 @@
+# Disaster Recovery Plan (DRP)
+
+## Perennia AI Platform
+
+---
+
+## 1. Document Control
+
+| Field | Value |
+|---|---|
+| **Document Title** | Disaster Recovery Plan |
+| **Version** | 1.0 |
+| **Effective Date** | 2026-03-27 |
+| **Last Reviewed** | 2026-03-27 |
+| **Next Review** | 2026-09-27 |
+| **Document Owner** | Engineering Lead |
+| **Approved By** | _See Section 14 - Approval & Signatures_ |
+| **Classification** | Internal - Confidential |
+| **SOC 2 Criteria** | A1 (Availability), A1.2 (Recovery), A1.3 (Testing) |
+
+**Review Schedule:** This document must be reviewed and updated:
+- Semi-annually (every 6 months) under normal conditions
+- After any Severity 1 or Severity 2 incident
+- After any significant infrastructure change (provider migration, new region, architecture shift)
+- After each DR test exercise
+
+**Change History:**
+
+| Version | Date | Author | Description |
+|---|---|---|---|
+| 1.0 | 2026-03-27 | Engineering Team | Initial formal DRP |
+
+---
+
+## 2. Purpose & Scope
+
+### 2.1 Purpose
+
+This Disaster Recovery Plan (DRP) defines the procedures, responsibilities, and resources required to recover the Perennia AI platform following a service disruption, data loss event, or infrastructure failure. It operationalizes the objectives stated in the [Disaster Recovery Policy](disaster_recovery_policy.md) and provides step-by-step runbooks for each failure scenario.
+
+This document satisfies SOC 2 Trust Services Criteria:
+- **A1.2** -- Environmental protections, data backups, and recovery infrastructure are authorized, designed, developed, implemented, operated, approved, maintained, and monitored to meet the entity's availability commitments and system requirements.
+- **A1.3** -- Recovery plan procedures supporting system recovery are tested to help meet the entity's availability commitments.
+
+### 2.2 Scope
+
+This plan covers all production systems comprising the Perennia AI platform:
+
+- Backend API application (FastAPI on Railway)
+- PostgreSQL database (Railway-hosted)
+- Redis instance (task queue broker, caching layer)
+- AWS S3 buckets (document storage, file assets)
+- Frontend application (Vercel-hosted SPA)
+- Marketing site (Vercel-hosted)
+- Celery worker processes (background task execution)
+- Third-party integrations (Telnyx telephony, Twilio/Vapi voice AI, Anthropic/OpenAI/Mistral LLM providers, Salesforce, Encompass LOS, Deepgram, DataDog)
+
+**Out of Scope:** End-user devices, third-party SaaS provider internal DR (covered by vendor management policy), and development/staging environments.
+
+---
+
+## 3. Recovery Objectives
+
+### 3.1 Recovery Point Objective (RPO)
+
+| Component | RPO Target | Mechanism |
+|---|---|---|
+| PostgreSQL database | **1 hour** | WAL archiving with continuous streaming; Railway PITR |
+| Redis (task queue) | **4 hours** | RDB snapshots + AOF persistence; tasks are idempotent and replay-safe |
+| AWS S3 (documents) | **24 hours** | Cross-region replication; versioning enabled |
+| Application code | **0 (zero loss)** | Git repository on GitHub; every deployment is a tagged commit |
+| Environment configuration | **0 (zero loss)** | Railway encrypted variable storage; documented in secure vault |
+
+### 3.2 Recovery Time Objective (RTO)
+
+| Scenario | RTO Target | Notes |
+|---|---|---|
+| Single component failure | **1 hour** | Automated failover or rapid manual intervention |
+| Multi-component failure | **2 hours** | Parallel recovery procedures |
+| Full infrastructure failure | **4 hours** | Complete rebuild from backups and IaC |
+| Security breach (containment + recovery) | **4 hours** recovery after containment | Containment is immediate; forensics may extend total timeline |
+
+### 3.3 Service Level Tiers
+
+The platform operates in four degradation levels as defined by the `GracefulDegradation` service:
+
+| Level | Definition | User Impact |
+|---|---|---|
+| **Full** | All services operational | None |
+| **Degraded** | AI features limited, core CRM functional | AI chat/voice unavailable; CRUD operations work |
+| **Minimal** | Database + auth only | Read-only pipeline view; no integrations |
+| **Maintenance** | All services offline | Full outage; status page active |
+
+---
+
+## 4. Infrastructure Overview
+
+### 4.1 Architecture Diagram (Logical)
+
+```
+                    +-----------------+
+                    |   Vercel CDN    |
+                    | (Frontend SPA)  |
+                    +--------+--------+
+                             |
+                    +--------v--------+
+                    |  Railway LB     |
+                    | (Load Balancer) |
+                    +--------+--------+
+                             |
+              +--------------+--------------+
+              |                             |
+     +--------v--------+          +--------v--------+
+     | Railway App      |          | Celery Workers   |
+     | (FastAPI)        |          | (Background)     |
+     +--------+---------+          +--------+---------+
+              |                             |
+     +--------v---------+         +--------v---------+
+     | Railway PostgreSQL|         | Redis             |
+     | (Primary DB)      |         | (Broker + Cache)  |
+     +-------------------+         +-------------------+
+              |
+     +--------v---------+
+     | AWS S3            |
+     | (Document Store)  |
+     +-------------------+
+```
+
+### 4.2 Component Details
+
+| Component | Provider | Region | Redundancy |
+|---|---|---|---|
+| **PostgreSQL Database** | Railway | US (Oregon) | WAL archiving, PITR, daily snapshots |
+| **Application Server** | Railway | US (Oregon) | Stateless containers, instant rollback |
+| **Celery Workers** | Railway | US (Oregon) | Multiple worker processes, task retry |
+| **Redis** | Railway | US (Oregon) | RDB + AOF persistence |
+| **Frontend SPA** | Vercel | Edge (global CDN) | Multi-region edge deployment |
+| **Document Storage** | AWS S3 | us-east-1 (primary) | Versioning, cross-region replication |
+| **DNS** | Cloudflare / Vercel | Global | Anycast DNS, automatic failover |
+| **Monitoring** | DataDog | SaaS | Independent of application infrastructure |
+
+### 4.3 Critical Dependencies
+
+| Dependency | Impact if Unavailable | Fallback |
+|---|---|---|
+| Anthropic API | AI agent features disabled | Graceful degradation to non-AI CRM; circuit breaker pattern |
+| Telnyx | Outbound calls/SMS disabled | Queue messages for retry; manual calling |
+| Twilio/Vapi | Voice AI disabled | Telnyx direct dial fallback |
+| Deepgram | Voice transcription unavailable | Buffer audio for later processing |
+| Salesforce | Sync paused | Queue sync operations; manual export |
+| Encompass LOS | Loan sync paused | Queue operations; manual LOS entry |
+
+---
+
+## 5. Disaster Classification
+
+### Severity 1 -- Critical (Full Outage)
+
+**Definition:** Complete loss of platform availability. No users can access any functionality.
+
+**Examples:**
+- Railway region-wide outage
+- Database corruption affecting all tables
+- Compromised credentials with active data exfiltration
+- DNS hijacking or domain compromise
+- Complete network partition
+
+**Response Time:** Immediate (within 15 minutes of detection)
+**Escalation:** Engineering Lead + CTO + all on-call engineers
+
+### Severity 2 -- Major (Partial Outage, Core Affected)
+
+**Definition:** Core CRM functionality (pipeline, leads, loans) is unavailable, but some services may still operate.
+
+**Examples:**
+- PostgreSQL failure (database unreachable)
+- Authentication system failure (no user can log in)
+- Data integrity issue affecting loan records
+- Redis failure causing task queue loss and session issues
+
+**Response Time:** Within 30 minutes of detection
+**Escalation:** Engineering Lead + on-call engineer
+
+### Severity 3 -- Moderate (Feature Degradation)
+
+**Definition:** Non-core features unavailable; core CRM continues to function.
+
+**Examples:**
+- AI/LLM provider outage (Anthropic, OpenAI, Mistral)
+- Telephony provider outage (Telnyx or Twilio)
+- S3 access issues (document upload/download affected)
+- Celery worker failure (background tasks delayed)
+- Single third-party integration failure
+
+**Response Time:** Within 1 hour of detection
+**Escalation:** On-call engineer
+
+### Severity 4 -- Minor (Cosmetic / Low Impact)
+
+**Definition:** Minor service degradation with minimal user impact.
+
+**Examples:**
+- Elevated API response latency (but within timeouts)
+- Non-critical background job failures
+- Monitoring/alerting system partial failure
+- CDN cache invalidation issues
+
+**Response Time:** Within 4 hours (next business day if after hours)
+**Escalation:** Engineering team via standard ticketing
+
+---
+
+## 6. Recovery Procedures
+
+### 6a. Database Failure Recovery
+
+**Severity:** 1-2 | **RTO:** 1-2 hours | **RPO:** 1 hour
+
+**Detection:**
+- DataDog alert: PostgreSQL connection failures
+- Health endpoint (`/health`) returns database error
+- `/api/v1/admin/dr/failover-readiness` reports DB check failure
+
+**Automated Response:**
+- Circuit breaker activates for database-dependent routes
+- `GracefulDegradation` service transitions to "minimal" or "maintenance" level
+- Health endpoint reflects degraded state
+
+**Manual Recovery Steps:**
+
+1. **Assess the failure**
+   ```
+   # Check Railway dashboard for PostgreSQL service status
+   # Review DataDog PostgreSQL integration metrics
+   # Check /api/v1/admin/dr/degradation-health for current service level
+   ```
+
+2. **Attempt connection recovery**
+   ```
+   # Railway will auto-restart crashed database containers
+   # Wait up to 5 minutes for automatic recovery
+   # Monitor Railway deployment logs for PostgreSQL restart events
+   ```
+
+3. **If auto-recovery fails -- initiate PITR restore**
+   ```
+   # Navigate to Railway project > PostgreSQL service > Backups
+   # Select most recent clean backup point (within RPO window)
+   # Initiate Point-in-Time Recovery
+   # Railway provisions new volume from WAL archive
+   # Expected duration: 15-45 minutes depending on data volume
+   ```
+
+4. **Post-restore validation**
+   ```
+   # Run /api/v1/admin/dr/rto-benchmark to verify DB connectivity
+   # Execute schema verification (pending migrations check)
+   # Run data integrity checks via compliance scan
+   # Verify row counts on critical tables: loans, leads, users, organizations
+   ```
+
+5. **Re-run pending migrations**
+   ```
+   # Review alembic migration history
+   # Apply any migrations that were pending at time of failure
+   ```
+
+6. **Restore service**
+   ```
+   # Verify /health returns 200
+   # Verify /api/v1/admin/dr/failover-readiness passes all checks
+   # Monitor error rates for 30 minutes post-recovery
+   ```
+
+7. **Post-recovery audit**
+   - Record incident in `soc2_security_incident` table
+   - Verify audit logging resumed correctly
+   - Check for any data inconsistencies in the RPO gap window
+
+---
+
+### 6b. Application Server Failure
+
+**Severity:** 2-3 | **RTO:** 30 minutes | **RPO:** N/A (stateless)
+
+**Detection:**
+- DataDog alert: health endpoint unreachable
+- Vercel frontend reports API connection failures
+- Railway deployment status shows unhealthy containers
+
+**Recovery Steps:**
+
+1. **Check Railway deployment status**
+   ```
+   # Railway dashboard > App service > Deployments
+   # Identify if current deployment is healthy or crashed
+   ```
+
+2. **If current deployment crashed -- rollback**
+   ```
+   # Railway dashboard > Deployments > Select last known-good deployment
+   # Click "Rollback" to redeploy previous version
+   # Railway handles zero-downtime rollback for stateless services
+   ```
+
+3. **If Railway infrastructure issue -- redeploy**
+   ```
+   # Trigger fresh deployment from main branch
+   # git push origin main (or trigger via Railway CLI)
+   ```
+
+4. **Verify recovery**
+   ```
+   # Confirm /health returns 200
+   # Confirm /api/v1/admin/dr/degradation-health shows "full" service level
+   # Verify audit logging is active
+   # Test authentication flow end-to-end
+   ```
+
+5. **Notify stakeholders**
+   - If downtime exceeded 30 minutes, notify affected users per Communication Plan
+
+---
+
+### 6c. Redis / Queue Failure
+
+**Severity:** 2-3 | **RTO:** 1 hour | **RPO:** 4 hours (task state)
+
+**Detection:**
+- DataDog alert: Redis connection refused
+- `/api/v1/admin/dr/queue-persistence` reports failure
+- Celery workers log broker connection errors
+- Background tasks (email, SMS, sync) stop executing
+
+**Recovery Steps:**
+
+1. **Assess Redis availability**
+   ```
+   # Check Railway Redis service status
+   # Review /api/v1/admin/dr/queue-persistence for configuration status
+   ```
+
+2. **If Redis crashed -- wait for auto-restart**
+   ```
+   # Railway auto-restarts crashed Redis containers
+   # RDB snapshot + AOF log restore data to last persistence point
+   # Wait up to 5 minutes for automatic recovery
+   ```
+
+3. **If persistent data loss -- rebuild**
+   ```
+   # Provision new Redis instance on Railway
+   # Update REDIS_URL environment variable
+   # Restart application and Celery workers
+   ```
+
+4. **Recover lost tasks**
+   ```
+   # Celery tasks configured with task_acks_late=True and reject_on_worker_lost=True
+   # Unacknowledged tasks replay automatically on broker reconnection
+   # For tasks that may have been lost:
+   #   - Check pending email queue and resend
+   #   - Check pending SMS queue and resend
+   #   - Trigger manual Salesforce/Encompass sync if needed
+   #   - Re-dispatch any failed retention cleanup tasks
+   ```
+
+5. **Verify recovery**
+   ```
+   # Confirm /api/v1/admin/dr/queue-persistence passes all checks
+   # Verify Celery workers are processing tasks (check Flower dashboard if available)
+   # Test a round-trip task (e.g., trigger a test notification)
+   ```
+
+---
+
+### 6d. S3 / Storage Failure
+
+**Severity:** 3 | **RTO:** 2 hours | **RPO:** 24 hours
+
+**Detection:**
+- DataDog alert: S3 API errors
+- Document upload/download failures reported by users
+- Application logs show S3 timeout or access denied errors
+
+**Recovery Steps:**
+
+1. **Assess S3 availability**
+   ```
+   # Check AWS Health Dashboard for S3 service status
+   # Verify IAM credentials are valid and not rotated
+   # Test S3 connectivity with aws s3 ls
+   ```
+
+2. **If regional S3 outage -- switch to replica region**
+   ```
+   # Update S3_BUCKET_NAME and AWS_REGION environment variables to replica region
+   # Cross-region replication ensures data is available in secondary region
+   # Restart application to pick up new configuration
+   ```
+
+3. **If credential issue -- rotate credentials**
+   ```
+   # Generate new IAM access key in AWS console
+   # Update AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in Railway
+   # Restart application
+   ```
+
+4. **Verify recovery**
+   ```
+   # Test document upload via API
+   # Test document download for existing file
+   # Verify document listing returns expected results
+   ```
+
+5. **Deferred action**
+   - Once primary region recovers, revert configuration
+   - Verify cross-region replication is current
+   - Audit any documents uploaded during failover period
+
+---
+
+### 6e. Complete Infrastructure Failure
+
+**Severity:** 1 | **RTO:** 4 hours | **RPO:** 1 hour (database), 24 hours (files)
+
+**Trigger:** Total loss of Railway infrastructure, or coordinated multi-provider failure.
+
+**Recovery Steps:**
+
+1. **Activate incident command** (see Section 7 - Communication Plan)
+   - Incident Commander assumes control
+   - All engineers join emergency channel
+   - Status page updated to "Major Outage"
+
+2. **Provision new Railway project**
+   ```
+   # Create new Railway project from infrastructure-as-code templates
+   # Or: provision equivalent infrastructure on backup provider
+   ```
+
+3. **Restore database**
+   ```
+   # Obtain latest PostgreSQL backup from Railway backup storage
+   # (Railway retains backups even if project is deleted)
+   # Restore to new PostgreSQL instance
+   # Verify WAL replay completes successfully
+   # Validate table counts and data integrity
+   ```
+
+4. **Configure environment**
+   ```
+   # Restore all environment variables from secure vault
+   # Critical variables:
+   #   DATABASE_URL, REDIS_URL, SECRET_KEY
+   #   AWS credentials (S3 access)
+   #   TELNYX_API_KEY, TWILIO_AUTH_TOKEN
+   #   ANTHROPIC_API_KEY, OPENAI_API_KEY
+   #   VAPI_API_KEY, DEEPGRAM_API_KEY
+   #   DATADOG_API_KEY
+   #   SALESFORCE_* credentials
+   # Verify no trailing whitespace or newline characters in credentials
+   ```
+
+5. **Deploy application**
+   ```
+   # Connect new Railway project to GitHub repository (main branch)
+   # Trigger deployment
+   # Verify build completes and containers start
+   ```
+
+6. **Deploy Celery workers**
+   ```
+   # Configure worker service in Railway
+   # Set REDIS_URL to new Redis instance
+   # Verify workers connect and begin processing
+   ```
+
+7. **Provision Redis**
+   ```
+   # Create new Redis instance in Railway
+   # Configure RDB + AOF persistence
+   # Update REDIS_URL across all services
+   ```
+
+8. **Update DNS**
+   ```
+   # If Railway URL changed, update api.perenniaai.com DNS record
+   # TTL is typically 300s; propagation within 5-10 minutes
+   ```
+
+9. **Run full validation**
+   ```
+   # /health endpoint returns 200
+   # /api/v1/admin/dr/failover-readiness -- all checks pass
+   # /api/v1/admin/dr/queue-persistence -- all checks pass
+   # /api/v1/admin/dr/rto-benchmark -- within RTO target
+   # /api/v1/admin/dr/degradation-health -- service level "full"
+   # Test end-to-end: login, view pipeline, create lead, upload document
+   ```
+
+10. **Verify integrations**
+    ```
+    # Salesforce sync connectivity
+    # Telnyx telephony (test outbound SMS)
+    # Vapi voice AI (test call)
+    # Encompass LOS sync (if configured)
+    # Email delivery (test notification)
+    ```
+
+11. **Post-recovery**
+    - Run compliance scan
+    - Verify audit logging is active and recording
+    - Reconcile any data in the RPO gap (check source systems)
+    - Update status page to "Operational"
+    - Notify all users of recovery
+
+---
+
+### 6f. Security Breach / Data Compromise
+
+**Severity:** 1 | **RTO:** 4 hours (after containment) | **RPO:** Determined by forensics
+
+**This procedure supplements the [Incident Response Policy](incident_response_policy.md).**
+
+**Immediate Containment (within 15 minutes):**
+
+1. **Isolate affected systems**
+   ```
+   # Revoke compromised credentials immediately
+   # Rotate SECRET_KEY to invalidate all active sessions/JWTs
+   # If DB compromised: restrict network access to Railway PostgreSQL
+   # If S3 compromised: revoke IAM credentials, enable bucket policy deny-all
+   ```
+
+2. **Preserve forensic evidence**
+   ```
+   # Take database snapshot BEFORE any cleanup
+   # Export Railway deployment logs
+   # Export DataDog logs for affected timeframe
+   # Capture current audit trail from soc2_security_incident table
+   # Do NOT restart services until evidence is preserved
+   ```
+
+3. **Assess scope**
+   ```
+   # Determine what data was accessed/exfiltrated
+   # Check audit logs for unauthorized access patterns
+   # Review JWT blacklist for tokens that should have been revoked
+   # Check for unauthorized API key usage
+   ```
+
+**Recovery (after containment confirmed):**
+
+4. **Credential rotation**
+   ```
+   # Rotate ALL secrets (not just compromised ones):
+   #   SECRET_KEY, DATABASE_URL password, REDIS_URL password
+   #   All API keys (Telnyx, Twilio, Vapi, Anthropic, OpenAI, Mistral, Deepgram)
+   #   AWS IAM credentials
+   #   Salesforce OAuth tokens
+   #   Encompass client secret
+   # Update all values in Railway environment variables
+   ```
+
+5. **Database recovery (if tampered)**
+   ```
+   # Restore database from last known-clean backup (pre-breach)
+   # This may be before the 1-hour RPO if breach was undetected
+   # Replay legitimate transactions from audit log if possible
+   ```
+
+6. **Force user password resets**
+   ```
+   # Invalidate all user sessions (SECRET_KEY rotation handles JWTs)
+   # Flag all user accounts for password reset on next login
+   # Notify users via out-of-band communication (email from separate system)
+   ```
+
+7. **Regulatory notification**
+   - Assess if breach triggers state data breach notification laws
+   - Mortgage data (NPI) falls under GLBA Safeguards Rule
+   - California: CCPA notification within 72 hours if CA residents affected
+   - Other states: per state breach notification statutes
+   - Document all notification decisions and timestamps
+
+8. **Post-breach hardening**
+   - Review and tighten RBAC permissions
+   - Enable additional monitoring/alerting rules
+   - Conduct security review of the attack vector
+   - Update this DRP with lessons learned
+
+---
+
+## 7. Communication Plan
+
+### 7.1 Internal Escalation Matrix
+
+| Severity | First Responder | Escalation (15 min) | Escalation (30 min) | Executive Notification |
+|---|---|---|---|---|
+| **Sev 1** | On-call engineer | Engineering Lead | CTO | Immediate |
+| **Sev 2** | On-call engineer | Engineering Lead | CTO (if unresolved at 1 hr) | Within 1 hour |
+| **Sev 3** | On-call engineer | Engineering Lead (if unresolved at 2 hrs) | -- | Daily summary |
+| **Sev 4** | Engineering team | -- | -- | Weekly summary |
+
+### 7.2 Incident Roles
+
+| Role | Responsibility |
+|---|---|
+| **Incident Commander** | Coordinates response, makes decisions, owns communication |
+| **Technical Lead** | Directs technical recovery, assigns tasks |
+| **Communications Lead** | Updates status page, drafts customer notifications |
+| **Scribe** | Documents timeline, actions, and decisions in real time |
+
+### 7.3 External Communication
+
+| Audience | Channel | Timing |
+|---|---|---|
+| All users | Status page (status.perenniaai.com) | Immediately upon Sev 1-2 detection |
+| Affected users | In-app banner + email | Within 1 hour for outages > 30 minutes |
+| All users | Email | Post-incident summary within 48 hours |
+| Regulatory (if breach) | Formal written notice | Per applicable state/federal requirements |
+
+### 7.4 Communication Templates
+
+**Status Page -- Investigating:**
+> We are currently investigating an issue affecting [component]. Some users may experience [impact]. We will provide updates every 30 minutes.
+
+**Status Page -- Identified:**
+> We have identified the cause of [issue] and are actively working on recovery. Estimated time to resolution: [ETA].
+
+**Status Page -- Resolved:**
+> The issue affecting [component] has been resolved. All services are operating normally. A full post-incident report will be published within 48 hours.
+
+---
+
+## 8. Backup Strategy
+
+### 8.1 PostgreSQL Database
+
+| Attribute | Value |
+|---|---|
+| **Provider** | Railway managed PostgreSQL |
+| **Backup Method** | WAL (Write-Ahead Log) archiving + daily base backups |
+| **Frequency** | Continuous WAL streaming; daily full snapshots |
+| **Retention** | 7 days (Railway default); critical snapshots exported monthly |
+| **RPO Capability** | Point-in-time recovery to any second within retention window |
+| **Restore Method** | Railway console PITR or snapshot restore |
+| **Encryption** | At rest (Railway volume encryption); in transit (TLS) |
+
+**Validation:** The `/api/v1/admin/dr/failover-readiness` endpoint checks:
+- WAL archiving is active (`archive_mode = on`)
+- Replication slots are configured
+- Database latency is within acceptable bounds
+
+### 8.2 AWS S3 Document Storage
+
+| Attribute | Value |
+|---|---|
+| **Bucket** | Production document bucket (us-east-1) |
+| **Versioning** | Enabled (protects against accidental deletion/overwrite) |
+| **Replication** | Cross-region replication to secondary region |
+| **Retention** | Per document type; minimum 7 years for loan documents per GLBA/TRID |
+| **Encryption** | SSE-S3 (server-side encryption at rest); TLS in transit |
+| **Access Control** | IAM role with least-privilege; bucket policy restricts by IP/role |
+
+### 8.3 Redis
+
+| Attribute | Value |
+|---|---|
+| **Persistence** | RDB snapshots (every 60 seconds if >= 1 key changed) + AOF (append-only file) |
+| **Backup** | Railway-managed; RDB files retained on volume |
+| **Data Classification** | Transient (cache, session, task queue); not source-of-truth |
+| **Loss Impact** | Tasks replay via Celery retry; cache rebuilds automatically; sessions re-authenticate |
+
+**Validation:** The `/api/v1/admin/dr/queue-persistence` endpoint checks:
+- Celery `task_acks_late` is enabled
+- Celery `reject_on_worker_lost` is enabled
+- Redis RDB/AOF persistence configuration
+- Current queue depths
+
+### 8.4 Application Code
+
+| Attribute | Value |
+|---|---|
+| **Repository** | GitHub (private) |
+| **Branches** | `main` (production), feature branches |
+| **Protection** | Branch protection on `main`; PR review required |
+| **CI/CD** | GitHub Actions (test suite) + Railway auto-deploy on push to `main` |
+| **Retention** | Full Git history; indefinite |
+
+### 8.5 Configuration & Secrets
+
+| Attribute | Value |
+|---|---|
+| **Storage** | Railway encrypted environment variables |
+| **Backup** | Documented in secure credential vault (see Appendix B) |
+| **Rotation Schedule** | API keys quarterly; passwords semi-annually; after any suspected compromise |
+
+---
+
+## 9. Failover Procedures
+
+### 9.1 Database Failover
+
+Railway PostgreSQL uses managed PITR (Point-in-Time Recovery). Failover is provider-managed for hardware failures. For logical corruption (bad migration, accidental deletion), manual PITR restore is required.
+
+**Automated Failover (Hardware):**
+- Railway detects container/volume failure
+- New container provisioned with existing volume or PITR restore
+- Connection string remains stable (Railway internal networking)
+- Application reconnects via SQLAlchemy connection pool retry
+
+**Manual Failover (Logical Corruption):**
+1. Identify last known-good point in time from audit logs
+2. Initiate PITR restore in Railway console
+3. Validate restored data (see Section 11)
+4. Update `DATABASE_URL` if new instance provisioned
+5. Restart application services
+
+### 9.2 Application Failover
+
+Railway provides instant rollback to any previous deployment:
+
+1. Navigate to Railway dashboard > Service > Deployments
+2. Select last successful deployment
+3. Click "Rollback"
+4. Railway performs zero-downtime deployment swap
+5. Verify health endpoint
+
+### 9.3 Redis Failover
+
+1. Railway auto-restarts crashed Redis containers
+2. Data restored from RDB snapshot + AOF replay
+3. If volume is unrecoverable:
+   - Provision new Redis instance
+   - Update `REDIS_URL` environment variable
+   - Restart all application and worker services
+   - Lost tasks will be retried by Celery's retry policy
+
+### 9.4 Frontend Failover
+
+Vercel provides automatic failover:
+- Global edge CDN with automatic failover between edge nodes
+- If build fails, previous deployment remains active
+- Instant rollback via Vercel dashboard
+- Static assets served from CDN even if origin is unavailable
+
+### 9.5 AI Provider Failover
+
+The platform implements circuit breaker pattern (`CircuitBreaker` service) for AI providers:
+
+1. Circuit opens after 5 consecutive failures (configurable)
+2. `GracefulDegradation` transitions to "degraded" service level
+3. Core CRM functionality remains available without AI
+4. Circuit half-opens after recovery timeout (30 seconds)
+5. Single successful request closes circuit, restoring full service
+
+Provider fallback chain: Anthropic -> OpenAI -> Mistral (for call intelligence)
+
+---
+
+## 10. DR Testing Schedule
+
+### 10.1 Test Calendar
+
+| Test Type | Frequency | Duration | Participants | Next Scheduled |
+|---|---|---|---|---|
+| **Backup Restoration Test** | Quarterly | 2-4 hours | Engineering Team | Q2 2026 (April) |
+| **Failover Drill** | Semi-annually | 2-4 hours | Engineering Team | Q3 2026 (July) |
+| **Full DR Exercise** | Annually | Full day | Engineering + Security | Q4 2026 (October) |
+| **Tabletop Exercise** | Semi-annually | 1-2 hours | Engineering + Leadership | Q2 2026 (May) |
+| **Policy Review** | Semi-annually | 1 hour | Engineering Lead | Q3 2026 (September) |
+
+### 10.2 Backup Restoration Test Procedure
+
+1. Select a recent Railway PostgreSQL backup
+2. Restore to an isolated test environment (not production)
+3. Verify table counts match production (within RPO tolerance)
+4. Run application health checks against restored database
+5. Execute sample queries for critical data (loans, leads, users)
+6. Document results, time to restore, and any issues
+7. File test report in SOC 2 evidence repository
+
+### 10.3 Failover Drill Procedure
+
+1. Simulate component failure (stop one Railway service)
+2. Verify graceful degradation activates correctly
+3. Execute recovery procedure from this document
+4. Measure actual recovery time against RTO target
+5. Verify all automated readiness checks pass post-recovery
+6. Document gaps between plan and actual execution
+7. Update this DRP with any needed corrections
+
+### 10.4 Full DR Exercise Procedure
+
+1. Simulate complete infrastructure failure (theoretical or actual)
+2. Execute full recovery from Section 6e
+3. Measure total time from "disaster declared" to "fully operational"
+4. Validate all integrations restored and functional
+5. Run compliance scan and verify audit trail continuity
+6. Conduct post-exercise debrief
+7. Update all DR documentation with findings
+
+### 10.5 Test Success Criteria
+
+| Criteria | Target |
+|---|---|
+| Database restored within RTO | < 4 hours |
+| Data loss within RPO | < 1 hour of transactions |
+| All health checks pass post-recovery | 100% |
+| Audit logging resumed | Verified |
+| All automated DR endpoints return healthy | Verified |
+
+### 10.6 SOC 2 Evidence (A1.3)
+
+All DR test results must be documented and retained as evidence:
+- Test date, participants, and scenario
+- Actual RTO/RPO achieved
+- Issues encountered and remediation
+- Sign-off by Engineering Lead
+
+---
+
+## 11. Post-Recovery Validation Checklist
+
+Execute this checklist after any recovery event. All items must pass before declaring "recovered."
+
+### 11.1 Infrastructure Validation
+
+- [ ] Railway dashboard shows all services healthy (green)
+- [ ] `/health` endpoint returns HTTP 200 with all checks passing
+- [ ] `/api/v1/admin/dr/failover-readiness` -- all checks passed
+- [ ] `/api/v1/admin/dr/queue-persistence` -- all checks passed
+- [ ] `/api/v1/admin/dr/rto-benchmark` -- recovery time within RTO target
+- [ ] `/api/v1/admin/dr/degradation-health` -- service level is "full"
+- [ ] DataDog monitoring is receiving metrics and logs
+
+### 11.2 Database Validation
+
+- [ ] All database migrations are current (no pending)
+- [ ] Row counts on critical tables are within expected range:
+  - `users` / `organizations`
+  - `loans` / `leads`
+  - `documents` / `activities`
+  - `compliance_alerts` / `soc2_security_incident`
+- [ ] Sample queries return expected data for recent records
+- [ ] Foreign key constraints are intact (no orphaned records)
+- [ ] Indexes are present and used (check `pg_stat_user_indexes`)
+
+### 11.3 Application Validation
+
+- [ ] User authentication works (login, JWT issuance, token refresh)
+- [ ] Role-based access control is enforced (test admin vs. LO)
+- [ ] Pipeline view loads with correct data
+- [ ] Lead creation and update works
+- [ ] Loan record CRUD operations succeed
+- [ ] Document upload and download works (S3 connectivity)
+- [ ] Search functionality returns results
+
+### 11.4 Integration Validation
+
+- [ ] Celery workers are processing tasks (check queue depth trending down)
+- [ ] Email delivery functional (trigger test notification)
+- [ ] SMS delivery functional (test via Telnyx)
+- [ ] AI chat responds (Anthropic/OpenAI connectivity)
+- [ ] Voice AI functional (Vapi connectivity if applicable)
+- [ ] Salesforce sync operational (if configured for org)
+- [ ] Encompass LOS sync operational (if configured for org)
+
+### 11.5 Compliance Validation
+
+- [ ] Audit logging is active and recording new events
+- [ ] Tenant isolation (RLS) is enforced
+- [ ] CSRF middleware is active
+- [ ] Rate limiting is functional
+- [ ] SOC 2 compliance scan passes
+- [ ] No compliance alerts in "open" state from the incident itself are unaddressed
+
+### 11.6 Documentation
+
+- [ ] Incident recorded in `soc2_security_incident` table
+- [ ] Timeline documented (detection, response, recovery, validation)
+- [ ] Root cause identified (or investigation opened)
+- [ ] Status page updated to "Operational"
+- [ ] User notification sent (if outage exceeded 30 minutes)
+- [ ] Post-incident report draft started (due within 48 hours)
+
+---
+
+## 12. Appendix A: Contact List
+
+> **CLASSIFICATION: RESTRICTED** -- This section contains contact information. Maintain in secure document management system alongside this plan.
+
+| Role | Name | Phone | Email | Backup Contact |
+|---|---|---|---|---|
+| Engineering Lead | _[NAME]_ | _[PHONE]_ | _[EMAIL]_ | _[BACKUP]_ |
+| CTO | _[NAME]_ | _[PHONE]_ | _[EMAIL]_ | _[BACKUP]_ |
+| On-Call Engineer (Primary) | _[NAME]_ | _[PHONE]_ | _[EMAIL]_ | _[BACKUP]_ |
+| On-Call Engineer (Secondary) | _[NAME]_ | _[PHONE]_ | _[EMAIL]_ | _[BACKUP]_ |
+| Security Officer | _[NAME]_ | _[PHONE]_ | _[EMAIL]_ | _[BACKUP]_ |
+
+### External Contacts
+
+| Provider | Support Channel | Account ID | SLA |
+|---|---|---|---|
+| Railway | Dashboard support / Discord | _[ACCOUNT]_ | Best-effort (managed hosting) |
+| AWS | AWS Support console | _[ACCOUNT]_ | Business support tier |
+| Vercel | Dashboard support | _[ACCOUNT]_ | Pro plan support |
+| DataDog | Support portal | _[ACCOUNT]_ | Standard support |
+| Telnyx | Portal / support@telnyx.com | _[ACCOUNT]_ | Enterprise support |
+| Twilio | Console / support | _[ACCOUNT]_ | Standard support |
+| Anthropic | API support | _[ACCOUNT]_ | API tier support |
+
+---
+
+## 13. Appendix B: System Access Credentials Location
+
+> **CLASSIFICATION: RESTRICTED** -- This section documents WHERE credentials are stored, not the credentials themselves.
+
+| System | Credential Location | Access Method |
+|---|---|---|
+| Railway (all services) | Railway dashboard > Project > Variables | Railway account login (SSO) |
+| AWS (S3, IAM) | AWS IAM console | Root account MFA + IAM role |
+| GitHub (repository) | GitHub organization settings | GitHub SSO |
+| Vercel (frontend) | Vercel dashboard > Project > Settings | Vercel account login |
+| DataDog (monitoring) | DataDog organization settings | DataDog account login |
+| Domain registrar (DNS) | Registrar account | Account login + MFA |
+| Telnyx (telephony) | Telnyx Mission Control portal | Account login |
+| Twilio (voice) | Twilio console | Account login |
+| Anthropic (AI) | Anthropic console | Account login |
+
+**Credential Backup:**
+- All production environment variables are documented in the secure credential vault
+- Vault location: _[VAULT_URL]_ (accessible to Engineering Lead and CTO only)
+- Last vault sync: _[DATE]_
+- Vault backup: _[BACKUP_LOCATION]_
+
+**Emergency Access:**
+- If primary credential holder is unavailable, secondary access is through _[PROCESS]_
+- Break-glass procedure: _[DOCUMENTED_SEPARATELY]_
+
+---
+
+## 14. Approval & Signatures
+
+This Disaster Recovery Plan has been reviewed and approved by the following parties:
+
+| Role | Name | Signature | Date |
+|---|---|---|---|
+| Engineering Lead | __________________ | __________________ | ________ |
+| CTO | __________________ | __________________ | ________ |
+| Security Officer | __________________ | __________________ | ________ |
+
+**Approval Criteria:**
+- All recovery procedures have been validated in test environment
+- RTO and RPO targets are achievable based on DR test results
+- Contact list and credential locations are current
+- Communication templates and escalation matrix are approved by leadership
+
+---
+
+## SOC 2 Criteria Mapping
+
+| SOC 2 Criteria | DRP Section | Evidence |
+|---|---|---|
+| **A1** -- Availability commitments | Section 3 (Recovery Objectives) | RPO/RTO targets documented |
+| **A1.2** -- Recovery infrastructure | Section 4 (Infrastructure), Section 8 (Backups) | Architecture, backup strategy, failover procedures |
+| **A1.2** -- Recovery procedures | Section 6 (Recovery Procedures) | Step-by-step runbooks for each scenario |
+| **A1.3** -- Recovery plan testing | Section 10 (DR Testing Schedule) | Test calendar, procedures, success criteria |
+| **CC7.4** -- Incident response | Section 6f (Security Breach), Section 7 (Communication) | Breach response, escalation matrix |
+| **CC7.5** -- Incident recovery | Section 11 (Post-Recovery Checklist) | Validation steps, compliance verification |
+| **CC9.1** -- Risk mitigation | Section 5 (Disaster Classification) | Severity tiers, response times |
+
+---
+
+## Automated DR Readiness Endpoints
+
+The following admin API endpoints support automated DR validation and should be executed regularly:
+
+| Endpoint | Purpose | Frequency |
+|---|---|---|
+| `GET /api/v1/admin/dr/failover-readiness` | Validates WAL, replication, DB latency, Redis, connection recovery | Daily (automated) |
+| `GET /api/v1/admin/dr/queue-persistence` | Verifies Celery config, Redis persistence, queue depths | Daily (automated) |
+| `GET /api/v1/admin/dr/rto-benchmark` | Benchmarks recovery steps and projects achievable RTO | Weekly (automated) |
+| `GET /api/v1/admin/dr/degradation-health` | Reports current service level and circuit breaker status | Continuous (monitoring) |
+| `GET /api/v1/admin/dr/runbook` | Returns documented failover procedures via API | On-demand |
+| `GET /api/v1/admin/dr/retention-policy` | Returns data retention configuration | Monthly review |
+| `GET /api/v1/admin/data-retention/report` | Comprehensive retention status across CRM + SOC 2 tables | Monthly review |
+
+All endpoints require admin-level authentication (`admin`, `site_admin`, or `platform_admin` role).
+
+---
+
+*End of Disaster Recovery Plan*

--- a/backend/soc2_compliance/policies/written_information_security_program.md
+++ b/backend/soc2_compliance/policies/written_information_security_program.md
@@ -1,0 +1,1070 @@
+# Written Information Security Program (WISP)
+
+**Perennia AI, Inc.**
+
+---
+
+| Field | Value |
+|---|---|
+| **Document Title** | Written Information Security Program (WISP) |
+| **Document ID** | WISP-001 |
+| **Classification** | Confidential |
+| **Version** | 1.0 |
+| **Effective Date** | 2026-03-27 |
+| **Last Reviewed** | 2026-03-27 |
+| **Next Review** | 2026-09-27 |
+| **Owner** | Security Officer |
+| **SOC 2 Criteria** | CC1-CC9, A1, PI1, C1, P1-P8 |
+
+---
+
+## Table of Contents
+
+1. [Executive Summary & Purpose](#1-executive-summary--purpose)
+2. [Scope](#2-scope)
+3. [Organizational Security Governance](#3-organizational-security-governance)
+4. [Information Security Objectives](#4-information-security-objectives)
+5. [Risk Assessment Framework](#5-risk-assessment-framework)
+6. [Security Control Framework](#6-security-control-framework)
+7. [Data Classification & Handling](#7-data-classification--handling)
+8. [Access Control & Authentication](#8-access-control--authentication)
+9. [Encryption Standards](#9-encryption-standards)
+10. [Incident Response Overview](#10-incident-response-overview)
+11. [Business Continuity & Disaster Recovery](#11-business-continuity--disaster-recovery)
+12. [Vendor & Third-Party Risk Management](#12-vendor--third-party-risk-management)
+13. [Employee Security Responsibilities](#13-employee-security-responsibilities)
+14. [Security Awareness Training Requirements](#14-security-awareness-training-requirements)
+15. [Compliance Monitoring & Audit](#15-compliance-monitoring--audit)
+16. [Policy Review & Update Schedule](#16-policy-review--update-schedule)
+17. [Approval & Signatures](#17-approval--signatures)
+
+---
+
+## 1. Executive Summary & Purpose
+
+**SOC 2 Criteria:** CC1.1, CC1.2, CC1.3, CC1.4, CC5.1
+
+### 1.1 Executive Summary
+
+Perennia AI, Inc. ("Perennia AI," "the Company") operates an AI-first operating platform for mortgage loan officers, processing and storing sensitive financial data including personally identifiable information (PII), loan application data, credit information, and financial records subject to federal and state regulatory requirements.
+
+This Written Information Security Program (WISP) establishes the comprehensive framework governing the protection of all information assets under Perennia AI's custody or control. It serves as the authoritative, board-level security document that consolidates and governs eight subordinate security policies into a unified program aligned with SOC 2 Type II Trust Service Criteria.
+
+### 1.2 Purpose
+
+The purpose of this WISP is to:
+
+(a) Define the organizational structure, roles, and responsibilities for information security governance at Perennia AI, Inc.
+
+(b) Establish information security objectives and the risk management framework used to identify, assess, and mitigate threats to the confidentiality, integrity, and availability of information assets.
+
+(c) Provide a unified control framework that consolidates and references eight subordinate security policies, ensuring comprehensive coverage of all SOC 2 Trust Service Criteria.
+
+(d) Ensure compliance with applicable federal and state regulations, including but not limited to the Gramm-Leach-Bliley Act (GLBA), the Truth in Lending Act/Real Estate Settlement Procedures Act Integrated Disclosure rule (TRID), the California Consumer Privacy Act (CCPA), and state breach notification laws.
+
+(e) Communicate security expectations to all personnel, contractors, and third-party service providers who access, process, or store Perennia AI information assets.
+
+### 1.3 Authority
+
+This WISP is approved by the Chief Executive Officer, Chief Technology Officer, and Security Officer of Perennia AI, Inc. It supersedes all prior versions and takes precedence in the event of any conflict with subordinate policies. Subordinate policies shall be interpreted in a manner consistent with this WISP.
+
+### 1.4 Regulatory Context
+
+Perennia AI operates within the mortgage lending industry and is subject to the following regulatory frameworks, which inform the controls established in this program:
+
+| Regulation | Applicability |
+|---|---|
+| Gramm-Leach-Bliley Act (GLBA) | Financial data safeguards, privacy notices |
+| TILA-RESPA Integrated Disclosure (TRID) | Loan disclosure timing and tolerance |
+| Real Estate Settlement Procedures Act (RESPA) | Settlement service provider oversight |
+| California Consumer Privacy Act (CCPA) | Consumer data rights for California residents |
+| State Breach Notification Laws | Incident notification obligations (all 50 states) |
+| Fair Credit Reporting Act (FCRA) | Credit data handling and permissible purposes |
+| SOC 2 Type II | Trust Service Criteria for service organizations |
+
+---
+
+## 2. Scope
+
+**SOC 2 Criteria:** CC1.1, CC2.1, CC2.2
+
+### 2.1 Systems in Scope
+
+This WISP applies to all information systems owned, operated, or managed by Perennia AI, Inc., including but not limited to:
+
+(a) **Production Platform** -- The Perennia AI mortgage CRM application, including all backend services (FastAPI application server), frontend single-page application, and supporting microservices.
+
+(b) **Data Stores** -- All PostgreSQL databases, including production, staging, and backup instances hosted on Railway infrastructure.
+
+(c) **AI and Voice Services** -- Aria voice AI agent, AI chat services, call intelligence processing, and all integrations with third-party AI providers (OpenAI, Deepgram, Vapi).
+
+(d) **Communication Systems** -- Telephony integrations (Telnyx, Twilio), email intelligence (SendGrid), SMS services, and voicemail drop capabilities.
+
+(e) **Integration Points** -- Salesforce CRM synchronization, Encompass LOS integration, and all third-party API connections.
+
+(f) **Monitoring and Observability** -- DataDog SIEM integration, audit logging infrastructure, and compliance scanning systems.
+
+(g) **Development Infrastructure** -- Source code repositories (GitHub), CI/CD pipelines (Railway), and development environments.
+
+### 2.2 Data in Scope
+
+All data processed, stored, or transmitted by Perennia AI systems, classified per the Data Classification Policy (Section 7), including:
+
+- Borrower personally identifiable information (PII)
+- Loan application and processing data
+- Financial records (income, assets, credit)
+- Communication records (calls, emails, SMS)
+- Audit logs and security event data
+- System configuration and credentials
+
+### 2.3 Personnel in Scope
+
+This WISP applies to all individuals who access Perennia AI information systems or data:
+
+- Full-time and part-time employees
+- Independent contractors and consultants
+- Third-party service providers and their personnel
+- Temporary workers and interns
+- Loan officers, processors, and other end users of the platform
+
+### 2.4 Exclusions
+
+No systems, data categories, or personnel with access to Perennia AI information assets are excluded from the scope of this WISP.
+
+---
+
+## 3. Organizational Security Governance
+
+**SOC 2 Criteria:** CC1.1, CC1.2, CC1.3, CC1.4, CC1.5
+
+### 3.1 Governance Structure
+
+Perennia AI maintains a security governance structure with clearly defined roles, responsibilities, and reporting lines to ensure accountability for the protection of information assets.
+
+```
+Board of Directors / CEO
+        |
+Chief Technology Officer (CTO)
+        |
+  +-----+-----+
+  |             |
+Security    Engineering
+Officer       Lead
+  |
+Data Protection
+  Officer
+```
+
+### 3.2 Roles and Responsibilities
+
+#### 3.2.1 Chief Executive Officer (CEO)
+
+- Bears ultimate accountability for the information security posture of Perennia AI, Inc.
+- Approves this WISP and allocates resources for its implementation.
+- Receives quarterly security posture briefings from the Security Officer.
+- Authorizes exceptions to security policies when business justification warrants and compensating controls are documented.
+
+#### 3.2.2 Chief Technology Officer (CTO)
+
+- Provides executive oversight of the security program and its alignment with business objectives.
+- Approves the security budget, staffing, and technology investments.
+- Ensures security requirements are integrated into the software development lifecycle.
+- Serves as the executive escalation point for security incidents classified as Critical severity.
+- Co-approves this WISP and all material amendments.
+
+#### 3.2.3 Security Officer (CISO Function)
+
+- Owns and maintains this WISP and all subordinate security policies.
+- Directs the security team in the execution of the information security program.
+- Conducts or oversees risk assessments, vulnerability management, and compliance monitoring.
+- Manages the incident response program and serves as the Incident Commander for Critical and High severity incidents.
+- Reports security posture metrics to the CTO and CEO on a quarterly basis.
+- Coordinates SOC 2 Type II audit activities with external auditors.
+- Oversees security awareness training program for all personnel.
+
+#### 3.2.4 Data Protection Officer (DPO)
+
+- Ensures compliance with data privacy regulations (GLBA, CCPA, FCRA, state privacy laws).
+- Manages data subject access requests (DSARs) and deletion requests.
+- Oversees the data classification program and ensures appropriate handling controls are implemented.
+- Reviews data processing agreements (DPAs) with third-party vendors.
+- Advises on privacy impact assessments for new features or integrations involving PII.
+- Coordinates breach notification obligations under applicable state and federal law.
+
+#### 3.2.5 Engineering Lead
+
+- Implements technical security controls within the Perennia AI platform.
+- Manages the change management process and ensures all changes follow the Change Management Policy.
+- Maintains the CI/CD pipeline security, including automated testing and deployment safeguards.
+- Oversees database security, encryption implementation, and infrastructure hardening.
+- Leads post-mortem reviews for security incidents involving application or infrastructure components.
+- Conducts code reviews with security considerations for all pull requests affecting sensitive systems.
+
+#### 3.2.6 All Personnel
+
+- Comply with this WISP and all subordinate security policies.
+- Complete required security awareness training within established timelines.
+- Report suspected security incidents, policy violations, and vulnerabilities promptly.
+- Protect credentials, access tokens, and other authentication materials from unauthorized disclosure.
+
+### 3.3 Security Governance Cadence
+
+| Activity | Frequency | Participants |
+|---|---|---|
+| Security posture briefing to CEO | Quarterly | Security Officer, CEO |
+| Security program review | Semi-annual | CTO, Security Officer, Engineering Lead, DPO |
+| Policy review cycle | Semi-annual | Security Officer, policy owners |
+| Risk assessment review | Annual (or upon material change) | Security Officer, CTO, Engineering Lead |
+| SOC 2 audit coordination | Annual | Security Officer, external auditors |
+| Incident response drill | Quarterly | Security team, engineering team |
+
+---
+
+## 4. Information Security Objectives
+
+**SOC 2 Criteria:** CC1.1, CC1.3, CC2.1
+
+### 4.1 Primary Objectives
+
+Perennia AI establishes the following information security objectives, which shall guide the design, implementation, and continuous improvement of all security controls:
+
+**(a) Confidentiality** -- Ensure that sensitive information, including borrower PII, financial records, loan data, and proprietary business information, is accessible only to authorized individuals and systems with a legitimate need. *(SOC 2 Criteria: C1)*
+
+**(b) Integrity** -- Maintain the accuracy, completeness, and reliability of all information assets throughout their lifecycle. Prevent unauthorized modification of data, system configurations, and audit records. *(SOC 2 Criteria: PI1)*
+
+**(c) Availability** -- Ensure that information systems and data are accessible to authorized users when needed, with defined recovery time and recovery point objectives. *(SOC 2 Criteria: A1)*
+
+**(d) Privacy** -- Process personal information in accordance with applicable privacy regulations and the Company's privacy commitments, including collection limitation, use limitation, and secure disposal. *(SOC 2 Criteria: P1-P8)*
+
+**(e) Regulatory Compliance** -- Maintain continuous compliance with GLBA, TRID, RESPA, CCPA, FCRA, and other applicable federal and state regulations governing the mortgage lending industry.
+
+### 4.2 Measurable Security Targets
+
+| Objective | Metric | Target |
+|---|---|---|
+| Incident response time (Critical) | Time from detection to containment | Less than or equal to 1 hour |
+| Incident response time (High) | Time from detection to containment | Less than or equal to 4 hours |
+| System availability | Platform uptime | Greater than or equal to 99.5% |
+| Vulnerability remediation (Critical) | Time from identification to patch | Less than or equal to 72 hours |
+| Access review completion | Percentage of reviews completed on schedule | 100% quarterly |
+| Security training completion | Percentage of personnel trained | 100% within 30 days of hire; annual refresher |
+| Encryption coverage (Restricted data) | Percentage of Restricted fields encrypted at rest | 100% |
+| Backup restoration success | Quarterly restoration test pass rate | 100% |
+| SOC 2 audit findings | Number of qualified/adverse findings | Zero |
+
+### 4.3 Continuous Improvement
+
+The security program shall be subject to continuous improvement through:
+
+- Lessons learned from security incidents and post-mortems.
+- Findings from internal compliance scans and external audits.
+- Changes in the regulatory landscape or threat environment.
+- Feedback from personnel, customers, and third-party assessors.
+
+---
+
+## 5. Risk Assessment Framework
+
+**SOC 2 Criteria:** CC3.1, CC3.2, CC3.3, CC3.4, CC9.1
+
+### 5.1 Risk Assessment Methodology
+
+Perennia AI conducts formal risk assessments to identify, analyze, and evaluate risks to the confidentiality, integrity, and availability of information assets. The risk assessment methodology follows these phases:
+
+#### Phase 1: Asset Identification
+- Inventory all information assets, including data stores, applications, integrations, and infrastructure components.
+- Classify assets according to the Data Classification Policy.
+- Identify asset owners responsible for security decisions.
+
+#### Phase 2: Threat Identification
+- Identify potential threat sources, including external adversaries, insider threats, environmental hazards, and system failures.
+- Consider threats specific to the mortgage lending industry, including fraud, identity theft, and regulatory non-compliance.
+- Review threat intelligence sources and industry advisories.
+
+#### Phase 3: Vulnerability Assessment
+- Identify vulnerabilities in systems, processes, and controls that could be exploited by identified threats.
+- Conduct automated vulnerability scanning of application dependencies (pinned in `requirements.lock`).
+- Perform annual penetration testing by a qualified third party.
+- Review application security through code reviews and static analysis.
+
+#### Phase 4: Risk Analysis
+
+Risks are evaluated using a qualitative risk matrix based on likelihood and impact:
+
+| | **Impact: Low** | **Impact: Medium** | **Impact: High** | **Impact: Critical** |
+|---|---|---|---|---|
+| **Likelihood: High** | Medium | High | Critical | Critical |
+| **Likelihood: Medium** | Low | Medium | High | Critical |
+| **Likelihood: Low** | Low | Low | Medium | High |
+| **Likelihood: Rare** | Low | Low | Low | Medium |
+
+#### Phase 5: Risk Treatment
+
+For each identified risk, one of the following treatment strategies shall be applied:
+
+- **Mitigate** -- Implement controls to reduce the likelihood or impact of the risk to an acceptable level.
+- **Transfer** -- Transfer the risk to a third party through insurance, contractual terms, or outsourcing.
+- **Accept** -- Accept the residual risk with documented justification and executive approval.
+- **Avoid** -- Eliminate the risk by discontinuing the activity or removing the asset.
+
+### 5.2 Risk Assessment Schedule
+
+| Assessment Type | Frequency | Responsible Party |
+|---|---|---|
+| Comprehensive risk assessment | Annual | Security Officer |
+| Targeted risk assessment (new features/integrations) | As needed | Security Officer, Engineering Lead |
+| Automated vulnerability scanning | Monthly (dependency review) | Engineering Lead |
+| Penetration testing | Annual | External vendor |
+| Risk register review | Quarterly | Security Officer, CTO |
+
+### 5.3 Risk Acceptance
+
+Risks with a residual rating of High or Critical after treatment require documented acceptance by the CTO or CEO. Accepted risks shall be reviewed quarterly and re-evaluated at each annual risk assessment.
+
+### 5.4 Mortgage Industry-Specific Risks
+
+The following risk categories receive heightened attention due to the nature of the mortgage lending industry:
+
+| Risk Category | Description | Primary Controls |
+|---|---|---|
+| Borrower PII exposure | Unauthorized access to SSN, financial data, credit scores | Fernet field-level encryption, RLS, access logging |
+| Regulatory non-compliance | TRID timing violations, RESPA fee tolerance breaches | Automated compliance scanning, disclosure timeline tracking |
+| Loan data integrity | Unauthorized modification of loan terms, rates, or conditions | Audit trails, change management, WORM protections |
+| Third-party data sharing | Improper data exposure through integrations | Vendor risk management, DPAs, scoped API credentials |
+| Fraud and identity theft | Synthetic identity fraud, wire fraud schemes | Anomaly detection, verification workflows |
+
+---
+
+## 6. Security Control Framework
+
+**SOC 2 Criteria:** CC5.1, CC5.2, CC5.3
+
+### 6.1 Framework Overview
+
+Perennia AI implements a layered security control framework organized into eight subordinate policies. Each policy addresses a specific domain of the security program and maps to one or more SOC 2 Trust Service Criteria. Together, these policies provide comprehensive coverage of all applicable criteria.
+
+This WISP serves as the governing document. In the event of any conflict between this WISP and a subordinate policy, this WISP shall prevail.
+
+### 6.2 Subordinate Policy Index
+
+| # | Policy Name | Path | SOC 2 Criteria | Owner |
+|---|---|---|---|---|
+| 1 | Information Security Policy | `backend/soc2_compliance/policies/information_security_policy.md` | CC1, CC5 | Security Team |
+| 2 | Access Control Policy | `backend/soc2_compliance/policies/access_control_policy.md` | CC6 | Security Team |
+| 3 | Incident Response Policy | `backend/soc2_compliance/policies/incident_response_policy.md` | CC7 | Security Team |
+| 4 | Change Management Policy | `backend/soc2_compliance/policies/change_management_policy.md` | CC8 | Engineering Team |
+| 5 | Data Classification Policy | `backend/soc2_compliance/policies/data_classification_policy.md` | C1 | Security Team |
+| 6 | Data Retention Policy | `backend/soc2_compliance/policies/data_retention_policy.md` | P4 | Security Team |
+| 7 | Vendor Management Policy | `backend/soc2_compliance/policies/vendor_management_policy.md` | CC9 | Security Team |
+| 8 | Disaster Recovery Policy | `backend/soc2_compliance/policies/disaster_recovery_policy.md` | A1 | Engineering Team |
+
+### 6.3 SOC 2 Trust Service Criteria Coverage Matrix
+
+The following matrix maps each SOC 2 Trust Service Criterion to the subordinate policies and WISP sections that address it:
+
+| Criterion | Description | Governing Policies | WISP Sections |
+|---|---|---|---|
+| **CC1** | Control Environment | Information Security Policy, WISP | 1, 3, 4, 13, 14 |
+| **CC2** | Communication and Information | WISP | 2, 3, 6, 14 |
+| **CC3** | Risk Assessment | WISP | 5 |
+| **CC4** | Monitoring Activities | WISP | 15 |
+| **CC5** | Control Activities | Information Security Policy, WISP | 6, 7, 8, 9 |
+| **CC6** | Logical and Physical Access | Access Control Policy | 8 |
+| **CC7** | System Operations | Incident Response Policy | 10 |
+| **CC8** | Change Management | Change Management Policy | 6.2 (#4) |
+| **CC9** | Risk Mitigation | Vendor Management Policy, WISP | 5, 12 |
+| **A1** | Availability | Disaster Recovery Policy | 11 |
+| **PI1** | Processing Integrity | Change Management Policy, WISP | 4, 6, 9 |
+| **C1** | Confidentiality | Data Classification Policy, WISP | 7, 9 |
+| **P1** | Privacy Notice | WISP | 7, 13 |
+| **P2** | Choice and Consent | WISP | 7.5 |
+| **P3** | Collection | Data Classification Policy, WISP | 7 |
+| **P4** | Use, Retention, and Disposal | Data Retention Policy | 7, 16 |
+| **P5** | Access (Data Subject Rights) | Data Retention Policy, WISP | 7.5 |
+| **P6** | Disclosure and Notification | Incident Response Policy, WISP | 10 |
+| **P7** | Quality | WISP | 7, 15 |
+| **P8** | Monitoring and Enforcement | WISP | 15 |
+
+### 6.4 Control Implementation Tiers
+
+Controls are implemented across three tiers:
+
+**(a) Administrative Controls** -- Policies, procedures, governance structures, training, and personnel security measures documented in this WISP and subordinate policies.
+
+**(b) Technical Controls** -- Automated enforcement mechanisms within the Perennia AI platform, including:
+- Fernet field-level encryption for Restricted data (`EncryptionService`)
+- Row-Level Security (RLS) tenant isolation at the database layer
+- JWT RS256 token-based authentication with blacklist enforcement
+- SOC 2 audit middleware for comprehensive API request logging
+- Automated compliance scanning (daily at 02:15 UTC)
+- Automated data retention enforcement (daily at 03:00 UTC)
+- Anomaly detection with risk-score-based escalation
+- WORM triggers preventing ad-hoc deletion of audit trails
+- CSRF middleware with defined bypass protocols
+
+**(c) Physical Controls** -- Infrastructure security provided by Railway (SOC 2 certified) for hosting, with US-based data residency for mortgage data compliance.
+
+---
+
+## 7. Data Classification & Handling
+
+**SOC 2 Criteria:** C1, P1, P2, P3, P4, P7
+
+### 7.1 Classification Levels
+
+All data processed, stored, or transmitted by Perennia AI systems shall be classified into one of the following levels, as defined in the Data Classification Policy:
+
+| Classification Level | Description | Examples |
+|---|---|---|
+| **Public** | Information approved for unrestricted distribution. No harm from unauthorized disclosure. | Marketing materials, public API documentation, published rate sheets |
+| **Internal** | Business information not intended for public distribution. Limited harm from unauthorized disclosure. | Pipeline metrics, organization settings, internal reports, system configuration (non-credential) |
+| **Confidential** | Sensitive business information whose unauthorized disclosure could cause significant harm. | Loan application details, borrower contact information, pricing data, internal communications |
+| **Restricted** | Highly sensitive information subject to regulatory requirements. Unauthorized disclosure could cause severe harm. | Social Security Numbers, bank account numbers, credit scores, tax returns, income documentation, credit card numbers |
+
+### 7.2 PII Field Inventory
+
+Perennia AI maintains an authoritative inventory of thirty (30) PII fields in the data classification registry (`soc2_compliance/constants.py:PII_FIELDS`). This inventory includes, but is not limited to:
+
+- Social Security Numbers, Tax IDs, Employer Identification Numbers
+- Bank account numbers, routing numbers, credit card numbers
+- Dates of birth, driver's license numbers, passport numbers
+- Credit scores, income data, employment information
+- Phone numbers, email addresses, physical addresses
+
+The PII field inventory is re-seeded weekly by the automated scheduler and verified during daily compliance scans. New PII fields must be registered in the inventory and classified before implementation in production systems.
+
+### 7.3 Handling Requirements by Classification Level
+
+| Requirement | Public | Internal | Confidential | Restricted |
+|---|---|---|---|---|
+| Encryption at rest | Optional | Optional | Recommended | **Required** (Fernet) |
+| Encryption in transit | TLS 1.2+ | TLS 1.2+ | TLS 1.2+ | TLS 1.2+ |
+| Access logging | Not required | Required | Required | Required (PII flag) |
+| Access control | Open | Role-based | Role-based + need-to-know | Role-based + need-to-know + audit |
+| Data masking in logs | Not required | Not required | Recommended | **Required** |
+| Retention period | Indefinite | Per policy | Per policy | Per regulation (see Section 7.4) |
+| Disposal method | Standard deletion | Standard deletion | Secure deletion | Secure deletion with audit trail |
+| Backup encryption | Not required | Recommended | Required | **Required** |
+
+### 7.4 Regulatory Retention Requirements
+
+As defined in the Data Retention Policy, the following retention periods apply:
+
+| Data Category | Retention Period | Regulatory Basis |
+|---|---|---|
+| Audit logs | 2 years (730 days) | SOC 2 |
+| Access logs | 2 years (730 days) | SOC 2 |
+| Security incidents | 3 years (1,095 days) | SOC 2 / GLBA |
+| Change records | 2 years (730 days) | SOC 2 |
+| Compliance checks | 2 years (730 days) | SOC 2 |
+| PII data | 3 years (1,095 days) | CCPA / GLBA |
+| Loan data | 5 years (1,825 days) | TRID / RESPA |
+| Financial records | 7 years (2,555 days) | IRS / GLBA |
+
+Retention is enforced automatically by the `RetentionService` at 03:00 UTC daily. Records are archived to the `soc2_retention_archive` table before deletion. WORM triggers prevent ad-hoc deletion of audit trails outside the automated retention process.
+
+### 7.5 Data Subject Rights
+
+In accordance with CCPA, GLBA, and other applicable privacy regulations:
+
+**(a)** Data subjects may request access to their personal information held by Perennia AI.
+
+**(b)** Data subjects may request deletion of their personal information, subject to regulatory retention requirements. Deletion requests shall be processed within thirty (30) days.
+
+**(c)** Deletion of loan records and financial data subject to TRID, RESPA, or IRS retention requirements may be deferred until the applicable retention period has expired, with written notice to the requestor.
+
+**(d)** The Data Protection Officer shall manage all data subject access requests and maintain a log of requests and dispositions.
+
+---
+
+## 8. Access Control & Authentication
+
+**SOC 2 Criteria:** CC6.1, CC6.2, CC6.3, CC6.4, CC6.5, CC6.6, CC6.7, CC6.8
+
+### 8.1 Principles
+
+All access to Perennia AI systems and data shall be governed by the following principles, as detailed in the Access Control Policy:
+
+**(a) Least Privilege** -- Users and systems shall be granted the minimum level of access necessary to perform their authorized functions.
+
+**(b) Need-to-Know** -- Access to Confidential and Restricted data shall be limited to individuals with a demonstrated business need.
+
+**(c) Separation of Duties** -- Critical functions shall be divided among multiple individuals to prevent unauthorized actions by a single person.
+
+**(d) Defense in Depth** -- Multiple layers of access controls shall be implemented so that the failure of a single control does not result in unauthorized access.
+
+### 8.2 Authentication Standards
+
+| Control | Requirement |
+|---|---|
+| Authentication method | JWT RS256 token-based authentication |
+| Password minimum length | 12 characters |
+| Password complexity | Uppercase, lowercase, digit, and special character required |
+| Password expiration | 90 days |
+| Password history | Last 12 passwords may not be reused |
+| Multi-factor authentication | Required for all administrative access |
+| Account lockout threshold | 5 failed attempts |
+| Account lockout duration | 30 minutes |
+| Session timeout | 30 minutes of inactivity (configurable via `SOC2_SESSION_TIMEOUT_MINUTES`) |
+| Token blacklist | Maintained for revoked tokens; checked on every authentication |
+
+### 8.3 Authorization Model
+
+Perennia AI implements role-based access control (RBAC) with the following principal roles:
+
+| Role | Access Level | Administrative Privileges |
+|---|---|---|
+| Platform Admin | Full platform access across all tenants | User management, system configuration, security administration |
+| Site Admin | Full access within assigned organization | Organization user management, configuration |
+| Loan Officer | Access to own pipeline and assigned data | Loan management, borrower communication |
+| Processor | Access to assigned loans for processing | Loan processing, document management |
+| Read-Only | View access to authorized data | Reporting, dashboard viewing |
+
+### 8.4 Tenant Isolation
+
+Row-Level Security (RLS) is enforced at the database layer to ensure that each organization's data is isolated from all other organizations. The `get_db()` function applies tenant context to every database session, and all queries are automatically scoped to the authenticated user's organization.
+
+### 8.5 API Key Management
+
+- API keys are stored as cryptographic hashes in the `soc2_api_key_registry` table; plaintext keys are never persisted.
+- All API keys must have defined access scopes and expiration dates.
+- Revoked keys are logged with the reason for revocation and the identity of the revoking user.
+- API key usage is subject to the same audit logging as interactive user sessions.
+
+### 8.6 Anomaly Detection
+
+The platform implements automated login anomaly detection:
+
+| Risk Score | Action |
+|---|---|
+| Less than 40 | Normal -- access granted, event logged |
+| 40-59 | Anomalous -- access granted, event flagged for review |
+| 60-79 | High risk -- access granted, security incident auto-created |
+| 80 or above | Critical -- access granted, high-severity incident auto-created, immediate notification to Security Officer |
+
+Risk scores are calculated based on factors including new IP addresses, new devices, geographic anomalies, and temporal patterns.
+
+### 8.7 Provisioning and Deprovisioning
+
+**(a) Provisioning** -- New accounts are created by an authorized administrator. Users must set a compliant password and enroll in MFA before accessing Confidential or Restricted data.
+
+**(b) Access Reviews** -- All active accounts and their permissions are reviewed quarterly by the Platform Admin and Security Team.
+
+**(c) Deprovisioning** -- Upon termination of the access relationship (employment termination, contract end, role change), the following actions are taken within one (1) business day:
+- User account disabled
+- All active sessions terminated
+- All API keys revoked
+- Access removal logged in the audit trail
+
+---
+
+## 9. Encryption Standards
+
+**SOC 2 Criteria:** CC5.1, CC6.1, C1, PI1
+
+### 9.1 Encryption at Rest
+
+| Data Classification | Encryption Requirement | Method |
+|---|---|---|
+| Restricted | Mandatory | Fernet symmetric encryption (AES-128-CBC with HMAC-SHA256) applied at the field level via `EncryptionService` |
+| Confidential | Recommended | AES-256 or equivalent where technically feasible |
+| Internal | Optional | Database-level encryption where available |
+| Public | Not required | N/A |
+
+Fernet field-level encryption is applied to all PII columns identified in the data classification registry. Encryption keys are managed securely and stored as encrypted environment variables in Railway's credential management system.
+
+### 9.2 Encryption in Transit
+
+All data transmitted between clients and the Perennia AI platform, between platform components, and between the platform and third-party services shall be encrypted using TLS 1.2 or higher. Plaintext transmission of any data classified as Internal or above is prohibited.
+
+| Communication Path | Minimum TLS Version | Certificate Management |
+|---|---|---|
+| Client to API (`api.perenniaai.com`) | TLS 1.2 | Managed by Railway (auto-renewal) |
+| Client to frontend (`app.perenniaai.com`) | TLS 1.2 | Managed by Railway (auto-renewal) |
+| API to PostgreSQL | TLS 1.2 | Railway internal certificates |
+| API to third-party services | TLS 1.2 | Vendor-managed certificates |
+| Internal service communication | TLS 1.2 | Railway internal network |
+
+### 9.3 Encryption Key Management
+
+**(a)** Encryption keys shall not be stored in source code, configuration files, or unencrypted storage.
+
+**(b)** All encryption keys and API credentials are stored as encrypted environment variables in Railway's secure credential store.
+
+**(c)** Key rotation shall be performed at least annually or immediately upon suspicion of compromise.
+
+**(d)** Access to encryption keys is limited to the Security Officer and authorized Engineering personnel.
+
+**(e)** Key access events are logged in the audit trail.
+
+### 9.4 Cryptographic Standards
+
+| Use Case | Algorithm | Key Length |
+|---|---|---|
+| Field-level encryption (PII) | Fernet (AES-128-CBC + HMAC-SHA256) | 256-bit key |
+| Authentication tokens | RS256 (RSA-SHA256) | 2048-bit minimum |
+| Password hashing | bcrypt | Cost factor 12 |
+| Data in transit | TLS 1.2+ (AES-GCM preferred) | 128-bit minimum |
+| API key hashing | SHA-256 | N/A (hash-only storage) |
+
+---
+
+## 10. Incident Response Overview
+
+**SOC 2 Criteria:** CC7.1, CC7.2, CC7.3, CC7.4, CC7.5, P6
+
+### 10.1 Incident Response Program
+
+Perennia AI maintains a formal incident response program as detailed in the Incident Response Policy. This section provides the governance-level overview; operational procedures are defined in the subordinate policy.
+
+### 10.2 Incident Categories
+
+The following categories of security events are within the scope of the incident response program:
+
+- Unauthorized access to systems or data
+- Data breaches involving PII or Restricted data
+- Malware infections or phishing attacks
+- Insider threat activity
+- Denial of service attacks
+- Data loss or corruption
+- Configuration errors with security implications
+- Vulnerability exploitation
+- Policy violations
+
+### 10.3 Severity Classification and Response Times
+
+| Severity | Definition | Response Time | Escalation Path |
+|---|---|---|---|
+| **Critical** | Active data breach, widespread system compromise, or imminent threat to Restricted data | 1 hour | Immediate notification to CEO, CTO, Security Officer |
+| **High** | Confirmed unauthorized access, significant vulnerability exploitation, or system integrity compromise | 4 hours | Security Officer, Engineering Lead |
+| **Medium** | Policy violation, failed attack attempt, or minor security weakness identified | 24 hours | Security team |
+| **Low** | Informational security event, low-impact policy deviation | 72 hours | Logged for review |
+
+### 10.4 Incident Lifecycle
+
+All security incidents shall progress through the following lifecycle stages, each documented in the `soc2_security_incident` table with timestamped status transitions:
+
+1. **Detection** -- Automated detection via anomaly detection, compliance scanning, or manual report by personnel.
+2. **Triage** -- Classification by category and severity; assignment of Incident Commander.
+3. **Containment** -- Immediate actions to limit the impact (session termination, IP blocking, credential revocation).
+4. **Investigation** -- Root cause analysis to determine the scope, attack vector, and affected assets.
+5. **Remediation** -- Fix the underlying vulnerability and implement corrective controls.
+6. **Recovery** -- Restore normal operations and verify system integrity.
+7. **Post-Mortem** -- Document lessons learned and preventive measures within five (5) business days of resolution.
+8. **Closure** -- Incident closed after post-mortem completion and verification of preventive measures.
+
+### 10.5 Breach Notification
+
+In the event of a data breach involving personally identifiable information:
+
+**(a)** Affected individuals shall be notified within seventy-two (72) hours of breach confirmation, as required by applicable state breach notification laws.
+
+**(b)** Regulatory authorities shall be notified in accordance with GLBA and applicable state requirements.
+
+**(c)** The Data Protection Officer shall coordinate all breach notification activities, including content review, notification logistics, and regulatory filings.
+
+**(d)** A written breach report shall be prepared and retained for a minimum of three (3) years.
+
+### 10.6 Automated Escalation
+
+The platform implements automated escalation based on anomaly detection risk scores:
+
+- Login anomaly with risk score of 60 or above: Security incident auto-created at Medium severity.
+- Login anomaly with risk score of 80 or above: Security incident auto-created at High severity.
+- Overdue Critical and High severity incidents: Flagged by the daily compliance scan at 02:15 UTC.
+
+---
+
+## 11. Business Continuity & Disaster Recovery
+
+**SOC 2 Criteria:** A1.1, A1.2, A1.3
+
+### 11.1 Business Continuity Commitment
+
+Perennia AI is committed to maintaining the availability and resilience of its platform services. The disaster recovery program, detailed in the Disaster Recovery Policy, ensures that business-critical operations can be restored within defined objectives following a disruptive event.
+
+### 11.2 Recovery Objectives
+
+| Metric | Target | Description |
+|---|---|---|
+| **Recovery Time Objective (RTO)** | 4 hours | Maximum acceptable duration of service disruption |
+| **Recovery Point Objective (RPO)** | 1 hour | Maximum acceptable data loss measured in time |
+
+### 11.3 Infrastructure Resilience
+
+| Component | Resilience Measure | Provider |
+|---|---|---|
+| Application server | Stateless containers with instant rollback to previous deployment | Railway |
+| PostgreSQL database | Automated daily backups with 7-day retention | Railway |
+| Source code | Git repository with full version history | GitHub |
+| Environment configuration | Encrypted storage with current-state preservation | Railway |
+| Audit logs | Database storage with real-time SIEM forwarding | DataDog |
+
+### 11.4 Recovery Procedures
+
+The Disaster Recovery Policy defines three recovery scenarios:
+
+**(a) Database Recovery** -- Restore from the latest clean Railway backup, verify data integrity via compliance scan, and re-run pending migrations.
+
+**(b) Application Recovery** -- Roll back to the last known-good deployment via Railway, verify the health endpoint, and confirm audit logging is active.
+
+**(c) Complete Infrastructure Recovery** -- Provision a new Railway project, restore the database from backup, configure environment variables, deploy the application, run a full compliance scan, and verify all integrations.
+
+### 11.5 Communication During Disruptions
+
+| Condition | Notification | Timeline |
+|---|---|---|
+| Service disruption detected | Engineering on-call team | Immediate |
+| Outage exceeding 30 minutes | Affected customers | Within 1 hour |
+| Post-incident | All stakeholders | Written report within 48 hours |
+
+### 11.6 Testing and Validation
+
+| Test Type | Frequency | Responsible Party |
+|---|---|---|
+| Backup restoration test | Quarterly | Engineering Team |
+| Failover drill | Semi-annual | Engineering Team |
+| Full disaster recovery exercise | Annual | Engineering + Security Teams |
+
+---
+
+## 12. Vendor & Third-Party Risk Management
+
+**SOC 2 Criteria:** CC9.1, CC9.2
+
+### 12.1 Vendor Risk Management Program
+
+Perennia AI maintains a formal vendor risk management program, detailed in the Vendor Management Policy, to assess and monitor the security posture of all third-party service providers that access, process, or store Company data.
+
+### 12.2 Vendor Registry
+
+All third-party vendors and service providers are registered in the `soc2_vendor_registry` table with the following attributes:
+
+- Vendor name, category, and contact information
+- Data access level (full, limited, metadata, none)
+- SOC 2 Type II certification status
+- Risk level assessment (Low, Medium, High)
+- Data processing agreement (DPA) status
+- Review schedule based on risk level
+
+### 12.3 Current Vendor Inventory
+
+| Vendor | Category | Data Access | SOC 2 Status | Risk Level |
+|---|---|---|---|---|
+| Railway | Infrastructure (hosting) | Full | Certified | Low |
+| SendGrid | Communication (email) | Limited | Certified | Low |
+| DataDog | Monitoring (observability) | Metadata | Certified | Low |
+| Telnyx | Telephony (voice, SMS) | Limited | Certified | Medium |
+| Twilio | Telephony (AI voice) | Limited | Certified | Medium |
+| Vapi | AI telephony | Limited | Review Pending | Medium |
+| OpenAI | AI services (LLM) | Content | Certified | Medium |
+| Salesforce | CRM integration | Full | Certified | Low |
+
+### 12.4 Vendor Assessment Requirements
+
+Before granting any vendor access to Perennia AI data, the following assessments must be completed:
+
+**(a)** SOC 2 Type II certification is required for all vendors with data access classified as "Full" or "Limited." Vendors without current SOC 2 certification must undergo an enhanced security assessment and are classified as Medium or High risk.
+
+**(b)** A Data Processing Agreement (DPA) must be executed before any data access is granted. The DPA shall address data handling, security requirements, breach notification obligations, and data deletion upon contract termination.
+
+**(c)** Data residency compliance must be verified. Mortgage data must reside within the United States.
+
+**(d)** Incident notification procedures must be defined, with vendors required to notify Perennia AI of security incidents affecting Company data within the timeframes specified in the DPA.
+
+### 12.5 Vendor Risk Classification and Review Schedule
+
+| Risk Level | Criteria | Review Frequency |
+|---|---|---|
+| **Low** | SOC 2 certified, limited or metadata data access | Annual |
+| **Medium** | Pending SOC 2 certification, or sensitive data access | Semi-annual |
+| **High** | No SOC 2 certification with data access, or full access without DPA | Quarterly |
+
+### 12.6 Vendor Lifecycle Management
+
+**(a) Onboarding** -- Security questionnaire, risk assessment, DPA execution, credential configuration (encrypted environment variables), access scope definition, and vendor registry entry.
+
+**(b) Ongoing Monitoring** -- Risk-based review per the schedule above, SOC 2 certification renewal tracking, and incident monitoring.
+
+**(c) Offboarding** -- Access revocation, confirmation of data deletion, credential rotation for shared systems, and vendor registry update.
+
+---
+
+## 13. Employee Security Responsibilities
+
+**SOC 2 Criteria:** CC1.1, CC1.4, P1
+
+### 13.1 General Responsibilities
+
+All personnel (employees, contractors, and temporary workers) with access to Perennia AI information systems shall:
+
+**(a)** Read, understand, and acknowledge this WISP and all applicable subordinate security policies upon hire or engagement, and annually thereafter.
+
+**(b)** Protect authentication credentials (passwords, API keys, MFA tokens) from unauthorized disclosure. Credentials shall not be shared, written down in plaintext, or stored in unencrypted files.
+
+**(c)** Use Perennia AI systems and data solely for authorized business purposes.
+
+**(d)** Report suspected or confirmed security incidents, policy violations, and vulnerabilities to the Security Officer promptly and without fear of retaliation.
+
+**(e)** Complete all required security awareness training within established timelines (see Section 14).
+
+**(f)** Lock workstations and mobile devices when unattended.
+
+**(g)** Follow the change management process for all modifications to production systems (see Change Management Policy).
+
+**(h)** Cooperate with security investigations, audits, and access reviews.
+
+### 13.2 Role-Specific Responsibilities
+
+#### Administrators (Platform Admin, Site Admin)
+
+- Perform quarterly access reviews for all users within their scope.
+- Ensure timely deprovisioning of accounts for terminated personnel.
+- Review and approve privilege escalation requests.
+- Monitor anomalous activity alerts and take appropriate action.
+
+#### Engineers and Developers
+
+- Follow secure coding practices and conduct security-focused code reviews.
+- Ensure all changes follow the Change Management Policy, including peer review and testing.
+- Report and remediate security vulnerabilities discovered during development.
+- Maintain encryption implementation and key management practices.
+
+#### Loan Officers and Processors
+
+- Access borrower PII and loan data only for authorized loan processing purposes.
+- Verify borrower identity before disclosing sensitive information.
+- Comply with GLBA, TRID, and RESPA requirements in all borrower interactions.
+- Report unusual borrower activity or suspected fraud.
+
+### 13.3 Acceptable Use
+
+**(a)** Company systems shall be used for authorized business purposes. Limited personal use is permitted provided it does not violate any security policy, introduce risk to Company systems, or interfere with job performance.
+
+**(b)** The following activities are expressly prohibited:
+- Attempting to circumvent access controls or security mechanisms.
+- Accessing, modifying, or deleting data without authorization.
+- Installing unauthorized software on Company systems.
+- Transmitting Confidential or Restricted data via unapproved channels.
+- Using Company systems for illegal activities.
+
+### 13.4 Consequences of Non-Compliance
+
+Violations of this WISP or subordinate security policies may result in disciplinary action up to and including termination of employment or contract, and referral to law enforcement where warranted.
+
+---
+
+## 14. Security Awareness Training Requirements
+
+**SOC 2 Criteria:** CC1.4, CC2.2
+
+### 14.1 Training Program Overview
+
+Perennia AI maintains a security awareness training program to ensure all personnel understand their security responsibilities and can identify and respond to security threats.
+
+### 14.2 Training Requirements
+
+| Training Type | Audience | Frequency | Completion Deadline |
+|---|---|---|---|
+| New hire security orientation | All new personnel | Upon hire | Within 30 calendar days of start date |
+| Annual security awareness refresher | All personnel | Annual | Within 30 calendar days of anniversary |
+| Phishing awareness training | All personnel with email access | Semi-annual | Within 14 calendar days of assignment |
+| Secure development training | Engineers and developers | Annual | Within 30 calendar days of assignment |
+| Incident response training | Security team, engineering leads | Quarterly | Within 7 calendar days of drill |
+| Privacy and data handling (GLBA/CCPA) | All personnel handling PII | Annual | Within 30 calendar days of assignment |
+| Administrative access training | Platform Admins, Site Admins | Upon role assignment | Before administrative access is granted |
+
+### 14.3 Training Content
+
+Security awareness training shall cover, at a minimum:
+
+- Overview of this WISP and subordinate security policies
+- Password hygiene and multi-factor authentication
+- Phishing and social engineering recognition
+- Data classification and handling procedures
+- Incident reporting procedures
+- Acceptable use requirements
+- Physical security awareness
+- Regulatory obligations specific to the mortgage industry (GLBA, TRID, RESPA, CCPA)
+
+### 14.4 Training Records
+
+**(a)** Completion records shall be maintained for all training activities, including participant name, training type, completion date, and assessment results.
+
+**(b)** Training completion rates shall be reported to the Security Officer monthly and to the CTO quarterly.
+
+**(c)** Personnel who fail to complete required training within the specified deadline shall have their system access restricted until training is completed.
+
+**(d)** Training records shall be retained for a minimum of two (2) years in accordance with the Data Retention Policy.
+
+---
+
+## 15. Compliance Monitoring & Audit
+
+**SOC 2 Criteria:** CC4.1, CC4.2, P8
+
+### 15.1 Continuous Monitoring
+
+Perennia AI implements continuous automated monitoring to detect control failures, policy violations, and security anomalies:
+
+| Monitoring Activity | Frequency | Mechanism |
+|---|---|---|
+| API request audit logging | Real-time | SOC 2 audit middleware logs all requests to `soc2_audit_log` |
+| Compliance scanning | Daily at 02:15 UTC | Automated `ComplianceScanner` checks 15+ control points |
+| Data retention enforcement | Daily at 03:00 UTC | `RetentionService` archives and purges expired records |
+| Data classification verification | Weekly | Automated re-seed of `soc2_data_classification` table |
+| Anomalous login detection | Real-time | Risk-score-based anomaly detection on every login |
+| Session management | Real-time | Active session tracking in `soc2_active_session` table |
+| Unapproved change detection | Daily | Automated scan of `soc2_change_record` table |
+
+### 15.2 Audit Trail Integrity
+
+**(a)** All audit records are stored in dedicated SOC 2 audit tables with WORM (Write-Once Read-Many) protections to prevent unauthorized modification or deletion.
+
+**(b)** The automated retention service is the only mechanism authorized to remove audit records, and only after the applicable retention period has expired.
+
+**(c)** Audit records include, at a minimum: timestamp, user identity, action performed, resource affected, IP address, and outcome (success/failure).
+
+**(d)** High-severity events are forwarded in real-time to DataDog SIEM for centralized monitoring and alerting.
+
+### 15.3 Internal Audit Activities
+
+| Audit Activity | Frequency | Responsible Party | Output |
+|---|---|---|---|
+| Access review (all accounts and permissions) | Quarterly | Platform Admin, Security Team | Access review report |
+| API key audit | Quarterly | Security Team | Key inventory and revocation report |
+| Anomaly detection review | Weekly | Security Team | Anomaly summary report |
+| Change management audit | Monthly | Security Team | Unapproved change report |
+| Data classification completeness | Quarterly | Security Team | PII field coverage report |
+| Retention enforcement verification | Monthly | Platform Admin | Retention status report |
+| Vendor risk reassessment | Per risk-level schedule | Security Team | Vendor assessment report |
+| Open incident review | Weekly | Security Team | Incident status report |
+| Post-mortem compliance | Monthly | Engineering Lead | Post-mortem completion report |
+
+### 15.4 External Audit
+
+**(a)** Perennia AI shall engage a qualified independent auditor to conduct an annual SOC 2 Type II audit covering all Trust Service Criteria in scope.
+
+**(b)** The Security Officer shall coordinate audit activities, including evidence collection, auditor access, and management response to findings.
+
+**(c)** Audit findings shall be tracked to resolution, with remediation plans approved by the CTO.
+
+**(d)** The SOC 2 Type II report shall be made available to customers and prospects under non-disclosure agreement upon request.
+
+### 15.5 Compliance Dashboard Metrics
+
+The following metrics shall be tracked and reported:
+
+| Metric | Target | Reporting Frequency |
+|---|---|---|
+| Compliance scan pass rate | 100% | Daily (automated) |
+| Open security incidents | Zero Critical/High for more than SLA | Weekly |
+| Access review completion | 100% on schedule | Quarterly |
+| Training completion rate | 100% within deadlines | Monthly |
+| Encryption coverage (Restricted fields) | 100% | Weekly (automated) |
+| Data classification coverage | 100% of PII fields registered | Weekly (automated) |
+| Vendor DPA coverage | 100% of data-access vendors | Quarterly |
+
+---
+
+## 16. Policy Review & Update Schedule
+
+**SOC 2 Criteria:** CC1.1, CC4.2
+
+### 16.1 Review Cadence
+
+This WISP and all subordinate security policies shall be reviewed on a semi-annual basis (every six months), or more frequently when triggered by the events described in Section 16.3.
+
+### 16.2 Review Schedule
+
+| Document | Current Version Date | Next Scheduled Review | Owner |
+|---|---|---|---|
+| Written Information Security Program (this document) | 2026-03-27 | 2026-09-27 | Security Officer |
+| Information Security Policy | 2026-02-25 | 2026-08-25 | Security Team |
+| Access Control Policy | 2026-02-25 | 2026-08-25 | Security Team |
+| Incident Response Policy | 2026-02-25 | 2026-08-25 | Security Team |
+| Change Management Policy | 2026-02-25 | 2026-08-25 | Engineering Team |
+| Data Classification Policy | 2026-02-25 | 2026-08-25 | Security Team |
+| Data Retention Policy | 2026-02-25 | 2026-08-25 | Security Team |
+| Vendor Management Policy | 2026-02-25 | 2026-08-25 | Security Team |
+| Disaster Recovery Policy | 2026-02-25 | 2026-08-25 | Engineering Team |
+
+### 16.3 Triggers for Unscheduled Review
+
+The following events shall trigger an unscheduled review of this WISP or relevant subordinate policies:
+
+- A significant security incident (Critical or High severity)
+- Material changes to the regulatory environment (new laws, amended regulations, updated guidance)
+- Significant changes to the Perennia AI platform architecture, technology stack, or infrastructure
+- Findings from SOC 2 audits or other external assessments
+- Introduction of new categories of sensitive data or new third-party integrations
+- Organizational changes (mergers, acquisitions, restructuring)
+- Lessons learned from incident post-mortems requiring policy updates
+
+### 16.4 Review Process
+
+**(a)** The Security Officer shall initiate the review cycle by distributing current policy versions to all policy owners at least thirty (30) days before the scheduled review date.
+
+**(b)** Policy owners shall assess their respective policies for accuracy, completeness, and alignment with current operations, threats, and regulatory requirements.
+
+**(c)** Proposed changes shall be documented with justification and submitted to the Security Officer for consolidation.
+
+**(d)** Material changes to this WISP require approval from the CEO and CTO.
+
+**(e)** Material changes to subordinate policies require approval from the Security Officer and the policy owner.
+
+**(f)** Approved changes shall be communicated to all affected personnel, and the version history shall be updated.
+
+### 16.5 Version History
+
+| Version | Date | Author | Description |
+|---|---|---|---|
+| 1.0 | 2026-03-27 | Security Officer | Initial publication |
+
+---
+
+## 17. Approval & Signatures
+
+This Written Information Security Program has been reviewed and approved by the undersigned officers of Perennia AI, Inc. By signing below, each officer acknowledges their understanding of and commitment to the security program established herein.
+
+---
+
+### Chief Executive Officer
+
+| Field | Value |
+|---|---|
+| **Name** | __________________________________ |
+| **Title** | Chief Executive Officer |
+| **Signature** | __________________________________ |
+| **Date** | ______ / ______ / __________ |
+
+---
+
+### Chief Technology Officer
+
+| Field | Value |
+|---|---|
+| **Name** | __________________________________ |
+| **Title** | Chief Technology Officer |
+| **Signature** | __________________________________ |
+| **Date** | ______ / ______ / __________ |
+
+---
+
+### Security Officer
+
+| Field | Value |
+|---|---|
+| **Name** | __________________________________ |
+| **Title** | Security Officer |
+| **Signature** | __________________________________ |
+| **Date** | ______ / ______ / __________ |
+
+---
+
+*This document constitutes the governing information security program for Perennia AI, Inc. All subordinate policies referenced herein are incorporated by reference and shall be maintained in accordance with the review schedule established in Section 16. Questions regarding this program should be directed to the Security Officer.*
+
+---
+
+**Document Classification: Confidential**
+**Perennia AI, Inc. -- All Rights Reserved**

--- a/backend/soc2_compliance/services/vendor_agreement_service.py
+++ b/backend/soc2_compliance/services/vendor_agreement_service.py
@@ -1,0 +1,613 @@
+"""
+Vendor BAA/DPA Agreement Tracking Service — Track and manage vendor data
+processing and business associate agreements.
+SOC 2 Criteria: CC9 (Risk Mitigation), C1 (Confidentiality), P1-P8 (Privacy)
+
+Provides methods for:
+- Querying agreement status for individual vendors
+- Updating/creating vendor agreements
+- Generating compliance summaries across all vendors
+- Identifying agreements approaching expiry or missing entirely
+
+Usage:
+    svc = VendorAgreementService(db)
+    status = svc.get_vendor_agreement_status(vendor_id=1)
+    summary = svc.get_all_vendor_compliance_summary()
+"""
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..constants import AgreementStatus, AgreementType
+
+logger = logging.getLogger("soc2.vendor_agreements")
+
+
+class VendorAgreementService:
+    """
+    Manage BAA/DPA agreements for vendors in the soc2_vendor_registry.
+
+    All methods operate within the caller's database session and do NOT
+    call ``session.commit()`` — the caller is responsible for committing
+    or rolling back the transaction.
+    """
+
+    # Vendors whose data_access_level means they likely need agreements
+    _LEVELS_REQUIRING_AGREEMENT = {"full", "content", "limited"}
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    def get_vendor_agreement_status(
+        self,
+        vendor_id: Optional[int] = None,
+        vendor_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Get the current BAA/DPA agreement status for a single vendor.
+
+        Looks up the vendor by ``vendor_id`` (preferred) or ``vendor_name``.
+        Returns vendor metadata together with all associated agreements.
+
+        Raises:
+            ValueError: If neither vendor_id nor vendor_name is provided.
+            LookupError: If the vendor is not found in the registry.
+        """
+        if vendor_id is None and vendor_name is None:
+            raise ValueError("Either vendor_id or vendor_name must be provided")
+
+        # Resolve vendor
+        if vendor_id is not None:
+            vendor = self._get_vendor_by_id(vendor_id)
+        else:
+            vendor = self._get_vendor_by_name(vendor_name)
+
+        if vendor is None:
+            identifier = vendor_id if vendor_id is not None else vendor_name
+            raise LookupError(f"Vendor not found: {identifier}")
+
+        # Fetch all agreements for this vendor
+        agreements = self._fetch_agreements(vendor["id"])
+
+        # Determine overall compliance posture
+        needs_agreement = vendor["data_access_level"] in self._LEVELS_REQUIRING_AGREEMENT
+        has_signed_agreement = any(
+            a["status"] == AgreementStatus.SIGNED for a in agreements
+        )
+        has_expired = any(
+            a["status"] == AgreementStatus.SIGNED
+            and a["expiry_date"] is not None
+            and a["expiry_date"] < date.today()
+            for a in agreements
+        )
+
+        if not needs_agreement:
+            compliance_status = "not_required"
+        elif has_expired:
+            compliance_status = "expired"
+        elif has_signed_agreement:
+            compliance_status = "compliant"
+        elif agreements:
+            compliance_status = "in_progress"
+        else:
+            compliance_status = "missing"
+
+        return {
+            "vendor": {
+                "id": vendor["id"],
+                "vendor_name": vendor["vendor_name"],
+                "category": vendor["category"],
+                "data_access_level": vendor["data_access_level"],
+                "risk_level": vendor["risk_level"],
+                "soc2_status": vendor["soc2_status"],
+            },
+            "compliance_status": compliance_status,
+            "needs_agreement": needs_agreement,
+            "agreements": [
+                self._format_agreement(a) for a in agreements
+            ],
+        }
+
+    def get_all_vendor_compliance_summary(self) -> Dict[str, Any]:
+        """
+        Generate a compliance summary across all registered vendors.
+
+        Returns counts by status, a list of vendors missing required
+        agreements, and a list of agreements expiring within the
+        configured renewal notice window.
+        """
+        vendors = self._fetch_all_vendors()
+        if not vendors:
+            logger.warning("No vendors found in soc2_vendor_registry")
+            return {
+                "total_vendors": 0,
+                "summary": {},
+                "vendors_needing_agreements": [],
+                "missing_agreements": [],
+                "expiring_soon": [],
+                "all_vendors": [],
+            }
+
+        # Build lookup: vendor_id -> list of agreements
+        all_agreements = self._fetch_all_agreements()
+        agreements_by_vendor: Dict[int, List[Dict]] = {}
+        for agreement in all_agreements:
+            vid = agreement["vendor_id"]
+            agreements_by_vendor.setdefault(vid, []).append(agreement)
+
+        today = date.today()
+        vendors_needing = []
+        missing = []
+        expiring_soon = []
+        vendor_details = []
+
+        status_counts = {
+            "compliant": 0,
+            "missing": 0,
+            "expired": 0,
+            "in_progress": 0,
+            "not_required": 0,
+        }
+
+        for vendor in vendors:
+            vid = vendor["id"]
+            vendor_agreements = agreements_by_vendor.get(vid, [])
+            needs_agreement = vendor["data_access_level"] in self._LEVELS_REQUIRING_AGREEMENT
+
+            has_signed = any(
+                a["status"] == AgreementStatus.SIGNED for a in vendor_agreements
+            )
+            has_expired = any(
+                a["status"] == AgreementStatus.SIGNED
+                and a["expiry_date"] is not None
+                and a["expiry_date"] < today
+                for a in vendor_agreements
+            )
+
+            if not needs_agreement:
+                compliance = "not_required"
+            elif has_expired:
+                compliance = "expired"
+            elif has_signed:
+                compliance = "compliant"
+            elif vendor_agreements:
+                compliance = "in_progress"
+            else:
+                compliance = "missing"
+
+            status_counts[compliance] += 1
+
+            vendor_summary = {
+                "vendor_id": vid,
+                "vendor_name": vendor["vendor_name"],
+                "category": vendor["category"],
+                "data_access_level": vendor["data_access_level"],
+                "risk_level": vendor["risk_level"],
+                "compliance_status": compliance,
+                "agreement_count": len(vendor_agreements),
+            }
+            vendor_details.append(vendor_summary)
+
+            if needs_agreement:
+                vendors_needing.append(vendor["vendor_name"])
+
+            if compliance == "missing":
+                missing.append({
+                    "vendor_id": vid,
+                    "vendor_name": vendor["vendor_name"],
+                    "data_access_level": vendor["data_access_level"],
+                    "risk_level": vendor["risk_level"],
+                })
+
+            # Check for expiring agreements
+            for agreement in vendor_agreements:
+                if (
+                    agreement["status"] == AgreementStatus.SIGNED
+                    and agreement["expiry_date"] is not None
+                ):
+                    renewal_days = agreement.get("renewal_notice_days") or 90
+                    alert_date = agreement["expiry_date"] - timedelta(days=renewal_days)
+                    if today >= alert_date:
+                        days_until = (agreement["expiry_date"] - today).days
+                        expiring_soon.append({
+                            "vendor_id": vid,
+                            "vendor_name": vendor["vendor_name"],
+                            "agreement_type": agreement["agreement_type"],
+                            "expiry_date": agreement["expiry_date"].isoformat(),
+                            "days_until_expiry": days_until,
+                            "is_expired": days_until < 0,
+                        })
+
+        # Sort expiring by urgency
+        expiring_soon.sort(key=lambda x: x["days_until_expiry"])
+
+        return {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "total_vendors": len(vendors),
+            "vendors_needing_agreements": vendors_needing,
+            "summary": status_counts,
+            "missing_agreements": missing,
+            "expiring_soon": expiring_soon,
+            "all_vendors": vendor_details,
+        }
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
+
+    def update_vendor_agreement(
+        self,
+        vendor_id: int,
+        agreement_type: str,
+        status: str = AgreementStatus.PENDING,
+        signed_date: Optional[date] = None,
+        effective_date: Optional[date] = None,
+        expiry_date: Optional[date] = None,
+        signed_by: Optional[str] = None,
+        vendor_signer: Optional[str] = None,
+        vendor_signer_title: Optional[str] = None,
+        document_url: Optional[str] = None,
+        document_hash: Optional[str] = None,
+        data_categories: Optional[List[str]] = None,
+        processing_purposes: Optional[List[str]] = None,
+        sub_processors: Optional[List[str]] = None,
+        auto_renew: bool = False,
+        renewal_notice_days: int = 90,
+        notes: Optional[str] = None,
+        reviewed_by: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Create or update a vendor agreement (upsert on vendor_id + agreement_type).
+
+        Validates the agreement_type and status against allowed enum values
+        before persisting.
+
+        Returns the upserted agreement record as a dict.
+
+        Raises:
+            ValueError: If agreement_type or status is invalid.
+            LookupError: If vendor_id does not exist.
+        """
+        # Validate enum values
+        try:
+            agreement_type_enum = AgreementType(agreement_type)
+        except ValueError:
+            valid = [e.value for e in AgreementType]
+            raise ValueError(
+                f"Invalid agreement_type '{agreement_type}'. Must be one of: {valid}"
+            )
+
+        try:
+            status_enum = AgreementStatus(status)
+        except ValueError:
+            valid = [e.value for e in AgreementStatus]
+            raise ValueError(
+                f"Invalid status '{status}'. Must be one of: {valid}"
+            )
+
+        # Verify vendor exists
+        vendor = self._get_vendor_by_id(vendor_id)
+        if vendor is None:
+            raise LookupError(f"Vendor with id {vendor_id} not found")
+
+        # Auto-set effective_date to signed_date if not provided
+        if effective_date is None and signed_date is not None:
+            effective_date = signed_date
+
+        # Compute next_review_date: 1 year from effective_date or today
+        review_base = effective_date or date.today()
+        next_review = date(review_base.year + 1, review_base.month, review_base.day)
+
+        now = datetime.now(timezone.utc)
+
+        result = self.db.execute(
+            text("""
+                INSERT INTO soc2_vendor_agreements (
+                    created_at, updated_at, vendor_id, agreement_type, status,
+                    signed_date, effective_date, expiry_date,
+                    signed_by, vendor_signer, vendor_signer_title,
+                    document_url, document_hash,
+                    data_categories, processing_purposes, sub_processors,
+                    auto_renew, renewal_notice_days,
+                    last_review_date, next_review_date,
+                    notes, reviewed_by
+                ) VALUES (
+                    :now, :now, :vendor_id, :agreement_type, :status,
+                    :signed_date, :effective_date, :expiry_date,
+                    :signed_by, :vendor_signer, :vendor_signer_title,
+                    :document_url, :document_hash,
+                    :data_categories, :processing_purposes, :sub_processors,
+                    :auto_renew, :renewal_notice_days,
+                    :last_review_date, :next_review_date,
+                    :notes, :reviewed_by
+                )
+                ON CONFLICT (vendor_id, agreement_type) DO UPDATE SET
+                    updated_at = :now,
+                    status = EXCLUDED.status,
+                    signed_date = EXCLUDED.signed_date,
+                    effective_date = EXCLUDED.effective_date,
+                    expiry_date = EXCLUDED.expiry_date,
+                    signed_by = EXCLUDED.signed_by,
+                    vendor_signer = EXCLUDED.vendor_signer,
+                    vendor_signer_title = EXCLUDED.vendor_signer_title,
+                    document_url = EXCLUDED.document_url,
+                    document_hash = EXCLUDED.document_hash,
+                    data_categories = EXCLUDED.data_categories,
+                    processing_purposes = EXCLUDED.processing_purposes,
+                    sub_processors = EXCLUDED.sub_processors,
+                    auto_renew = EXCLUDED.auto_renew,
+                    renewal_notice_days = EXCLUDED.renewal_notice_days,
+                    last_review_date = EXCLUDED.last_review_date,
+                    next_review_date = EXCLUDED.next_review_date,
+                    notes = EXCLUDED.notes,
+                    reviewed_by = EXCLUDED.reviewed_by
+                RETURNING id, vendor_id, agreement_type, status,
+                          signed_date, effective_date, expiry_date,
+                          signed_by, vendor_signer
+            """),
+            {
+                "now": now,
+                "vendor_id": vendor_id,
+                "agreement_type": agreement_type_enum.value,
+                "status": status_enum.value,
+                "signed_date": signed_date,
+                "effective_date": effective_date,
+                "expiry_date": expiry_date,
+                "signed_by": signed_by,
+                "vendor_signer": vendor_signer,
+                "vendor_signer_title": vendor_signer_title,
+                "document_url": document_url,
+                "document_hash": document_hash,
+                "data_categories": data_categories,
+                "processing_purposes": processing_purposes,
+                "sub_processors": sub_processors,
+                "auto_renew": auto_renew,
+                "renewal_notice_days": renewal_notice_days,
+                "last_review_date": date.today() if reviewed_by else None,
+                "next_review_date": next_review,
+                "notes": notes,
+                "reviewed_by": reviewed_by,
+            },
+        )
+
+        row = result.fetchone()
+        columns = result.keys()
+        record = dict(zip(columns, row))
+
+        logger.info(
+            "Vendor agreement upserted: vendor_id=%s type=%s status=%s",
+            vendor_id,
+            agreement_type_enum.value,
+            status_enum.value,
+        )
+
+        return {
+            "id": record["id"],
+            "vendor_id": record["vendor_id"],
+            "vendor_name": vendor["vendor_name"],
+            "agreement_type": record["agreement_type"],
+            "status": record["status"],
+            "signed_date": record["signed_date"].isoformat() if record["signed_date"] else None,
+            "effective_date": record["effective_date"].isoformat() if record["effective_date"] else None,
+            "expiry_date": record["expiry_date"].isoformat() if record["expiry_date"] else None,
+            "signed_by": record["signed_by"],
+            "vendor_signer": record["vendor_signer"],
+        }
+
+    def mark_agreement_expired(self, vendor_id: int, agreement_type: str) -> bool:
+        """
+        Mark a specific agreement as expired.
+
+        Returns True if a row was updated, False if no matching agreement found.
+        """
+        result = self.db.execute(
+            text("""
+                UPDATE soc2_vendor_agreements
+                SET status = :expired, updated_at = NOW()
+                WHERE vendor_id = :vendor_id
+                  AND agreement_type = :agreement_type
+                  AND status = :signed
+            """),
+            {
+                "expired": AgreementStatus.EXPIRED.value,
+                "vendor_id": vendor_id,
+                "agreement_type": agreement_type,
+                "signed": AgreementStatus.SIGNED.value,
+            },
+        )
+        updated = result.rowcount > 0
+        if updated:
+            logger.info(
+                "Agreement marked expired: vendor_id=%s type=%s",
+                vendor_id,
+                agreement_type,
+            )
+        return updated
+
+    def expire_overdue_agreements(self) -> int:
+        """
+        Bulk-expire all signed agreements whose expiry_date has passed.
+
+        Intended to be called from a scheduled task (e.g., daily Celery beat).
+        Returns the number of agreements expired.
+        """
+        result = self.db.execute(
+            text("""
+                UPDATE soc2_vendor_agreements
+                SET status = :expired, updated_at = NOW()
+                WHERE status = :signed
+                  AND expiry_date IS NOT NULL
+                  AND expiry_date < CURRENT_DATE
+            """),
+            {
+                "expired": AgreementStatus.EXPIRED.value,
+                "signed": AgreementStatus.SIGNED.value,
+            },
+        )
+        count = result.rowcount
+        if count > 0:
+            logger.warning("Expired %d overdue vendor agreements", count)
+        return count
+
+    def get_expiring_agreements(self, days_ahead: int = 90) -> List[Dict[str, Any]]:
+        """
+        Get agreements expiring within the next N days.
+
+        Useful for generating renewal reminders or compliance reports.
+        """
+        rows = self.db.execute(
+            text("""
+                SELECT
+                    va.id, va.vendor_id, va.agreement_type, va.status,
+                    va.signed_date, va.expiry_date, va.auto_renew,
+                    va.renewal_notice_days, va.signed_by, va.vendor_signer,
+                    vr.vendor_name, vr.category, vr.risk_level
+                FROM soc2_vendor_agreements va
+                JOIN soc2_vendor_registry vr ON vr.id = va.vendor_id
+                WHERE va.status = :signed
+                  AND va.expiry_date IS NOT NULL
+                  AND va.expiry_date <= CURRENT_DATE + :days_ahead
+                ORDER BY va.expiry_date ASC
+            """),
+            {
+                "signed": AgreementStatus.SIGNED.value,
+                "days_ahead": days_ahead,
+            },
+        ).fetchall()
+
+        today = date.today()
+        results = []
+        for row in rows:
+            row_dict = dict(row._mapping)
+            days_until = (row_dict["expiry_date"] - today).days
+            results.append({
+                "agreement_id": row_dict["id"],
+                "vendor_id": row_dict["vendor_id"],
+                "vendor_name": row_dict["vendor_name"],
+                "category": row_dict["category"],
+                "risk_level": row_dict["risk_level"],
+                "agreement_type": row_dict["agreement_type"],
+                "expiry_date": row_dict["expiry_date"].isoformat(),
+                "days_until_expiry": days_until,
+                "is_expired": days_until < 0,
+                "auto_renew": row_dict["auto_renew"],
+                "signed_by": row_dict["signed_by"],
+            })
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_vendor_by_id(self, vendor_id: int) -> Optional[Dict[str, Any]]:
+        """Fetch vendor from registry by ID."""
+        row = self.db.execute(
+            text("""
+                SELECT id, vendor_name, category, data_access_level,
+                       soc2_status, risk_level, notes
+                FROM soc2_vendor_registry
+                WHERE id = :vendor_id
+            """),
+            {"vendor_id": vendor_id},
+        ).fetchone()
+        return dict(row._mapping) if row else None
+
+    def _get_vendor_by_name(self, vendor_name: str) -> Optional[Dict[str, Any]]:
+        """Fetch vendor from registry by name (case-insensitive)."""
+        row = self.db.execute(
+            text("""
+                SELECT id, vendor_name, category, data_access_level,
+                       soc2_status, risk_level, notes
+                FROM soc2_vendor_registry
+                WHERE LOWER(vendor_name) = LOWER(:vendor_name)
+            """),
+            {"vendor_name": vendor_name},
+        ).fetchone()
+        return dict(row._mapping) if row else None
+
+    def _fetch_agreements(self, vendor_id: int) -> List[Dict[str, Any]]:
+        """Fetch all agreements for a vendor."""
+        rows = self.db.execute(
+            text("""
+                SELECT id, vendor_id, agreement_type, status,
+                       signed_date, effective_date, expiry_date,
+                       signed_by, vendor_signer, vendor_signer_title,
+                       document_url, document_hash,
+                       data_categories, processing_purposes, sub_processors,
+                       auto_renew, renewal_notice_days,
+                       last_review_date, next_review_date,
+                       notes, reviewed_by, created_at, updated_at
+                FROM soc2_vendor_agreements
+                WHERE vendor_id = :vendor_id
+                ORDER BY agreement_type
+            """),
+            {"vendor_id": vendor_id},
+        ).fetchall()
+        return [dict(row._mapping) for row in rows]
+
+    def _fetch_all_vendors(self) -> List[Dict[str, Any]]:
+        """Fetch all vendors from the registry."""
+        rows = self.db.execute(
+            text("""
+                SELECT id, vendor_name, category, data_access_level,
+                       soc2_status, risk_level
+                FROM soc2_vendor_registry
+                ORDER BY vendor_name
+            """),
+        ).fetchall()
+        return [dict(row._mapping) for row in rows]
+
+    def _fetch_all_agreements(self) -> List[Dict[str, Any]]:
+        """Fetch all agreements across all vendors."""
+        rows = self.db.execute(
+            text("""
+                SELECT id, vendor_id, agreement_type, status,
+                       signed_date, effective_date, expiry_date,
+                       signed_by, vendor_signer,
+                       auto_renew, renewal_notice_days,
+                       created_at, updated_at
+                FROM soc2_vendor_agreements
+                ORDER BY vendor_id, agreement_type
+            """),
+        ).fetchall()
+        return [dict(row._mapping) for row in rows]
+
+    @staticmethod
+    def _format_agreement(agreement: Dict[str, Any]) -> Dict[str, Any]:
+        """Format an agreement record for API responses."""
+        def _iso(val: Any) -> Optional[str]:
+            if val is None:
+                return None
+            if isinstance(val, (date, datetime)):
+                return val.isoformat()
+            return str(val)
+
+        return {
+            "id": agreement["id"],
+            "agreement_type": agreement["agreement_type"],
+            "status": agreement["status"],
+            "signed_date": _iso(agreement.get("signed_date")),
+            "effective_date": _iso(agreement.get("effective_date")),
+            "expiry_date": _iso(agreement.get("expiry_date")),
+            "signed_by": agreement.get("signed_by"),
+            "vendor_signer": agreement.get("vendor_signer"),
+            "vendor_signer_title": agreement.get("vendor_signer_title"),
+            "document_url": agreement.get("document_url"),
+            "data_categories": agreement.get("data_categories") or [],
+            "processing_purposes": agreement.get("processing_purposes") or [],
+            "sub_processors": agreement.get("sub_processors") or [],
+            "auto_renew": agreement.get("auto_renew", False),
+            "renewal_notice_days": agreement.get("renewal_notice_days", 90),
+            "last_review_date": _iso(agreement.get("last_review_date")),
+            "next_review_date": _iso(agreement.get("next_review_date")),
+            "notes": agreement.get("notes"),
+            "reviewed_by": agreement.get("reviewed_by"),
+        }

--- a/backend/soc2_compliance/templates/baa_template.md
+++ b/backend/soc2_compliance/templates/baa_template.md
@@ -1,0 +1,143 @@
+# BUSINESS ASSOCIATE AGREEMENT
+
+**Between Perennia AI, Inc. ("Covered Entity") and [VENDOR_NAME] ("Business Associate")**
+
+**Effective Date:** [EFFECTIVE_DATE]
+
+---
+
+## 1. DEFINITIONS
+
+1.1. **"Breach"** means the acquisition, access, use, or disclosure of Protected Health Information (PHI) in a manner not permitted under this Agreement or applicable law, which compromises the security or privacy of such information.
+
+1.2. **"Protected Health Information" (PHI)** means individually identifiable health information, including demographic information, that is created, received, maintained, or transmitted by Business Associate on behalf of Covered Entity, whether in electronic, paper, or oral form.
+
+1.3. **"Electronic Protected Health Information" (ePHI)** means PHI that is transmitted or maintained in electronic media.
+
+1.4. **"HIPAA Rules"** means the Privacy, Security, Breach Notification, and Enforcement Rules at 45 CFR Part 160 and Part 164, as amended.
+
+1.5. **"Required by Law"** means a mandate contained in law that compels an entity to make a use or disclosure of PHI, and that is enforceable in a court of law.
+
+1.6. **"Security Incident"** means the attempted or successful unauthorized access, use, disclosure, modification, or destruction of information or interference with system operations in an information system.
+
+1.7. **"Subcontractor"** means a person or entity to whom Business Associate delegates a function, activity, or service, other than in the capacity of a member of the workforce of the Business Associate.
+
+## 2. OBLIGATIONS OF BUSINESS ASSOCIATE
+
+2.1. **Permitted Uses and Disclosures.** Business Associate shall not use or disclose PHI other than as permitted or required by this Agreement or as Required by Law.
+
+2.2. **Safeguards.** Business Associate shall use appropriate administrative, physical, and technical safeguards, and shall comply with applicable requirements of the HIPAA Security Rule with respect to ePHI, to prevent the use or disclosure of PHI other than as provided for by this Agreement.
+
+2.3. **Minimum Necessary.** Business Associate shall limit its use, disclosure, or request of PHI to the minimum necessary to accomplish the intended purpose of the use, disclosure, or request.
+
+2.4. **Reporting.** Business Associate shall report to Covered Entity:
+- (a) Any use or disclosure of PHI not provided for by this Agreement of which Business Associate becomes aware, including Breaches of unsecured PHI as required by 45 CFR 164.410;
+- (b) Any Security Incident of which Business Associate becomes aware.
+
+Such reports shall be made without unreasonable delay and in no case later than **ten (10) business days** after discovery of the incident.
+
+2.5. **Subcontractors.** Business Associate shall ensure that any Subcontractor that creates, receives, maintains, or transmits PHI on behalf of the Business Associate agrees to the same restrictions, conditions, and requirements that apply to the Business Associate under this Agreement.
+
+2.6. **Access to PHI.** Business Associate shall make available PHI in a Designated Record Set to the Covered Entity as necessary to satisfy Covered Entity's obligations under 45 CFR 164.524.
+
+2.7. **Amendment of PHI.** Business Associate shall make any amendment(s) to PHI in a Designated Record Set as directed by Covered Entity pursuant to 45 CFR 164.526, or take other measures as necessary to satisfy Covered Entity's obligations under 45 CFR 164.526.
+
+2.8. **Accounting of Disclosures.** Business Associate shall make available the information required to provide an accounting of disclosures to Covered Entity as necessary to satisfy Covered Entity's obligations under 45 CFR 164.528.
+
+2.9. **Access to Books and Records.** Business Associate shall make its internal practices, books, and records available to the Secretary of the U.S. Department of Health and Human Services for purposes of determining compliance with the HIPAA Rules.
+
+## 3. PERMITTED USES AND DISCLOSURES
+
+3.1. Business Associate may use or disclose PHI as necessary to perform the services set forth in the underlying service agreement between the parties.
+
+3.2. Business Associate may use or disclose PHI as Required by Law.
+
+3.3. Business Associate may use PHI for the proper management and administration of the Business Associate or to carry out the legal responsibilities of the Business Associate, provided that:
+- (a) The disclosures are Required by Law; or
+- (b) Business Associate obtains reasonable assurances from the person to whom the information is disclosed that the information will remain confidential and will be used or further disclosed only as Required by Law or for the purposes for which it was disclosed, and the person notifies Business Associate of any instances of which it is aware in which the confidentiality of the information has been breached.
+
+3.4. Business Associate may de-identify PHI in accordance with 45 CFR 164.514(a)-(c).
+
+## 4. REQUIRED SAFEGUARDS
+
+4.1. **Administrative Safeguards.** Business Associate shall:
+- (a) Designate a security officer responsible for the development and implementation of security policies and procedures;
+- (b) Implement workforce security measures, including authorization and supervision procedures;
+- (c) Implement security awareness and training programs for workforce members;
+- (d) Develop and implement policies and procedures for security incident response and reporting;
+- (e) Develop and test a contingency plan, including data backup, disaster recovery, and emergency mode operation plans.
+
+4.2. **Physical Safeguards.** Business Associate shall:
+- (a) Implement facility access controls to limit physical access to ePHI;
+- (b) Implement policies and procedures for workstation use and security;
+- (c) Implement policies and procedures governing the receipt and removal of hardware and electronic media containing ePHI.
+
+4.3. **Technical Safeguards.** Business Associate shall:
+- (a) Implement access controls, including unique user identification, emergency access procedures, and automatic logoff;
+- (b) Implement audit controls to record and examine activity in systems containing ePHI;
+- (c) Implement integrity controls to protect ePHI from improper alteration or destruction;
+- (d) Implement transmission security measures, including encryption of ePHI transmitted over electronic networks.
+
+4.4. **Encryption Standards.** Business Associate shall encrypt all ePHI at rest using AES-256 or equivalent and in transit using TLS 1.2 or higher.
+
+## 5. BREACH NOTIFICATION
+
+5.1. **Discovery.** A Breach shall be treated as discovered by Business Associate as of the first day on which such Breach is known to Business Associate or, by exercising reasonable diligence, would have been known to Business Associate.
+
+5.2. **Notification Timeline.** Following the discovery of a Breach of unsecured PHI, Business Associate shall notify Covered Entity without unreasonable delay and in no case later than **ten (10) business days** after discovery of such Breach.
+
+5.3. **Notification Content.** Such notification shall include, to the extent possible:
+- (a) A description of what happened, including the date of the Breach and the date of discovery;
+- (b) A description of the types of unsecured PHI involved in the Breach;
+- (c) The identification of each individual whose unsecured PHI has been, or is reasonably believed to have been, accessed, acquired, used, or disclosed;
+- (d) Any steps Business Associate has taken or shall take to investigate the Breach, mitigate harm, and prevent future Breaches;
+- (e) Contact information for a representative of Business Associate.
+
+5.4. **Cooperation.** Business Associate shall cooperate with Covered Entity in investigating the Breach and in meeting Covered Entity's obligations under the HIPAA Breach Notification Rule.
+
+## 6. TERM AND TERMINATION
+
+6.1. **Term.** This Agreement shall be effective as of [EFFECTIVE_DATE] and shall terminate on the earlier of:
+- (a) The date of termination of the underlying service agreement between the parties; or
+- (b) The date either party terminates this Agreement for cause as described below.
+
+6.2. **Termination for Cause.** Either party may terminate this Agreement if it determines that the other party has violated a material term of this Agreement, provided that the terminating party:
+- (a) Provides written notice to the other party describing the violation;
+- (b) Provides thirty (30) days for the other party to cure the violation; and
+- (c) If the violation is not cured within such period, terminates the Agreement.
+
+6.3. **Obligations Upon Termination.** Upon termination of this Agreement, Business Associate shall:
+- (a) Return or destroy all PHI received from, or created or received by Business Associate on behalf of, Covered Entity, if feasible; and
+- (b) Retain no copies of PHI in any form.
+
+If return or destruction is not feasible, Business Associate shall extend the protections of this Agreement to such PHI and limit further uses and disclosures of such PHI to those purposes that make the return or destruction infeasible, for so long as Business Associate maintains such PHI.
+
+6.4. **Survival.** The obligations of Business Associate under Section 6.3 shall survive the termination of this Agreement.
+
+## 7. MISCELLANEOUS
+
+7.1. **Regulatory References.** A reference in this Agreement to a section in the HIPAA Rules means the section as in effect or as amended.
+
+7.2. **Amendment.** The parties agree to take such action as is necessary to amend this Agreement from time to time as is necessary for compliance with the HIPAA Rules.
+
+7.3. **Interpretation.** Any ambiguity in this Agreement shall be interpreted to permit compliance with the HIPAA Rules.
+
+7.4. **Governing Law.** This Agreement shall be governed by the laws of the State of Delaware, without regard to conflict of law principles, to the extent not preempted by federal law.
+
+---
+
+## SIGNATURES
+
+**Perennia AI, Inc. (Covered Entity)**
+
+Name: [PERENNIA_SIGNER]
+Title: ___________________________
+Signature: ___________________________
+Date: ___________________________
+
+**[VENDOR_NAME] (Business Associate)**
+
+Name: [VENDOR_SIGNER]
+Title: ___________________________
+Signature: ___________________________
+Date: ___________________________

--- a/backend/soc2_compliance/templates/dpa_template.md
+++ b/backend/soc2_compliance/templates/dpa_template.md
@@ -1,0 +1,255 @@
+# DATA PROCESSING AGREEMENT
+
+**Between Perennia AI, Inc. ("Controller") and [VENDOR_NAME] ("Processor")**
+
+**Effective Date:** [EFFECTIVE_DATE]
+
+This Data Processing Agreement ("DPA") forms part of the underlying service agreement between the parties and governs the processing of personal data by Processor on behalf of Controller, in compliance with the General Data Protection Regulation (EU 2016/679, "GDPR"), the California Consumer Privacy Act (Cal. Civ. Code 1798.100 et seq., "CCPA"), the Gramm-Leach-Bliley Act ("GLBA"), and other applicable data protection laws.
+
+---
+
+## 1. DEFINITIONS
+
+1.1. **"Personal Data"** means any information relating to an identified or identifiable natural person ("Data Subject"), as defined by applicable data protection law.
+
+1.2. **"Processing"** means any operation or set of operations performed on Personal Data, whether by automated means or otherwise, including collection, recording, organization, structuring, storage, adaptation, alteration, retrieval, consultation, use, disclosure by transmission, dissemination, alignment, combination, restriction, erasure, or destruction.
+
+1.3. **"Sub-processor"** means any third party engaged by Processor to process Personal Data on behalf of Controller.
+
+1.4. **"Data Breach"** means a breach of security leading to the accidental or unlawful destruction, loss, alteration, unauthorized disclosure of, or access to Personal Data.
+
+1.5. **"Supervisory Authority"** means the relevant regulatory body with jurisdiction over data protection matters, including but not limited to EU Data Protection Authorities and the California Attorney General.
+
+1.6. **"Standard Contractual Clauses" (SCCs)** means the standard contractual clauses for the transfer of personal data to processors established in third countries, as approved by the European Commission.
+
+## 2. PROCESSING DETAILS
+
+2.1. **Subject Matter.** Processor shall process Personal Data solely for the purpose of providing services to Controller under the underlying service agreement.
+
+2.2. **Duration.** Processing shall continue for the duration of the service agreement, unless otherwise specified in this DPA.
+
+2.3. **Nature and Purpose.** The nature and purpose of Processing are:
+
+| Attribute | Description |
+|-----------|-------------|
+| **Purpose** | To provide the services described in the underlying service agreement |
+| **Nature** | Automated and manual processing as required by the services |
+| **Frequency** | Continuous during the term of the agreement |
+
+2.4. **Type of Personal Data.** The following categories of Personal Data may be processed:
+
+- Contact information (name, email address, phone number, mailing address)
+- Financial information (loan amounts, income, credit scores, bank account references)
+- Property information (addresses, valuations)
+- Communication records (emails, call logs, SMS messages)
+- Authentication data (usernames, hashed passwords, session tokens)
+- Device and usage data (IP addresses, browser information, activity logs)
+
+2.5. **Categories of Data Subjects.** The Data Subjects include:
+
+- Borrowers and loan applicants
+- Real estate agents and referral partners
+- Loan officers and other end users of the platform
+- Authorized representatives of business entities
+
+## 3. DATA CATEGORIES AND CLASSIFICATION
+
+3.1. Processor acknowledges that Personal Data processed under this agreement may include data subject to the following regulatory frameworks:
+
+| Category | Classification | Regulatory Basis |
+|----------|---------------|-----------------|
+| Borrower PII | Restricted | GLBA, CCPA, TRID |
+| Financial records | Restricted | GLBA, RESPA |
+| Contact information | Confidential | CCPA |
+| Communication content | Confidential | TCPA, state law |
+| Authentication data | Restricted | SOC 2 CC6 |
+| Usage/telemetry data | Internal | SOC 2 CC4 |
+
+3.2. Processor shall maintain data handling procedures appropriate to the classification level of the data it processes.
+
+## 4. SECURITY MEASURES
+
+4.1. **General Obligation.** Processor shall implement and maintain appropriate technical and organizational measures to ensure a level of security appropriate to the risk, taking into account the state of the art, the costs of implementation, and the nature, scope, context, and purposes of Processing.
+
+4.2. **Specific Measures.** Without limiting the generality of the foregoing, Processor shall implement:
+
+**(a) Encryption:**
+- Encryption of Personal Data at rest using AES-256 or equivalent
+- Encryption of Personal Data in transit using TLS 1.2 or higher
+- Key management procedures that ensure encryption keys are stored separately from encrypted data
+
+**(b) Access Controls:**
+- Role-based access controls with the principle of least privilege
+- Multi-factor authentication for administrative access to systems containing Personal Data
+- Regular access reviews (at minimum, quarterly)
+- Immediate revocation of access upon personnel departure or role change
+
+**(c) Network Security:**
+- Firewalls and intrusion detection/prevention systems
+- Network segmentation isolating systems that process Personal Data
+- Regular vulnerability scanning and penetration testing (at minimum, annually)
+
+**(d) Logging and Monitoring:**
+- Audit logging of all access to systems containing Personal Data
+- Retention of audit logs for a minimum of two (2) years
+- Real-time alerting for anomalous access patterns
+
+**(e) Business Continuity:**
+- Regular backups of Personal Data with tested restoration procedures
+- Disaster recovery plan with documented recovery time objectives
+- Geographic redundancy of critical data stores
+
+**(f) Personnel Security:**
+- Background checks for personnel with access to Personal Data
+- Mandatory security awareness training (at minimum, annually)
+- Confidentiality obligations binding on all personnel
+
+## 5. SUB-PROCESSORS
+
+5.1. **Authorization.** Controller provides general written authorization for Processor to engage Sub-processors, subject to the requirements of this Section 5.
+
+5.2. **Sub-processor List.** Processor shall maintain and make available to Controller a current list of Sub-processors, including their name, location, and description of processing activities. The current list of authorized Sub-processors is attached as **Appendix A** or available at a URL provided by Processor.
+
+5.3. **Notification of Changes.** Processor shall notify Controller at least **thirty (30) days** before engaging a new Sub-processor or replacing an existing one. Controller may object to such engagement within fifteen (15) days of notification.
+
+5.4. **Objection.** If Controller objects to a new Sub-processor on reasonable data protection grounds, the parties shall discuss the objection in good faith. If no resolution is reached, Controller may terminate the affected services without penalty.
+
+5.5. **Sub-processor Obligations.** Processor shall enter into a written agreement with each Sub-processor imposing data protection obligations no less protective than those set out in this DPA. Processor shall remain fully liable to Controller for the performance of each Sub-processor's obligations.
+
+## 6. DATA SUBJECT RIGHTS
+
+6.1. **Assistance.** Processor shall assist Controller in fulfilling its obligation to respond to Data Subject requests exercising their rights under applicable data protection law, including but not limited to:
+
+- Right of access (GDPR Art. 15, CCPA 1798.100)
+- Right to rectification (GDPR Art. 16)
+- Right to erasure / right to deletion (GDPR Art. 17, CCPA 1798.105)
+- Right to restriction of processing (GDPR Art. 18)
+- Right to data portability (GDPR Art. 20, CCPA 1798.100)
+- Right to object (GDPR Art. 21)
+- Right to opt-out of sale/sharing (CCPA 1798.120)
+
+6.2. **Response Timeline.** Processor shall respond to Controller's requests for assistance within **five (5) business days** of receipt.
+
+6.3. **Direct Requests.** If Processor receives a request directly from a Data Subject, Processor shall promptly redirect the Data Subject to Controller and notify Controller of the request within **two (2) business days**.
+
+6.4. **Technical Capabilities.** Processor shall maintain the technical capability to:
+- Export Personal Data in a structured, commonly used, machine-readable format
+- Selectively delete Personal Data relating to a specific Data Subject
+- Restrict processing of specific Personal Data upon Controller's instruction
+
+## 7. INTERNATIONAL TRANSFERS
+
+7.1. **Transfer Restrictions.** Processor shall not transfer Personal Data to a country outside the European Economic Area (EEA) or to any jurisdiction that does not ensure an adequate level of data protection, unless appropriate safeguards are in place.
+
+7.2. **Safeguards.** Where transfers are necessary, the parties shall ensure that one of the following transfer mechanisms is in place:
+- (a) An adequacy decision by the European Commission covering the destination country;
+- (b) Standard Contractual Clauses (SCCs) as approved by the European Commission;
+- (c) Binding Corporate Rules approved by the relevant Supervisory Authority;
+- (d) The recipient's certification under the EU-U.S. Data Privacy Framework, where applicable.
+
+7.3. **Transfer Impact Assessment.** Where Processor relies on SCCs, Processor shall conduct and document a transfer impact assessment evaluating whether the legal framework of the destination country provides adequate protection for Personal Data, and shall implement supplementary measures where necessary.
+
+7.4. **U.S. State Law Compliance.** With respect to Personal Data of California residents, Processor shall comply with CCPA requirements, including:
+- Not selling or sharing Personal Data received from Controller
+- Not combining Personal Data with data from other sources except as permitted
+- Certifying understanding of and compliance with CCPA restrictions
+
+## 8. DATA BREACH NOTIFICATION
+
+8.1. **Notification Timeline.** Processor shall notify Controller of a Data Breach without undue delay and in no event later than **forty-eight (48) hours** after becoming aware of the Data Breach.
+
+8.2. **Notification Content.** The notification shall include:
+- (a) A description of the nature of the Data Breach, including the categories and approximate number of Data Subjects and records concerned;
+- (b) The name and contact details of the Processor's data protection officer or equivalent;
+- (c) A description of the likely consequences of the Data Breach;
+- (d) A description of the measures taken or proposed to address the Data Breach, including measures to mitigate its adverse effects.
+
+8.3. **Cooperation.** Processor shall cooperate with Controller and provide all reasonable assistance to:
+- Investigate and remediate the Data Breach
+- Fulfill Controller's notification obligations to Supervisory Authorities and Data Subjects
+- Mitigate the effects of the Data Breach
+
+8.4. **Documentation.** Processor shall document all Data Breaches, including the facts relating to the breach, its effects, and the remedial action taken, and shall make such documentation available to Controller upon request.
+
+## 9. AUDITS AND COMPLIANCE
+
+9.1. **Right to Audit.** Controller shall have the right to conduct audits, including inspections, of Processor's processing activities covered by this DPA. Processor shall cooperate with and provide all necessary assistance for such audits.
+
+9.2. **Audit Scope.** Audits may be conducted by Controller or a qualified third-party auditor appointed by Controller, and may include:
+- Review of Processor's security policies and procedures
+- Inspection of technical and organizational measures
+- Review of Sub-processor agreements and compliance
+- Verification of Data Breach response capabilities
+
+9.3. **Frequency.** Controller may conduct audits no more than once per calendar year, unless a Data Breach has occurred or there is a reasonable basis to suspect non-compliance.
+
+9.4. **Certifications.** Processor shall make available to Controller, upon request, relevant certifications and audit reports (e.g., SOC 2 Type II, ISO 27001) as evidence of compliance with the security measures described herein.
+
+9.5. **Notice.** Controller shall provide at least thirty (30) days' written notice before conducting an on-site audit, except in cases of suspected Data Breach.
+
+## 10. DATA RETENTION AND DELETION
+
+10.1. **Retention.** Processor shall not retain Personal Data longer than necessary for the purposes specified in this DPA or as required by applicable law.
+
+10.2. **Return or Deletion.** Upon termination of the service agreement or upon Controller's written request, Processor shall, at Controller's election:
+- (a) Return all Personal Data to Controller in a structured, commonly used, machine-readable format; or
+- (b) Securely delete all Personal Data and certify such deletion in writing.
+
+10.3. **Retention for Legal Obligations.** Where Processor is required by applicable law to retain Personal Data beyond the term of the agreement, Processor shall inform Controller of such requirement and shall ensure that the data is processed only for the purpose specified by such legal obligation.
+
+10.4. **Deletion Timeline.** Processor shall complete return or deletion within **thirty (30) days** of termination or receipt of Controller's request.
+
+## 11. TERM AND TERMINATION
+
+11.1. **Term.** This DPA shall remain in effect for the duration of the underlying service agreement between the parties.
+
+11.2. **Termination.** Either party may terminate this DPA:
+- (a) Upon termination of the underlying service agreement;
+- (b) If the other party materially breaches this DPA and fails to cure such breach within thirty (30) days of written notice;
+- (c) If required by a Supervisory Authority or court order.
+
+11.3. **Survival.** Sections 4 (Security Measures), 8 (Data Breach Notification), 9 (Audits), and 10 (Data Retention and Deletion) shall survive the termination of this DPA.
+
+## 12. LIABILITY AND INDEMNIFICATION
+
+12.1. **Liability.** Each party's liability under this DPA shall be subject to the limitations of liability set forth in the underlying service agreement.
+
+12.2. **Indemnification.** Processor shall indemnify and hold Controller harmless from and against any fines, penalties, damages, costs, or expenses arising from Processor's breach of this DPA or applicable data protection law, including costs of notification to Data Subjects and Supervisory Authorities.
+
+## 13. GOVERNING LAW
+
+13.1. This DPA shall be governed by the laws of the State of Delaware, without regard to conflict of law principles, to the extent not preempted by applicable data protection law (including the GDPR and CCPA).
+
+13.2. For disputes relating to the processing of Personal Data of Data Subjects in the EEA, the courts of the Member State where the Data Subject is located shall have jurisdiction.
+
+---
+
+## SIGNATURES
+
+**Perennia AI, Inc. (Controller)**
+
+Name: [PERENNIA_SIGNER]
+Title: ___________________________
+Signature: ___________________________
+Date: ___________________________
+
+**[VENDOR_NAME] (Processor)**
+
+Name: [VENDOR_SIGNER]
+Title: ___________________________
+Signature: ___________________________
+Date: ___________________________
+
+---
+
+## APPENDIX A: AUTHORIZED SUB-PROCESSORS
+
+| Sub-processor Name | Location | Processing Activities |
+|-------------------|----------|----------------------|
+| *(To be completed by Processor)* | | |
+
+---
+
+## APPENDIX B: TECHNICAL AND ORGANIZATIONAL MEASURES
+
+Processor shall maintain the security measures described in Section 4 of this DPA. A detailed description of the current technical and organizational measures implemented by Processor is available upon request and shall be updated no less than annually.

--- a/backend/tests/test_voice_tool_handler_scheduling.py
+++ b/backend/tests/test_voice_tool_handler_scheduling.py
@@ -1,0 +1,303 @@
+"""
+Tests for the start_scheduling_workflow tool handler in
+routes/voice/tool_handlers.py :: handle_browser_function_call()
+
+Verifies that the handler now creates a VoiceWorkflow record via the
+state machine rather than sending SMS directly (stateless).
+
+All tests mock external dependencies (VoiceSchedulingWorkflowService,
+SchedulingConversationService, DB) and verify:
+- Correct argument validation (missing name/phone)
+- VoiceWorkflow is created via create_workflow()
+- SchedulingConversationService.initiate_scheduling() is called
+- workflow_id is returned in the response
+- Error handling rolls back the DB session
+
+Run with: pytest tests/test_voice_tool_handler_scheduling.py -v
+"""
+
+import sys
+import os
+import itertools
+import pytest
+from unittest.mock import MagicMock, patch
+
+_backend = os.path.join(os.path.dirname(__file__), '..')
+if _backend not in sys.path:
+    sys.path.insert(0, _backend)
+
+pytestmark = [pytest.mark.unit]
+
+ORG_ID = "org-test-001"
+USER_ID = 42
+
+# Each test call gets a unique session ID to avoid hitting the in-memory rate
+# limiter (start_scheduling_workflow is capped at 2 per 300 seconds).
+_session_counter = itertools.count()
+
+
+def _mock_db():
+    db = MagicMock()
+    result_proxy = MagicMock()
+    result_proxy.fetchone.return_value = None
+    result_proxy.fetchall.return_value = []
+    db.execute.return_value = result_proxy
+    return db
+
+
+async def _call(func_name: str, args: dict, db=None, org_id=ORG_ID, user_id=USER_ID):
+    from routes.voice.tool_handlers import handle_browser_function_call
+    if db is None:
+        db = _mock_db()
+    session_id = f"test-sched-{next(_session_counter)}"
+    return await handle_browser_function_call(
+        func_name, args, db,
+        session_id=session_id,
+        organization_id=org_id,
+        user_id=user_id,
+    )
+
+
+# ===========================================================================
+# Argument Validation
+# ===========================================================================
+
+class TestSchedulingWorkflowValidation:
+
+    @pytest.mark.asyncio
+    async def test_missing_contact_name_returns_error(self):
+        result = await _call("start_scheduling_workflow", {
+            "contact_phone": "+15551234567",
+        })
+        assert result["success"] is False
+        assert "Contact name and phone number are required" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_missing_contact_phone_returns_error(self):
+        result = await _call("start_scheduling_workflow", {
+            "contact_name": "John Doe",
+        })
+        assert result["success"] is False
+        assert "Contact name and phone number are required" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_empty_strings_returns_error(self):
+        result = await _call("start_scheduling_workflow", {
+            "contact_name": "",
+            "contact_phone": "",
+        })
+        assert result["success"] is False
+        assert "Contact name and phone number are required" in result["message"]
+
+
+# ===========================================================================
+# Happy Path — workflow creation
+# ===========================================================================
+
+class TestSchedulingWorkflowCreation:
+
+    @pytest.mark.asyncio
+    @patch("routes.voice.tool_handlers.SchedulingConversationService", create=True)
+    @patch("routes.voice.tool_handlers.VoiceSchedulingWorkflowService", create=True)
+    async def test_creates_workflow_and_returns_id(self, mock_vw_cls, mock_sched_cls):
+        """The handler should create a VoiceWorkflow and return its id."""
+        # Because imports are lazy (inside the elif block), we patch the
+        # service modules where they are imported from.
+        fake_workflow = MagicMock()
+        fake_workflow.id = 99
+
+        mock_vw_instance = MagicMock()
+        mock_vw_instance.create_workflow.return_value = fake_workflow
+
+        mock_sched_instance = MagicMock()
+        mock_sched_instance.initiate_scheduling.return_value = {
+            "success": True,
+            "message_sent": "Hi John...",
+            "slots_offered": ["Monday 10:00 AM"],
+        }
+
+        db = _mock_db()
+
+        with patch(
+            "services.voice_scheduling_workflow_service.VoiceSchedulingWorkflowService",
+            return_value=mock_vw_instance,
+        ), patch(
+            "services.scheduling_conversation_service.SchedulingConversationService",
+            return_value=mock_sched_instance,
+        ):
+            result = await _call("start_scheduling_workflow", {
+                "contact_name": "John Doe",
+                "contact_phone": "+15551234567",
+                "meeting_type": "discovery_call",
+                "message_context": "discuss pre-approval",
+            }, db=db)
+
+        assert result["success"] is True
+        assert result["workflow_id"] == 99
+        assert "SMS sent to John Doe" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_workflow_is_called_with_correct_args(self):
+        """Verify create_workflow receives the expected keyword arguments."""
+        fake_workflow = MagicMock()
+        fake_workflow.id = 42
+
+        mock_vw_instance = MagicMock()
+        mock_vw_instance.create_workflow.return_value = fake_workflow
+
+        mock_sched_instance = MagicMock()
+        mock_sched_instance.initiate_scheduling.return_value = {"success": True}
+
+        db = _mock_db()
+
+        with patch(
+            "services.voice_scheduling_workflow_service.VoiceSchedulingWorkflowService",
+            return_value=mock_vw_instance,
+        ), patch(
+            "services.scheduling_conversation_service.SchedulingConversationService",
+            return_value=mock_sched_instance,
+        ):
+            await _call("start_scheduling_workflow", {
+                "contact_name": "Jane Smith",
+                "contact_phone": "+15559876543",
+                "meeting_type": "rate_review",
+                "message_context": "rate lock expiring",
+            }, db=db, org_id="org-123", user_id=7)
+
+        mock_vw_instance.create_workflow.assert_called_once_with(
+            organization_id="org-123",
+            user_id=7,
+            workflow_type="voice_schedule",
+            contact_name="Jane Smith",
+            contact_phone="+15559876543",
+            meeting_type="rate_review",
+            message_context="rate lock expiring",
+        )
+
+    @pytest.mark.asyncio
+    async def test_initiate_scheduling_is_called_with_correct_args(self):
+        """Verify initiate_scheduling receives the workflow_id and contact info."""
+        fake_workflow = MagicMock()
+        fake_workflow.id = 55
+
+        mock_vw_instance = MagicMock()
+        mock_vw_instance.create_workflow.return_value = fake_workflow
+
+        mock_sched_instance = MagicMock()
+        mock_sched_instance.initiate_scheduling.return_value = {"success": True}
+
+        db = _mock_db()
+
+        with patch(
+            "services.voice_scheduling_workflow_service.VoiceSchedulingWorkflowService",
+            return_value=mock_vw_instance,
+        ), patch(
+            "services.scheduling_conversation_service.SchedulingConversationService",
+            return_value=mock_sched_instance,
+        ):
+            await _call("start_scheduling_workflow", {
+                "contact_name": "Bob Wilson",
+                "contact_phone": "+15550001111",
+                "meeting_type": "discovery_call",
+                "message_context": "",
+            }, db=db, org_id="org-456", user_id=10)
+
+        mock_sched_instance.initiate_scheduling.assert_called_once_with(
+            workflow_id=55,
+            user_id=10,
+            organization_id="org-456",
+            contact_name="Bob Wilson",
+            contact_phone="+15550001111",
+            meeting_type="discovery_call",
+            message_context="",
+        )
+
+    @pytest.mark.asyncio
+    async def test_defaults_meeting_type_and_message_context(self):
+        """When meeting_type and message_context are omitted, use defaults."""
+        fake_workflow = MagicMock()
+        fake_workflow.id = 1
+
+        mock_vw_instance = MagicMock()
+        mock_vw_instance.create_workflow.return_value = fake_workflow
+
+        mock_sched_instance = MagicMock()
+        mock_sched_instance.initiate_scheduling.return_value = {"success": True}
+
+        db = _mock_db()
+
+        with patch(
+            "services.voice_scheduling_workflow_service.VoiceSchedulingWorkflowService",
+            return_value=mock_vw_instance,
+        ), patch(
+            "services.scheduling_conversation_service.SchedulingConversationService",
+            return_value=mock_sched_instance,
+        ):
+            result = await _call("start_scheduling_workflow", {
+                "contact_name": "Alice",
+                "contact_phone": "+15550002222",
+            }, db=db)
+
+        assert result["success"] is True
+        # Verify defaults were used
+        call_kwargs = mock_vw_instance.create_workflow.call_args
+        assert call_kwargs.kwargs["meeting_type"] == "discovery_call"
+        assert call_kwargs.kwargs["message_context"] == ""
+
+
+# ===========================================================================
+# Error Handling
+# ===========================================================================
+
+class TestSchedulingWorkflowErrorHandling:
+
+    @pytest.mark.asyncio
+    async def test_service_exception_rolls_back_and_returns_error(self):
+        """If create_workflow raises, handler should rollback and return error."""
+        mock_vw_instance = MagicMock()
+        mock_vw_instance.create_workflow.side_effect = RuntimeError("DB connection lost")
+
+        db = _mock_db()
+
+        with patch(
+            "services.voice_scheduling_workflow_service.VoiceSchedulingWorkflowService",
+            return_value=mock_vw_instance,
+        ):
+            result = await _call("start_scheduling_workflow", {
+                "contact_name": "Error Test",
+                "contact_phone": "+15550003333",
+            }, db=db)
+
+        assert result["success"] is False
+        assert "Failed to start scheduling workflow" in result["message"]
+        db.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_initiate_scheduling_exception_rolls_back(self):
+        """If initiate_scheduling raises after workflow creation, handler rolls back."""
+        fake_workflow = MagicMock()
+        fake_workflow.id = 77
+
+        mock_vw_instance = MagicMock()
+        mock_vw_instance.create_workflow.return_value = fake_workflow
+
+        mock_sched_instance = MagicMock()
+        mock_sched_instance.initiate_scheduling.side_effect = ValueError("SMS send failed")
+
+        db = _mock_db()
+
+        with patch(
+            "services.voice_scheduling_workflow_service.VoiceSchedulingWorkflowService",
+            return_value=mock_vw_instance,
+        ), patch(
+            "services.scheduling_conversation_service.SchedulingConversationService",
+            return_value=mock_sched_instance,
+        ):
+            result = await _call("start_scheduling_workflow", {
+                "contact_name": "SMS Fail",
+                "contact_phone": "+15550004444",
+            }, db=db)
+
+        assert result["success"] is False
+        assert "Failed to start scheduling workflow" in result["message"]
+        db.rollback.assert_called_once()

--- a/frontend/capacitor.config.ts
+++ b/frontend/capacitor.config.ts
@@ -1,12 +1,15 @@
 import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
-  appId: 'com.perenniaai.crm',
-  appName: 'Perennia AI',
+  appId: process.env.CAPACITOR_APP_ID || 'com.perenniaai.crm',
+  appName: process.env.CAPACITOR_APP_NAME || 'Perennia AI',
   webDir: 'build',
   server: {
-    ...(process.env.CAPACITOR_SERVER_URL ? { url: process.env.CAPACITOR_SERVER_URL } : {}),
-    allowNavigation: ['perenniaai.com', 'app.perenniaai.com', 'api.perenniaai.com', 'www.perenniaai.com', 'localhost', '127.0.0.1'],
+    ...(process.env.CAPACITOR_SERVER_URL ? { url: process.env.CAPACITOR_SERVER_URL, cleartext: true } : {}),
+    allowNavigation: [
+      ...(process.env.CAPACITOR_ALLOWED_DOMAINS?.split(',') || []),
+      'perenniaai.com', 'app.perenniaai.com', 'api.perenniaai.com', 'www.perenniaai.com', 'localhost', '127.0.0.1',
+    ],
   },
   ios: {
     contentInset: 'automatic',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -146,6 +146,7 @@ const Support = lazyRetry(() => import('./pages/Support'));
 const AriaVoiceApp = lazyRetry(() => import('./pages/AriaVoiceApp'));
 const AriaCalendarPage = lazyRetry(() => import('./pages/aria/AriaCalendarPage'));
 const AriaMortgageCalculator = lazyRetry(() => import('./pages/aria/AriaMortgageCalculator'));
+const BriefingPage = lazyRetry(() => import('./pages/BriefingPage'));
 const PowerDialer = lazyRetry(() => import('./pages/PowerDialer'));
 const UserCreationWizard = lazyRetry(() => import('./pages/UserCreationWizard'));
 const UserBulkUpload = lazyRetry(() => import('./pages/UserBulkUpload'));
@@ -544,6 +545,7 @@ function App() {
           <Route path="/verify-account" element={<AccountVerification />} />
           <Route path="/verify-email-sent" element={<EmailVerificationSent />} />
           <Route path="/login" element={<Login />} />
+          <Route path="/briefing" element={<PrivateRoute><LazyPage><BriefingPage /></LazyPage></PrivateRoute>} />
           <Route path="/aria" element={<PrivateRoute><LazyPage><AriaVoiceApp /></LazyPage></PrivateRoute>} />
           <Route path="/aria/calendar" element={<PrivateRoute><LazyPage><AriaCalendarPage /></LazyPage></PrivateRoute>} />
           <Route path="/aria/calculator" element={<PrivateRoute><LazyPage><AriaMortgageCalculator /></LazyPage></PrivateRoute>} />

--- a/frontend/src/components/dashboard/MorningBriefingCard.css
+++ b/frontend/src/components/dashboard/MorningBriefingCard.css
@@ -1,16 +1,28 @@
+/* ==========================================================================
+   MorningBriefingCard
+   ========================================================================== */
+
 .morning-briefing-card {
   background: linear-gradient(135deg, #f0fafa, #ffffff);
   border: 1px solid #218d8d33;
   border-radius: 12px;
   margin-bottom: 20px;
   overflow: hidden;
+  transition: border-color 0.2s ease;
 }
+
+/* Health-tinted top border */
+.morning-briefing-card.health-green { border-top: 3px solid #10b981; }
+.morning-briefing-card.health-yellow { border-top: 3px solid #f59e0b; }
+.morning-briefing-card.health-red { border-top: 3px solid #ef4444; }
+
+/* ---------- Header ---------- */
 
 .briefing-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: 14px 20px;
   cursor: pointer;
   user-select: none;
 }
@@ -28,15 +40,45 @@
   color: #1a1a2a;
 }
 
-.briefing-icon { font-size: 20px; }
-.briefing-date { font-size: 13px; color: #8888a0; }
+.briefing-date {
+  font-size: 13px;
+  color: #8888a0;
+}
 
+/* Health indicator dot */
+.health-indicator {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.health-indicator.green { background: #10b981; box-shadow: 0 0 4px #10b98155; }
+.health-indicator.yellow { background: #f59e0b; box-shadow: 0 0 4px #f59e0b55; }
+.health-indicator.red { background: #ef4444; box-shadow: 0 0 4px #ef444455; animation: pulse-red 2s infinite; }
+
+@keyframes pulse-red {
+  0%, 100% { box-shadow: 0 0 4px #ef444455; }
+  50% { box-shadow: 0 0 10px #ef444488; }
+}
+
+.health-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #8888a0;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+/* Header buttons */
 .briefing-actions {
   display: flex;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
 }
 
+.briefing-refresh-btn,
 .briefing-collapse-btn,
 .briefing-dismiss-btn {
   background: none;
@@ -45,72 +87,330 @@
   font-size: 16px;
   color: #8888a0;
   padding: 4px 8px;
-  border-radius: 4px;
+  border-radius: 6px;
+  line-height: 1;
+  transition: background 0.15s, color 0.15s;
 }
 
+.briefing-refresh-btn:hover,
 .briefing-collapse-btn:hover,
 .briefing-dismiss-btn:hover {
   background: #f0f0f4;
   color: #4a4a5a;
 }
 
-.briefing-body {
-  padding: 0 20px 20px;
+.briefing-refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
-.briefing-section {
+.briefing-refresh-btn .spin {
+  display: inline-block;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* ---------- Body ---------- */
+
+.briefing-body {
+  padding: 0 20px 16px;
+}
+
+/* ---------- AI Narrative ---------- */
+
+.briefing-narrative {
+  background: #f8fbfb;
+  border: 1px solid #e2eded;
+  border-radius: 8px;
+  padding: 12px 14px;
   margin-bottom: 16px;
 }
 
-.briefing-section h4 {
-  margin: 0 0 8px;
+.narrative-text {
+  font-size: 14px;
+  line-height: 1.65;
+  color: #1a1a2a;
+  white-space: pre-line;
+}
+
+.narrative-text.truncated {
+  max-height: 72px;
+  overflow: hidden;
+}
+
+.narrative-toggle {
+  background: none;
+  border: none;
+  color: #218d8d;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 0 0;
+}
+
+.narrative-toggle:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Sections ---------- */
+
+.briefing-section {
+  margin-bottom: 4px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.briefing-section.section-warn .briefing-section-header {
+  color: #ef4444;
+}
+
+.briefing-section.section-caution .briefing-section-header {
+  color: #f59e0b;
+}
+
+.briefing-section.section-team {
+  border-top: 1px solid #e8e8ed;
+  padding-top: 8px;
+  margin-top: 8px;
+}
+
+/* Collapsible section header */
+.briefing-section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px 4px;
   font-size: 13px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: #218d8d;
+  text-align: left;
 }
 
-.briefing-section.at-risk h4 { color: #e74c3c; }
-.briefing-section.stale-leads h4 { color: #f39c12; }
+.briefing-section-header:hover {
+  background: #f5fafa;
+  border-radius: 6px;
+}
 
-.briefing-section ul {
+.section-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.section-title {
+  flex: 1;
+}
+
+.section-badge {
+  background: #218d8d18;
+  color: #218d8d;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 10px;
+}
+
+.section-warn .section-badge {
+  background: #ef444418;
+  color: #ef4444;
+}
+
+.section-caution .section-badge {
+  background: #f59e0b18;
+  color: #f59e0b;
+}
+
+.section-chevron {
+  color: #aaa;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+/* Section content area */
+.section-content {
+  padding: 4px 4px 8px 26px;
+}
+
+.section-empty {
+  font-size: 13px;
+  color: #aaa;
+  padding: 4px 4px 8px 26px;
   margin: 0;
-  padding-left: 18px;
-  list-style: disc;
 }
 
-.briefing-section li {
-  margin: 4px 0;
+/* ---------- Metric Row ---------- */
+
+.metric-row {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.metric-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.metric-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: #1a1a2a;
+  line-height: 1.2;
+}
+
+.metric-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: #8888a0;
+  letter-spacing: 0.3px;
+}
+
+/* Trend arrows */
+.trend-arrow {
+  font-size: 11px;
+  font-weight: 600;
+  margin-left: 4px;
+}
+
+.trend-arrow.up { color: #10b981; }
+.trend-arrow.down { color: #ef4444; }
+.trend-arrow.neutral { color: #8888a0; }
+
+/* ---------- Stage pills ---------- */
+
+.stage-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.stage-pill {
+  font-size: 11px;
+  background: #f0f0f4;
+  color: #4a4a5a;
+  padding: 3px 10px;
+  border-radius: 12px;
+  white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.stage-pill strong {
+  color: #218d8d;
+  margin-left: 3px;
+}
+
+/* ---------- Lists ---------- */
+
+.briefing-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.briefing-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
   font-size: 13px;
   color: #4a4a5a;
-  line-height: 1.5;
+  border-bottom: 1px solid #f5f5f8;
+  flex-wrap: wrap;
 }
 
-.briefing-section li a {
+.briefing-list li:last-child {
+  border-bottom: none;
+}
+
+.item-link {
   color: #218d8d;
   text-decoration: none;
 }
 
-.briefing-section li a:hover { text-decoration: underline; }
-
-.priorities-text {
-  font-size: 14px;
-  line-height: 1.7;
-  color: #1a1a2a;
-  white-space: pre-line;
+.item-link:hover {
+  text-decoration: underline;
 }
 
-.briefing-stats {
-  display: flex;
-  gap: 20px;
-  margin-bottom: 8px;
+.item-detail {
+  color: #8888a0;
+  font-size: 12px;
 }
 
-.briefing-stats span {
-  font-size: 13px;
-  color: #4a4a5a;
+.item-badge {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-weight: 600;
+  flex-shrink: 0;
 }
+
+.item-badge.warn {
+  background: #fef3c7;
+  color: #d97706;
+}
+
+.item-badge.score {
+  background: #dbeafe;
+  color: #2563eb;
+}
+
+.item-loan {
+  font-size: 11px;
+  color: #aaa;
+  margin-left: auto;
+}
+
+/* Severity dots for conditions */
+.severity-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.severity-dot.critical { background: #ef4444; }
+.severity-dot.high { background: #f59e0b; }
+.severity-dot.medium { background: #3b82f6; }
+.severity-dot.low { background: #8888a0; }
+
+.past-due-banner {
+  background: #fef2f2;
+  color: #ef4444;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 6px;
+  margin-bottom: 6px;
+  display: inline-block;
+}
+
+.conditions-list li.past-due {
+  background: #fefce8;
+  border-radius: 4px;
+  padding-left: 6px;
+}
+
+/* Appointments */
+.appt-time {
+  font-weight: 600;
+  color: #218d8d;
+  min-width: 70px;
+  font-size: 12px;
+}
+
+/* ---------- Tables (Team / Org) ---------- */
 
 .briefing-table {
   width: 100%;
@@ -143,20 +443,77 @@
   margin-right: 6px;
 }
 
-.health-dot.green { background: #27ae60; }
-.health-dot.yellow { background: #f39c12; }
-.health-dot.red { background: #e74c3c; }
-
-.team-section, .org-section {
-  border-top: 1px solid #e8e8ed;
-  padding-top: 16px;
-}
+.health-dot.green { background: #10b981; }
+.health-dot.yellow { background: #f59e0b; }
+.health-dot.red { background: #ef4444; }
 
 .attention-items { margin-top: 12px; }
 .attention-items h5 {
   margin: 0 0 6px;
   font-size: 12px;
-  color: #e74c3c;
+  color: #ef4444;
   text-transform: uppercase;
   font-weight: 700;
+}
+
+.attention-items ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.attention-items li {
+  font-size: 13px;
+  color: #4a4a5a;
+  margin: 4px 0;
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 640px) {
+  .briefing-header {
+    padding: 12px 14px;
+  }
+
+  .briefing-body {
+    padding: 0 14px 14px;
+  }
+
+  .briefing-title h3 {
+    font-size: 14px;
+  }
+
+  .health-label {
+    display: none;
+  }
+
+  .metric-row {
+    gap: 12px;
+  }
+
+  .metric-value {
+    font-size: 18px;
+  }
+
+  .section-content {
+    padding-left: 12px;
+  }
+
+  .briefing-table th,
+  .briefing-table td {
+    padding: 6px 8px;
+    font-size: 12px;
+  }
+
+  .stage-pills {
+    gap: 4px;
+  }
+}
+
+/* ---------- Reduced Motion ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .health-indicator.red,
+  .briefing-refresh-btn .spin {
+    animation: none;
+  }
 }

--- a/frontend/src/components/dashboard/MorningBriefingCard.js
+++ b/frontend/src/components/dashboard/MorningBriefingCard.js
@@ -1,10 +1,280 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import api from '../../services/api';
+import { toast } from '../../utils/toast';
 import './MorningBriefingCard.css';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function healthLabel(level) {
+  if (level === 'red') return 'Needs Attention';
+  if (level === 'yellow') return 'Monitor';
+  return 'On Track';
+}
+
+function formatVolume(v) {
+  if (!v) return '$0';
+  if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `$${(v / 1_000).toFixed(0)}K`;
+  return `$${v.toFixed(0)}`;
+}
+
+function TrendArrow({ value, invertColor }) {
+  if (value === undefined || value === null) return null;
+  const num = Number(value);
+  if (num === 0) return <span className="trend-arrow neutral">--</span>;
+  const up = num > 0;
+  const colorClass = invertColor ? (up ? 'down' : 'up') : (up ? 'up' : 'down');
+  return (
+    <span className={`trend-arrow ${colorClass}`}>
+      {up ? '\u25B2' : '\u25BC'} {Math.abs(num)}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section sub-components
+// ---------------------------------------------------------------------------
+
+function SectionHeader({ title, icon, count, isOpen, onToggle }) {
+  return (
+    <button className="briefing-section-header" onClick={onToggle} type="button">
+      <span className="section-icon">{icon}</span>
+      <span className="section-title">{title}</span>
+      {count !== undefined && count > 0 && (
+        <span className="section-badge">{count}</span>
+      )}
+      <span className="section-chevron">{isOpen ? '\u25BE' : '\u25B8'}</span>
+    </button>
+  );
+}
+
+function PipelineSection({ pipeline }) {
+  if (!pipeline || pipeline.active_count === 0) return null;
+  const byStage = pipeline.by_stage || {};
+  const stageEntries = Object.entries(byStage).slice(0, 5);
+  return (
+    <div className="section-content">
+      <div className="metric-row">
+        <div className="metric-item">
+          <span className="metric-value">{pipeline.active_count}</span>
+          <span className="metric-label">Active Loans</span>
+        </div>
+        <div className="metric-item">
+          <span className="metric-value">{formatVolume(pipeline.total_volume)}</span>
+          <span className="metric-label">Pipeline Volume</span>
+        </div>
+        <div className="metric-item">
+          <span className="metric-value">{pipeline.closing_soon || 0}</span>
+          <span className="metric-label">Closing Soon</span>
+        </div>
+      </div>
+      {stageEntries.length > 0 && (
+        <div className="stage-pills">
+          {stageEntries.map(([stage, count]) => (
+            <span className="stage-pill" key={stage}>
+              {stage.replace(/_/g, ' ')} <strong>{count}</strong>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AtRiskSection({ items }) {
+  if (!items || items.length === 0) return <p className="section-empty">No at-risk loans</p>;
+  return (
+    <div className="section-content">
+      <ul className="briefing-list at-risk-list">
+        {items.slice(0, 5).map((loan, i) => (
+          <li key={loan.loan_id || i}>
+            <a href={`/loans/${loan.loan_id}`} className="item-link">
+              <strong>{loan.borrower}</strong>
+            </a>
+            <span className="item-detail">{loan.reason}</span>
+            {loan.days_in_stage && (
+              <span className="item-badge warn">{Math.round(loan.days_in_stage)}d</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ConditionsSection({ conditions }) {
+  if (!conditions || conditions.length === 0) return <p className="section-empty">No open conditions</p>;
+  const pastDueCount = conditions.filter(c => c.past_due).length;
+  return (
+    <div className="section-content">
+      {pastDueCount > 0 && (
+        <div className="past-due-banner">{pastDueCount} past due</div>
+      )}
+      <ul className="briefing-list conditions-list">
+        {conditions.slice(0, 5).map((c, i) => (
+          <li key={i} className={c.past_due ? 'past-due' : ''}>
+            <span className={`severity-dot ${c.severity || 'medium'}`} />
+            <span className="item-text">{c.title}</span>
+            {c.loan_number && <span className="item-loan">#{c.loan_number}</span>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function StaleLeadsSection({ leads }) {
+  if (!leads || leads.length === 0) return <p className="section-empty">No stale leads</p>;
+  return (
+    <div className="section-content">
+      <ul className="briefing-list leads-list">
+        {leads.slice(0, 5).map((lead, i) => (
+          <li key={lead.lead_id || i}>
+            <a href={`/leads/${lead.lead_id}`} className="item-link">
+              <strong>{lead.name}</strong>
+            </a>
+            {lead.score && <span className="item-badge score">Score {lead.score}</span>}
+            <span className="item-detail">{Math.round(lead.days_silent || 0)} days silent</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function AppointmentsSection({ appointments }) {
+  if (!appointments || appointments.length === 0) return <p className="section-empty">No appointments today</p>;
+  return (
+    <div className="section-content">
+      <ul className="briefing-list appointments-list">
+        {appointments.map((appt, i) => (
+          <li key={appt.id || i}>
+            <span className="appt-time">{appt.time}</span>
+            <span className="item-text">{appt.attendee}</span>
+            <span className="item-detail">{appt.type}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function YesterdaySection({ yesterday }) {
+  if (!yesterday) return null;
+  const { funded, new_loans, conversions } = yesterday;
+  if (!funded && !new_loans && !conversions) return <p className="section-empty">No activity yesterday</p>;
+  return (
+    <div className="section-content">
+      <div className="metric-row">
+        {funded > 0 && (
+          <div className="metric-item">
+            <span className="metric-value">{funded}</span>
+            <span className="metric-label">Funded</span>
+          </div>
+        )}
+        {new_loans > 0 && (
+          <div className="metric-item">
+            <span className="metric-value">{new_loans}</span>
+            <span className="metric-label">New Loans</span>
+          </div>
+        )}
+        {conversions > 0 && (
+          <div className="metric-item">
+            <span className="metric-value">{conversions}</span>
+            <span className="metric-label">Conversions</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TeamSection({ team, level }) {
+  if (!team) return null;
+
+  if (level === 'manager' && team.members) {
+    return (
+      <div className="section-content">
+        <table className="briefing-table">
+          <thead>
+            <tr><th>Name</th><th>Loans</th><th>Volume</th><th>Health</th></tr>
+          </thead>
+          <tbody>
+            {team.members.map((m, i) => (
+              <tr key={i}>
+                <td><span className={`health-dot ${m.health}`} /> {m.name}</td>
+                <td>{m.loan_count}</td>
+                <td>{formatVolume(m.volume)}</td>
+                <td>{m.health}{m.at_risk_count > 0 ? ` \u00B7 ${m.at_risk_count} at-risk` : ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {team.attention_items && team.attention_items.length > 0 && (
+          <div className="attention-items">
+            <h5>Attention Needed</h5>
+            <ul>
+              {team.attention_items.map((item, i) => (
+                <li key={i}><strong>{item.user_name}</strong> -- {item.issue}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (level === 'leadership' && team.branches) {
+    return (
+      <div className="section-content">
+        {team.org_snapshot && (
+          <div className="metric-row">
+            <div className="metric-item">
+              <span className="metric-value">{team.org_snapshot.active_count}</span>
+              <span className="metric-label">Active Loans</span>
+            </div>
+            <div className="metric-item">
+              <span className="metric-value">{formatVolume(team.org_snapshot.total_volume)}</span>
+              <span className="metric-label">Pipeline</span>
+            </div>
+            <div className="metric-item">
+              <span className="metric-value">{team.org_snapshot.funded_this_week}</span>
+              <span className="metric-label">Funded This Week</span>
+            </div>
+          </div>
+        )}
+        <table className="briefing-table">
+          <thead>
+            <tr><th>Branch</th><th>Loans</th><th>Volume</th><th>Health</th></tr>
+          </thead>
+          <tbody>
+            {team.branches.map((b, i) => (
+              <tr key={i}>
+                <td><span className={`health-dot ${b.health}`} /> {b.name}</td>
+                <td>{b.loan_count}</td>
+                <td>{formatVolume(b.volume)}</td>
+                <td>{b.health}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 export default function MorningBriefingCard() {
   const [briefing, setBriefing] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [collapsed, setCollapsed] = useState(() => {
     return localStorage.getItem('briefing_collapsed') === 'true';
   });
@@ -12,14 +282,26 @@ export default function MorningBriefingCard() {
     const d = localStorage.getItem('briefing_dismissed_date');
     return d === new Date().toISOString().split('T')[0];
   });
+  const [narrativeExpanded, setNarrativeExpanded] = useState(false);
+  const [openSections, setOpenSections] = useState({
+    pipeline: true,
+    at_risk: true,
+    conditions: true,
+    stale_leads: false,
+    appointments: true,
+    yesterday: false,
+    team: false,
+  });
 
+  // ----- Fetch today's briefing -----
   const fetchBriefing = useCallback(async () => {
     try {
       const res = await api.get('/api/v1/briefing/today', {
         validateStatus: (status) => status === 200 || status === 204,
       });
       if (res.status === 204) {
-        // No briefing yet — nothing to display
+        // No briefing yet today
+        setBriefing(null);
       } else if (res.data && res.data.status === 'delivered') {
         setBriefing(res.data);
         // Mark as viewed
@@ -27,8 +309,8 @@ export default function MorningBriefingCard() {
           api.post(`/api/v1/briefing/${res.data.id}/viewed`).catch(() => {});
         }
       }
-    } catch (err) {
-      // Silent failure — briefings are supplementary
+    } catch (_err) {
+      // Silent -- briefings are supplementary
     } finally {
       setLoading(false);
     }
@@ -39,6 +321,7 @@ export default function MorningBriefingCard() {
     else setLoading(false);
   }, [dismissed, fetchBriefing]);
 
+  // ----- Actions -----
   const toggleCollapse = () => {
     const next = !collapsed;
     setCollapsed(next);
@@ -50,150 +333,206 @@ export default function MorningBriefingCard() {
     localStorage.setItem('briefing_dismissed_date', new Date().toISOString().split('T')[0]);
   };
 
-  if (loading || dismissed || !briefing) return null;
+  const toggleSection = (key) => {
+    setOpenSections(prev => ({ ...prev, [key]: !prev[key] }));
+  };
 
-  const { ai_narrative, pipeline, at_risk, stale_leads, appointments, team, briefing_level } = briefing;
+  const handleRefresh = async (e) => {
+    e.stopPropagation();
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await api.post('/api/v1/briefing/generate-now?force=true');
+      toast.success('Briefing refresh started -- it may take a moment.');
+      // Poll briefly for the new briefing (generation is async via Celery)
+      setTimeout(async () => {
+        await fetchBriefing();
+        setRefreshing(false);
+      }, 4000);
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      toast.error(detail || 'Could not refresh briefing');
+      setRefreshing(false);
+    }
+  };
+
+  // ----- Compute health indicator -----
+  const computeHealth = () => {
+    if (!briefing) return 'green';
+    const atRiskCount = (briefing.at_risk || []).length;
+    const staleCount = (briefing.stale_leads || []).length;
+    const pastDueConditions = (briefing.conditions || []).filter(c => c.past_due).length;
+    if (pastDueConditions >= 2 || atRiskCount >= 3) return 'red';
+    if (atRiskCount >= 1 || staleCount >= 3 || pastDueConditions >= 1) return 'yellow';
+    return 'green';
+  };
+
+  // ----- Render guards -----
+  if (loading || dismissed) return null;
+  if (!briefing) return null;
+
+  const {
+    ai_narrative,
+    pipeline,
+    at_risk,
+    stale_leads,
+    appointments,
+    conditions,
+    yesterday,
+    team,
+    briefing_level,
+    briefing_date,
+  } = briefing;
+
+  const health = computeHealth();
+  const narrativeText = ai_narrative || '';
+  const showNarrativeTruncated = narrativeText.length > 200 && !narrativeExpanded;
 
   return (
-    <div className="morning-briefing-card">
+    <div className={`morning-briefing-card health-${health}`}>
+      {/* --- Header --- */}
       <div className="briefing-header" onClick={toggleCollapse}>
         <div className="briefing-title">
-          <span className="briefing-icon">&#9728;</span>
+          <span className={`health-indicator ${health}`} title={healthLabel(health)} />
           <h3>Morning Briefing</h3>
-          <span className="briefing-date">{briefing.briefing_date}</span>
+          <span className="health-label">{healthLabel(health)}</span>
+          <span className="briefing-date">{briefing_date}</span>
         </div>
         <div className="briefing-actions">
-          <button className="briefing-collapse-btn" title={collapsed ? 'Expand' : 'Collapse'}>
-            {collapsed ? '▸' : '▾'}
+          <button
+            className="briefing-refresh-btn"
+            onClick={handleRefresh}
+            disabled={refreshing}
+            title="Refresh briefing"
+          >
+            <span className={refreshing ? 'spin' : ''}>&#x21bb;</span>
           </button>
-          <button className="briefing-dismiss-btn" onClick={(e) => { e.stopPropagation(); dismiss(); }} title="Dismiss for today">
-            ✕
+          <button className="briefing-collapse-btn" title={collapsed ? 'Expand' : 'Collapse'}>
+            {collapsed ? '\u25B8' : '\u25BE'}
+          </button>
+          <button
+            className="briefing-dismiss-btn"
+            onClick={(e) => { e.stopPropagation(); dismiss(); }}
+            title="Dismiss for today"
+          >
+            &#x2715;
           </button>
         </div>
       </div>
 
+      {/* --- Body --- */}
       {!collapsed && (
         <div className="briefing-body">
-          {/* AI Priorities */}
-          {ai_narrative && (
-            <div className="briefing-section priorities">
-              <h4>Top 3 Priorities</h4>
-              <div className="priorities-text">{ai_narrative}</div>
+          {/* AI Narrative */}
+          {narrativeText && (
+            <div className="briefing-narrative">
+              <div className={`narrative-text ${showNarrativeTruncated ? 'truncated' : ''}`}>
+                {showNarrativeTruncated ? narrativeText.slice(0, 200) + '...' : narrativeText}
+              </div>
+              {narrativeText.length > 200 && (
+                <button
+                  className="narrative-toggle"
+                  onClick={() => setNarrativeExpanded(!narrativeExpanded)}
+                >
+                  {narrativeExpanded ? 'Show less' : 'Read more'}
+                </button>
+              )}
             </div>
           )}
 
-          {/* Pipeline */}
+          {/* Pipeline Health */}
           {pipeline && pipeline.active_count > 0 && (
             <div className="briefing-section">
-              <h4>Pipeline</h4>
-              <div className="briefing-stats">
-                <span><strong>{pipeline.active_count}</strong> active</span>
-                <span><strong>${(pipeline.total_volume / 1000000).toFixed(1)}M</strong> volume</span>
-                <span><strong>{pipeline.closing_soon}</strong> closing soon</span>
-              </div>
+              <SectionHeader
+                title="Pipeline Health"
+                icon="&#x1F4CA;"
+                count={pipeline.active_count}
+                isOpen={openSections.pipeline}
+                onToggle={() => toggleSection('pipeline')}
+              />
+              {openSections.pipeline && <PipelineSection pipeline={pipeline} />}
             </div>
           )}
 
-          {/* At-Risk */}
+          {/* SLA Alerts / At-Risk */}
           {at_risk && at_risk.length > 0 && (
-            <div className="briefing-section at-risk">
-              <h4>&#9888; At-Risk ({at_risk.length})</h4>
-              <ul>
-                {at_risk.slice(0, 3).map((loan, i) => (
-                  <li key={i}>
-                    <a href={`/loans/${loan.loan_id}`}><strong>{loan.borrower}</strong></a>
-                    {' — '}{loan.reason}
-                  </li>
-                ))}
-              </ul>
+            <div className="briefing-section section-warn">
+              <SectionHeader
+                title="SLA Alerts"
+                icon="&#x26A0;"
+                count={at_risk.length}
+                isOpen={openSections.at_risk}
+                onToggle={() => toggleSection('at_risk')}
+              />
+              {openSections.at_risk && <AtRiskSection items={at_risk} />}
+            </div>
+          )}
+
+          {/* Conditions */}
+          {conditions && conditions.length > 0 && (
+            <div className="briefing-section">
+              <SectionHeader
+                title="Open Conditions"
+                icon="&#x1F4CB;"
+                count={conditions.length}
+                isOpen={openSections.conditions}
+                onToggle={() => toggleSection('conditions')}
+              />
+              {openSections.conditions && <ConditionsSection conditions={conditions} />}
             </div>
           )}
 
           {/* Stale Leads */}
           {stale_leads && stale_leads.length > 0 && (
-            <div className="briefing-section stale-leads">
-              <h4>&#128293; Leads Going Cold ({stale_leads.length})</h4>
-              <ul>
-                {stale_leads.slice(0, 3).map((lead, i) => (
-                  <li key={i}>
-                    <a href={`/leads/${lead.lead_id}`}><strong>{lead.name}</strong></a>
-                    {' (score '}{lead.score}{') — '}{lead.days_silent} days quiet
-                  </li>
-                ))}
-              </ul>
+            <div className="briefing-section section-caution">
+              <SectionHeader
+                title="Lead Activity"
+                icon="&#x1F525;"
+                count={stale_leads.length}
+                isOpen={openSections.stale_leads}
+                onToggle={() => toggleSection('stale_leads')}
+              />
+              {openSections.stale_leads && <StaleLeadsSection leads={stale_leads} />}
             </div>
           )}
 
           {/* Appointments */}
           {appointments && appointments.length > 0 && (
             <div className="briefing-section">
-              <h4>&#128197; Today ({appointments.length})</h4>
-              <ul>
-                {appointments.map((appt, i) => (
-                  <li key={i}><strong>{appt.time}</strong> — {appt.attendee}, {appt.type}</li>
-                ))}
-              </ul>
+              <SectionHeader
+                title="Today's Schedule"
+                icon="&#x1F4C5;"
+                count={appointments.length}
+                isOpen={openSections.appointments}
+                onToggle={() => toggleSection('appointments')}
+              />
+              {openSections.appointments && <AppointmentsSection appointments={appointments} />}
             </div>
           )}
 
-          {/* Team Section (Manager) */}
-          {briefing_level === 'manager' && team && team.members && (
-            <div className="briefing-section team-section">
-              <h4>Your Team</h4>
-              <table className="briefing-table">
-                <thead>
-                  <tr><th>Name</th><th>Loans</th><th>Volume</th><th>Health</th></tr>
-                </thead>
-                <tbody>
-                  {team.members.map((m, i) => (
-                    <tr key={i}>
-                      <td><span className={`health-dot ${m.health}`}></span> {m.name}</td>
-                      <td>{m.loan_count}</td>
-                      <td>${(m.volume / 1000).toFixed(0)}K</td>
-                      <td>{m.health}{m.at_risk_count > 0 ? ` · ${m.at_risk_count} at-risk` : ''}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {team.attention_items && team.attention_items.length > 0 && (
-                <div className="attention-items">
-                  <h5>Attention Needed</h5>
-                  <ul>
-                    {team.attention_items.map((item, i) => (
-                      <li key={i}><strong>{item.user_name}</strong> — {item.issue}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
+          {/* Yesterday Recap */}
+          {yesterday && (yesterday.funded > 0 || yesterday.new_loans > 0 || yesterday.conversions > 0) && (
+            <div className="briefing-section">
+              <SectionHeader
+                title="Yesterday Recap"
+                icon="&#x1F4C8;"
+                isOpen={openSections.yesterday}
+                onToggle={() => toggleSection('yesterday')}
+              />
+              {openSections.yesterday && <YesterdaySection yesterday={yesterday} />}
             </div>
           )}
 
-          {/* Org Section (Leadership) */}
-          {briefing_level === 'leadership' && team && team.branches && (
-            <div className="briefing-section org-section">
-              <h4>Organization Overview</h4>
-              {team.org_snapshot && (
-                <div className="briefing-stats">
-                  <span><strong>{team.org_snapshot.active_count}</strong> active loans</span>
-                  <span><strong>${(team.org_snapshot.total_volume / 1000000).toFixed(1)}M</strong> pipeline</span>
-                  <span><strong>{team.org_snapshot.funded_this_week}</strong> funded this week</span>
-                </div>
-              )}
-              <table className="briefing-table">
-                <thead>
-                  <tr><th>Branch</th><th>Loans</th><th>Volume</th><th>Health</th></tr>
-                </thead>
-                <tbody>
-                  {team.branches.map((b, i) => (
-                    <tr key={i}>
-                      <td><span className={`health-dot ${b.health}`}></span> {b.name}</td>
-                      <td>{b.loan_count}</td>
-                      <td>${(b.volume / 1000000).toFixed(1)}M</td>
-                      <td>{b.health}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+          {/* Team (Manager) / Org (Leadership) */}
+          {team && (briefing_level === 'manager' || briefing_level === 'leadership') && (
+            <div className="briefing-section section-team">
+              <SectionHeader
+                title={briefing_level === 'leadership' ? 'Organization Overview' : 'Your Team'}
+                icon="&#x1F465;"
+                isOpen={openSections.team}
+                onToggle={() => toggleSection('team')}
+              />
+              {openSections.team && <TeamSection team={team} level={briefing_level} />}
             </div>
           )}
         </div>

--- a/frontend/src/config/roleConfig.js
+++ b/frontend/src/config/roleConfig.js
@@ -85,6 +85,11 @@ export const NAVIGATION_ITEMS = {
     label: 'Calendar',
     module: 'base'
   },
+  briefing: {
+    path: '/briefing',
+    label: 'Morning Briefing',
+    module: 'base'
+  },
   scorecard: {
     path: '/scorecard',
     label: 'Scorecard',
@@ -348,6 +353,7 @@ export const ROLE_NAVIGATION = {
     'smartDocs',
     'marketing',            // Marketing page (includes Voice & Call Center, Video OS)
     'calendar',
+    'briefing',             // Morning Briefing page
     'scorecard',            // Scorecard
     'goalTracker',          // Goal Tracker for production goals
     'partners',
@@ -379,6 +385,7 @@ export const ROLE_NAVIGATION = {
     'smartDocs',
     'marketing',            // Marketing page (includes Voice & Call Center, Video OS)
     'calendar',
+    'briefing',             // Morning Briefing page
     'scorecard',
     'goalTracker',          // Goal Tracker for production goals
     'partners',
@@ -405,6 +412,7 @@ export const ROLE_NAVIGATION = {
     'smartDocs',
     'marketing',            // Marketing page includes Voice & Call Center tools
     'calendar',
+    'briefing',             // Morning Briefing page
     'scorecard',            // Scorecard for performance tracking
     'goalTracker',          // Goal Tracker for production goals
     'partners',
@@ -424,6 +432,7 @@ export const ROLE_NAVIGATION = {
     'reconciliation',
     'smartDocs',
     'calendar',
+    'briefing',       // Morning Briefing page
     'aiUnderwriter'
   ],
 
@@ -437,6 +446,7 @@ export const ROLE_NAVIGATION = {
     'reconciliation',
     'smartDocs',
     'calendar',
+    'briefing',       // Morning Briefing page
     'aiUnderwriter'
   ],
 
@@ -448,6 +458,7 @@ export const ROLE_NAVIGATION = {
     'reconciliation',
     'smartDocs',
     'calendar',
+    'briefing',     // Morning Briefing page
     'aiUnderwriter'
   ],
 
@@ -459,6 +470,7 @@ export const ROLE_NAVIGATION = {
     'reconciliation',
     'smartDocs',
     'calendar',
+    'briefing',     // Morning Briefing page
     'aiUnderwriter'
   ],
 
@@ -470,6 +482,7 @@ export const ROLE_NAVIGATION = {
     'reconciliation',
     'smartDocs',
     'calendar',
+    'briefing',     // Morning Briefing page
     'aiUnderwriter'
   ],
 
@@ -484,6 +497,7 @@ export const ROLE_NAVIGATION = {
     'smartDocs',
     'marketing',
     'calendar',
+    'briefing',         // Morning Briefing page
     'scorecard',        // Scorecard for performance tracking
     'goalTracker',      // Goal Tracker for production goals
     'aiUnderwriter',
@@ -498,6 +512,7 @@ export const ROLE_NAVIGATION = {
     'tasks',
     'reconciliation',
     'calendar',
+    'briefing',         // Morning Briefing page
     'accounting',       // Accounting System
     // 'recruiting'  // DEPRECATED: Premium feature deregistered — not yet launched
   ]

--- a/frontend/src/pages/BriefingPage.css
+++ b/frontend/src/pages/BriefingPage.css
@@ -1,0 +1,723 @@
+/* ==========================================================================
+   BriefingPage - Full-page briefing view
+   ========================================================================== */
+
+.briefing-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px 20px 40px;
+}
+
+/* ---------- Page Header ---------- */
+
+.bp-page-header {
+  margin-bottom: 20px;
+}
+
+.bp-page-header h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  color: #1a1a2a;
+}
+
+/* ---------- Tabs ---------- */
+
+.bp-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid #e8e8ed;
+  margin-bottom: 24px;
+}
+
+.bp-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #8888a0;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.bp-tab:hover {
+  color: #4a4a5a;
+}
+
+.bp-tab.active {
+  color: #218d8d;
+  border-bottom-color: #218d8d;
+}
+
+/* ---------- Tab Content ---------- */
+
+.bp-tab-content {
+  min-height: 300px;
+}
+
+/* ---------- Loading / Empty States ---------- */
+
+.briefing-page-loading,
+.briefing-page-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: #8888a0;
+  font-size: 15px;
+}
+
+.briefing-page-empty .bp-btn {
+  margin-top: 16px;
+}
+
+/* ---------- Buttons ---------- */
+
+.bp-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.bp-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bp-btn-primary {
+  background: #218d8d;
+  color: #fff;
+}
+
+.bp-btn-primary:hover:not(:disabled) {
+  background: #1a7a7a;
+}
+
+.bp-btn-secondary {
+  background: #f0f0f4;
+  color: #4a4a5a;
+}
+
+.bp-btn-secondary:hover:not(:disabled) {
+  background: #e2e2ea;
+}
+
+/* ==========================================================================
+   Today Tab
+   ========================================================================== */
+
+.bp-today-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.bp-today-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.bp-today-title h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a2a;
+}
+
+/* Reuse shared briefing CSS classes from MorningBriefingCard */
+
+.briefing-page .health-indicator {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.briefing-page .health-indicator.green { background: #10b981; box-shadow: 0 0 4px #10b98155; }
+.briefing-page .health-indicator.yellow { background: #f59e0b; box-shadow: 0 0 4px #f59e0b55; }
+.briefing-page .health-indicator.red { background: #ef4444; box-shadow: 0 0 4px #ef444455; }
+
+.briefing-page .health-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #8888a0;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.briefing-page .briefing-narrative {
+  background: #f8fbfb;
+  border: 1px solid #e2eded;
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin-bottom: 20px;
+}
+
+.briefing-page .narrative-text {
+  font-size: 14px;
+  line-height: 1.65;
+  color: #1a1a2a;
+  white-space: pre-line;
+}
+
+.briefing-page .briefing-section {
+  background: #ffffff;
+  border: 1px solid #f0f0f4;
+  border-radius: 10px;
+  margin-bottom: 8px;
+  overflow: hidden;
+}
+
+.briefing-page .briefing-section.section-warn .briefing-section-header {
+  color: #ef4444;
+}
+
+.briefing-page .briefing-section.section-caution .briefing-section-header {
+  color: #f59e0b;
+}
+
+.briefing-page .briefing-section.section-team {
+  border-top: 1px solid #e8e8ed;
+  padding-top: 0;
+  margin-top: 8px;
+}
+
+.briefing-page .briefing-section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 12px 16px;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #218d8d;
+  text-align: left;
+}
+
+.briefing-page .briefing-section-header:hover {
+  background: #f5fafa;
+}
+
+.briefing-page .section-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.briefing-page .section-title {
+  flex: 1;
+}
+
+.briefing-page .section-badge {
+  background: #218d8d18;
+  color: #218d8d;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 10px;
+}
+
+.briefing-page .section-warn .section-badge {
+  background: #ef444418;
+  color: #ef4444;
+}
+
+.briefing-page .section-caution .section-badge {
+  background: #f59e0b18;
+  color: #f59e0b;
+}
+
+.briefing-page .section-chevron {
+  color: #aaa;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.briefing-page .section-content {
+  padding: 4px 16px 12px 36px;
+}
+
+.briefing-page .section-empty {
+  font-size: 13px;
+  color: #aaa;
+  padding: 4px 16px 12px 36px;
+  margin: 0;
+}
+
+.briefing-page .metric-row {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.briefing-page .metric-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.briefing-page .metric-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: #1a1a2a;
+  line-height: 1.2;
+}
+
+.briefing-page .metric-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: #8888a0;
+  letter-spacing: 0.3px;
+}
+
+.briefing-page .stage-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.briefing-page .stage-pill {
+  font-size: 11px;
+  background: #f0f0f4;
+  color: #4a4a5a;
+  padding: 3px 10px;
+  border-radius: 12px;
+  white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.briefing-page .stage-pill strong {
+  color: #218d8d;
+  margin-left: 3px;
+}
+
+.briefing-page .briefing-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.briefing-page .briefing-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  font-size: 13px;
+  color: #4a4a5a;
+  border-bottom: 1px solid #f5f5f8;
+  flex-wrap: wrap;
+}
+
+.briefing-page .briefing-list li:last-child {
+  border-bottom: none;
+}
+
+.briefing-page .item-link {
+  color: #218d8d;
+  text-decoration: none;
+}
+
+.briefing-page .item-link:hover {
+  text-decoration: underline;
+}
+
+.briefing-page .item-detail {
+  color: #8888a0;
+  font-size: 12px;
+}
+
+.briefing-page .item-badge {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.briefing-page .item-badge.warn {
+  background: #fef3c7;
+  color: #d97706;
+}
+
+.briefing-page .item-badge.score {
+  background: #dbeafe;
+  color: #2563eb;
+}
+
+.briefing-page .item-loan {
+  font-size: 11px;
+  color: #aaa;
+  margin-left: auto;
+}
+
+.briefing-page .severity-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.briefing-page .severity-dot.critical { background: #ef4444; }
+.briefing-page .severity-dot.high { background: #f59e0b; }
+.briefing-page .severity-dot.medium { background: #3b82f6; }
+.briefing-page .severity-dot.low { background: #8888a0; }
+
+.briefing-page .past-due-banner {
+  background: #fef2f2;
+  color: #ef4444;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 6px;
+  margin-bottom: 6px;
+  display: inline-block;
+}
+
+.briefing-page .conditions-list li.past-due {
+  background: #fefce8;
+  border-radius: 4px;
+  padding-left: 6px;
+}
+
+.briefing-page .appt-time {
+  font-weight: 600;
+  color: #218d8d;
+  min-width: 70px;
+  font-size: 12px;
+}
+
+.briefing-page .briefing-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin-top: 8px;
+}
+
+.briefing-page .briefing-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 11px;
+  text-transform: uppercase;
+  color: #8888a0;
+  border-bottom: 1px solid #e8e8ed;
+  font-weight: 600;
+}
+
+.briefing-page .briefing-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid #f0f0f4;
+  color: #4a4a5a;
+}
+
+.briefing-page .health-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+}
+
+.briefing-page .health-dot.green { background: #10b981; }
+.briefing-page .health-dot.yellow { background: #f59e0b; }
+.briefing-page .health-dot.red { background: #ef4444; }
+
+.briefing-page .attention-items { margin-top: 12px; }
+.briefing-page .attention-items h5 {
+  margin: 0 0 6px;
+  font-size: 12px;
+  color: #ef4444;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.briefing-page .attention-items ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.briefing-page .attention-items li {
+  font-size: 13px;
+  color: #4a4a5a;
+  margin: 4px 0;
+}
+
+/* ==========================================================================
+   History Tab
+   ========================================================================== */
+
+.bp-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bp-history-item {
+  border: 1px solid #f0f0f4;
+  border-radius: 10px;
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+
+.bp-history-item.expanded {
+  border-color: #218d8d44;
+}
+
+.bp-history-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 13px;
+  color: #4a4a5a;
+}
+
+.bp-history-row:hover {
+  background: #f8fbfb;
+}
+
+.bp-history-date {
+  font-weight: 600;
+  color: #1a1a2a;
+  min-width: 90px;
+}
+
+.bp-history-level {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  text-transform: capitalize;
+  background: #f0f0f4;
+  color: #4a4a5a;
+}
+
+.bp-history-level.manager {
+  background: #dbeafe;
+  color: #2563eb;
+}
+
+.bp-history-level.leadership {
+  background: #ede9fe;
+  color: #7c3aed;
+}
+
+.bp-history-status {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  text-transform: capitalize;
+}
+
+.bp-history-status.delivered {
+  background: #d1fae5;
+  color: #059669;
+}
+
+.bp-history-status.pending {
+  background: #fef3c7;
+  color: #d97706;
+}
+
+.bp-history-status.failed {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.bp-history-viewed {
+  font-size: 11px;
+  color: #8888a0;
+}
+
+.bp-history-narrative-preview {
+  flex: 1;
+  font-size: 12px;
+  color: #8888a0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.bp-history-detail {
+  padding: 0 16px 16px;
+  border-top: 1px solid #f0f0f4;
+}
+
+.bp-detail-section {
+  margin-top: 12px;
+}
+
+.bp-detail-section h4 {
+  margin: 0 0 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #218d8d;
+}
+
+.bp-detail-section p {
+  margin: 0;
+  font-size: 13px;
+  color: #4a4a5a;
+}
+
+.bp-load-more {
+  text-align: center;
+  margin-top: 20px;
+}
+
+/* ==========================================================================
+   Preferences Tab
+   ========================================================================== */
+
+.bp-preferences {
+  max-width: 560px;
+}
+
+.bp-pref-group {
+  margin-bottom: 28px;
+}
+
+.bp-pref-group h3 {
+  margin: 0 0 14px;
+  font-size: 15px;
+  font-weight: 700;
+  color: #1a1a2a;
+  border-bottom: 1px solid #f0f0f4;
+  padding-bottom: 8px;
+}
+
+.bp-toggle-row,
+.bp-field-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  font-size: 14px;
+  color: #4a4a5a;
+  cursor: pointer;
+}
+
+.bp-toggle-row + .bp-toggle-row,
+.bp-field-row + .bp-field-row,
+.bp-toggle-row + .bp-field-row,
+.bp-field-row + .bp-toggle-row {
+  border-top: 1px solid #f5f5f8;
+}
+
+.bp-toggle-row input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: #218d8d;
+  cursor: pointer;
+}
+
+.bp-input-number {
+  width: 70px;
+  padding: 6px 10px;
+  border: 1px solid #e0e0e6;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #1a1a2a;
+  text-align: center;
+}
+
+.bp-input-number:focus {
+  outline: none;
+  border-color: #218d8d;
+  box-shadow: 0 0 0 2px #218d8d22;
+}
+
+.bp-select {
+  padding: 6px 12px;
+  border: 1px solid #e0e0e6;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #1a1a2a;
+  background: #fff;
+  cursor: pointer;
+}
+
+.bp-select:focus {
+  outline: none;
+  border-color: #218d8d;
+  box-shadow: 0 0 0 2px #218d8d22;
+}
+
+.bp-pref-actions {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid #e8e8ed;
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+
+@media (max-width: 640px) {
+  .briefing-page {
+    padding: 16px 12px 32px;
+  }
+
+  .bp-page-header h1 {
+    font-size: 20px;
+  }
+
+  .bp-tab {
+    padding: 8px 14px;
+    font-size: 13px;
+  }
+
+  .bp-today-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .briefing-page .section-content {
+    padding-left: 16px;
+  }
+
+  .briefing-page .metric-row {
+    gap: 14px;
+  }
+
+  .briefing-page .metric-value {
+    font-size: 18px;
+  }
+
+  .bp-history-row {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .bp-history-narrative-preview {
+    display: none;
+  }
+
+  .bp-preferences {
+    max-width: 100%;
+  }
+}

--- a/frontend/src/pages/BriefingPage.js
+++ b/frontend/src/pages/BriefingPage.js
@@ -1,0 +1,814 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import api from '../services/api';
+import { toast } from '../utils/toast';
+import './BriefingPage.css';
+
+// ---------------------------------------------------------------------------
+// Shared helpers (same as MorningBriefingCard)
+// ---------------------------------------------------------------------------
+
+function healthLabel(level) {
+  if (level === 'red') return 'Needs Attention';
+  if (level === 'yellow') return 'Monitor';
+  return 'On Track';
+}
+
+function formatVolume(v) {
+  if (!v) return '$0';
+  if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return `$${(v / 1_000).toFixed(0)}K`;
+  return `$${v.toFixed(0)}`;
+}
+
+function SectionHeader({ title, icon, count, isOpen, onToggle }) {
+  return (
+    <button className="briefing-section-header" onClick={onToggle} type="button">
+      <span className="section-icon">{icon}</span>
+      <span className="section-title">{title}</span>
+      {count !== undefined && count > 0 && (
+        <span className="section-badge">{count}</span>
+      )}
+      <span className="section-chevron">{isOpen ? '\u25BE' : '\u25B8'}</span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section sub-components
+// ---------------------------------------------------------------------------
+
+function PipelineSection({ pipeline }) {
+  if (!pipeline || pipeline.active_count === 0) return null;
+  const byStage = pipeline.by_stage || {};
+  const stageEntries = Object.entries(byStage).slice(0, 8);
+  return (
+    <div className="section-content">
+      <div className="metric-row">
+        <div className="metric-item">
+          <span className="metric-value">{pipeline.active_count}</span>
+          <span className="metric-label">Active Loans</span>
+        </div>
+        <div className="metric-item">
+          <span className="metric-value">{formatVolume(pipeline.total_volume)}</span>
+          <span className="metric-label">Pipeline Volume</span>
+        </div>
+        <div className="metric-item">
+          <span className="metric-value">{pipeline.closing_soon || 0}</span>
+          <span className="metric-label">Closing Soon</span>
+        </div>
+      </div>
+      {stageEntries.length > 0 && (
+        <div className="stage-pills">
+          {stageEntries.map(([stage, count]) => (
+            <span className="stage-pill" key={stage}>
+              {stage.replace(/_/g, ' ')} <strong>{count}</strong>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AtRiskSection({ items }) {
+  if (!items || items.length === 0) return <p className="section-empty">No at-risk loans</p>;
+  return (
+    <div className="section-content">
+      <ul className="briefing-list at-risk-list">
+        {items.map((loan, i) => (
+          <li key={loan.loan_id || i}>
+            <a href={`/loans/${loan.loan_id}`} className="item-link">
+              <strong>{loan.borrower}</strong>
+            </a>
+            <span className="item-detail">{loan.reason}</span>
+            {loan.days_in_stage && (
+              <span className="item-badge warn">{Math.round(loan.days_in_stage)}d</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ConditionsSection({ conditions }) {
+  if (!conditions || conditions.length === 0) return <p className="section-empty">No open conditions</p>;
+  const pastDueCount = conditions.filter(c => c.past_due).length;
+  return (
+    <div className="section-content">
+      {pastDueCount > 0 && (
+        <div className="past-due-banner">{pastDueCount} past due</div>
+      )}
+      <ul className="briefing-list conditions-list">
+        {conditions.map((c, i) => (
+          <li key={i} className={c.past_due ? 'past-due' : ''}>
+            <span className={`severity-dot ${c.severity || 'medium'}`} />
+            <span className="item-text">{c.title}</span>
+            {c.loan_number && <span className="item-loan">#{c.loan_number}</span>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function StaleLeadsSection({ leads }) {
+  if (!leads || leads.length === 0) return <p className="section-empty">No stale leads</p>;
+  return (
+    <div className="section-content">
+      <ul className="briefing-list leads-list">
+        {leads.map((lead, i) => (
+          <li key={lead.lead_id || i}>
+            <a href={`/leads/${lead.lead_id}`} className="item-link">
+              <strong>{lead.name}</strong>
+            </a>
+            {lead.score && <span className="item-badge score">Score {lead.score}</span>}
+            <span className="item-detail">{Math.round(lead.days_silent || 0)} days silent</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function AppointmentsSection({ appointments }) {
+  if (!appointments || appointments.length === 0) return <p className="section-empty">No appointments today</p>;
+  return (
+    <div className="section-content">
+      <ul className="briefing-list appointments-list">
+        {appointments.map((appt, i) => (
+          <li key={appt.id || i}>
+            <span className="appt-time">{appt.time}</span>
+            <span className="item-text">{appt.attendee}</span>
+            <span className="item-detail">{appt.type}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function YesterdaySection({ yesterday }) {
+  if (!yesterday) return null;
+  const { funded, new_loans, conversions } = yesterday;
+  if (!funded && !new_loans && !conversions) return <p className="section-empty">No activity yesterday</p>;
+  return (
+    <div className="section-content">
+      <div className="metric-row">
+        {funded > 0 && (
+          <div className="metric-item">
+            <span className="metric-value">{funded}</span>
+            <span className="metric-label">Funded</span>
+          </div>
+        )}
+        {new_loans > 0 && (
+          <div className="metric-item">
+            <span className="metric-value">{new_loans}</span>
+            <span className="metric-label">New Loans</span>
+          </div>
+        )}
+        {conversions > 0 && (
+          <div className="metric-item">
+            <span className="metric-value">{conversions}</span>
+            <span className="metric-label">Conversions</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TeamSection({ team, level }) {
+  if (!team) return null;
+
+  if (level === 'manager' && team.members) {
+    return (
+      <div className="section-content">
+        <table className="briefing-table">
+          <thead>
+            <tr><th>Name</th><th>Loans</th><th>Volume</th><th>Health</th></tr>
+          </thead>
+          <tbody>
+            {team.members.map((m, i) => (
+              <tr key={i}>
+                <td><span className={`health-dot ${m.health}`} /> {m.name}</td>
+                <td>{m.loan_count}</td>
+                <td>{formatVolume(m.volume)}</td>
+                <td>{m.health}{m.at_risk_count > 0 ? ` \u00B7 ${m.at_risk_count} at-risk` : ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {team.attention_items && team.attention_items.length > 0 && (
+          <div className="attention-items">
+            <h5>Attention Needed</h5>
+            <ul>
+              {team.attention_items.map((item, i) => (
+                <li key={i}><strong>{item.user_name}</strong> -- {item.issue}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (level === 'leadership' && team.branches) {
+    return (
+      <div className="section-content">
+        {team.org_snapshot && (
+          <div className="metric-row">
+            <div className="metric-item">
+              <span className="metric-value">{team.org_snapshot.active_count}</span>
+              <span className="metric-label">Active Loans</span>
+            </div>
+            <div className="metric-item">
+              <span className="metric-value">{formatVolume(team.org_snapshot.total_volume)}</span>
+              <span className="metric-label">Pipeline</span>
+            </div>
+            <div className="metric-item">
+              <span className="metric-value">{team.org_snapshot.funded_this_week}</span>
+              <span className="metric-label">Funded This Week</span>
+            </div>
+          </div>
+        )}
+        <table className="briefing-table">
+          <thead>
+            <tr><th>Branch</th><th>Loans</th><th>Volume</th><th>Health</th></tr>
+          </thead>
+          <tbody>
+            {team.branches.map((b, i) => (
+              <tr key={i}>
+                <td><span className={`health-dot ${b.health}`} /> {b.name}</td>
+                <td>{b.loan_count}</td>
+                <td>{formatVolume(b.volume)}</td>
+                <td>{b.health}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Today Tab
+// ---------------------------------------------------------------------------
+
+function TodayTab() {
+  const [briefing, setBriefing] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [openSections, setOpenSections] = useState({
+    pipeline: true,
+    at_risk: true,
+    conditions: true,
+    stale_leads: true,
+    appointments: true,
+    yesterday: true,
+    team: true,
+  });
+
+  const fetchBriefing = useCallback(async () => {
+    try {
+      const res = await api.get('/api/v1/briefing/today', {
+        validateStatus: (status) => status === 200 || status === 204,
+      });
+      if (res.status === 204) {
+        setBriefing(null);
+      } else if (res.data) {
+        setBriefing(res.data);
+        if (res.data.id && !res.data.viewed_in_app) {
+          api.post(`/api/v1/briefing/${res.data.id}/viewed`).catch(() => {});
+        }
+      }
+    } catch (_err) {
+      // Silent failure - briefings are supplementary
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchBriefing(); }, [fetchBriefing]);
+
+  const toggleSection = (key) => {
+    setOpenSections(prev => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleRefresh = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await api.post('/api/v1/briefing/generate-now?force=true');
+      toast.success('Briefing refresh started -- it may take a moment.');
+      setTimeout(async () => {
+        await fetchBriefing();
+        setRefreshing(false);
+      }, 4000);
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      toast.error(detail || 'Could not refresh briefing');
+      setRefreshing(false);
+    }
+  };
+
+  const computeHealth = () => {
+    if (!briefing) return 'green';
+    const atRiskCount = (briefing.at_risk || []).length;
+    const staleCount = (briefing.stale_leads || []).length;
+    const pastDueConditions = (briefing.conditions || []).filter(c => c.past_due).length;
+    if (pastDueConditions >= 2 || atRiskCount >= 3) return 'red';
+    if (atRiskCount >= 1 || staleCount >= 3 || pastDueConditions >= 1) return 'yellow';
+    return 'green';
+  };
+
+  if (loading) {
+    return <div className="briefing-page-loading">Loading today's briefing...</div>;
+  }
+
+  if (!briefing) {
+    return (
+      <div className="briefing-page-empty">
+        <p>No briefing available for today yet.</p>
+        <button className="bp-btn bp-btn-primary" onClick={handleRefresh} disabled={refreshing}>
+          {refreshing ? 'Generating...' : 'Generate Now'}
+        </button>
+      </div>
+    );
+  }
+
+  const {
+    ai_narrative, pipeline, at_risk, stale_leads,
+    appointments, conditions, yesterday, team,
+    briefing_level, briefing_date,
+  } = briefing;
+
+  const health = computeHealth();
+
+  return (
+    <div className="bp-today">
+      <div className="bp-today-header">
+        <div className="bp-today-title">
+          <span className={`health-indicator ${health}`} title={healthLabel(health)} />
+          <h2>{briefing_date || "Today's Briefing"}</h2>
+          <span className="health-label">{healthLabel(health)}</span>
+        </div>
+        <button
+          className="bp-btn bp-btn-secondary"
+          onClick={handleRefresh}
+          disabled={refreshing}
+        >
+          {refreshing ? 'Refreshing...' : 'Refresh'}
+        </button>
+      </div>
+
+      {ai_narrative && (
+        <div className="briefing-narrative">
+          <div className="narrative-text">{ai_narrative}</div>
+        </div>
+      )}
+
+      {pipeline && pipeline.active_count > 0 && (
+        <div className="briefing-section">
+          <SectionHeader
+            title="Pipeline Health"
+            icon=""
+            count={pipeline.active_count}
+            isOpen={openSections.pipeline}
+            onToggle={() => toggleSection('pipeline')}
+          />
+          {openSections.pipeline && <PipelineSection pipeline={pipeline} />}
+        </div>
+      )}
+
+      {at_risk && at_risk.length > 0 && (
+        <div className="briefing-section section-warn">
+          <SectionHeader
+            title="SLA Alerts"
+            icon=""
+            count={at_risk.length}
+            isOpen={openSections.at_risk}
+            onToggle={() => toggleSection('at_risk')}
+          />
+          {openSections.at_risk && <AtRiskSection items={at_risk} />}
+        </div>
+      )}
+
+      {conditions && conditions.length > 0 && (
+        <div className="briefing-section">
+          <SectionHeader
+            title="Open Conditions"
+            icon=""
+            count={conditions.length}
+            isOpen={openSections.conditions}
+            onToggle={() => toggleSection('conditions')}
+          />
+          {openSections.conditions && <ConditionsSection conditions={conditions} />}
+        </div>
+      )}
+
+      {stale_leads && stale_leads.length > 0 && (
+        <div className="briefing-section section-caution">
+          <SectionHeader
+            title="Lead Activity"
+            icon=""
+            count={stale_leads.length}
+            isOpen={openSections.stale_leads}
+            onToggle={() => toggleSection('stale_leads')}
+          />
+          {openSections.stale_leads && <StaleLeadsSection leads={stale_leads} />}
+        </div>
+      )}
+
+      {appointments && appointments.length > 0 && (
+        <div className="briefing-section">
+          <SectionHeader
+            title="Today's Schedule"
+            icon=""
+            count={appointments.length}
+            isOpen={openSections.appointments}
+            onToggle={() => toggleSection('appointments')}
+          />
+          {openSections.appointments && <AppointmentsSection appointments={appointments} />}
+        </div>
+      )}
+
+      {yesterday && (yesterday.funded > 0 || yesterday.new_loans > 0 || yesterday.conversions > 0) && (
+        <div className="briefing-section">
+          <SectionHeader
+            title="Yesterday Recap"
+            icon=""
+            isOpen={openSections.yesterday}
+            onToggle={() => toggleSection('yesterday')}
+          />
+          {openSections.yesterday && <YesterdaySection yesterday={yesterday} />}
+        </div>
+      )}
+
+      {team && (briefing_level === 'manager' || briefing_level === 'leadership') && (
+        <div className="briefing-section section-team">
+          <SectionHeader
+            title={briefing_level === 'leadership' ? 'Organization Overview' : 'Your Team'}
+            icon=""
+            isOpen={openSections.team}
+            onToggle={() => toggleSection('team')}
+          />
+          {openSections.team && <TeamSection team={team} level={briefing_level} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// History Tab
+// ---------------------------------------------------------------------------
+
+function HistoryTab() {
+  const [history, setHistory] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [expandedId, setExpandedId] = useState(null);
+  const perPage = 10;
+
+  const fetchHistory = useCallback(async (pg) => {
+    try {
+      setLoading(true);
+      const res = await api.get(`/api/v1/briefing/history?page=${pg}&per_page=${perPage}`);
+      const items = res.data?.items || res.data || [];
+      if (pg === 1) {
+        setHistory(items);
+      } else {
+        setHistory(prev => [...prev, ...items]);
+      }
+      setHasMore(items.length === perPage);
+    } catch (err) {
+      toast.error('Failed to load briefing history');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchHistory(1); }, [fetchHistory]);
+
+  const loadMore = () => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchHistory(nextPage);
+  };
+
+  const toggleExpand = (id) => {
+    setExpandedId(prev => prev === id ? null : id);
+  };
+
+  if (loading && history.length === 0) {
+    return <div className="briefing-page-loading">Loading history...</div>;
+  }
+
+  if (history.length === 0) {
+    return <div className="briefing-page-empty"><p>No briefing history available.</p></div>;
+  }
+
+  return (
+    <div className="bp-history">
+      <div className="bp-history-list">
+        {history.map((item) => (
+          <div
+            key={item.id}
+            className={`bp-history-item ${expandedId === item.id ? 'expanded' : ''}`}
+          >
+            <button
+              className="bp-history-row"
+              onClick={() => toggleExpand(item.id)}
+              type="button"
+            >
+              <span className="bp-history-date">{item.briefing_date || 'Unknown date'}</span>
+              <span className={`bp-history-level ${item.briefing_level || 'lo'}`}>
+                {item.briefing_level || 'lo'}
+              </span>
+              <span className={`bp-history-status ${item.status || 'unknown'}`}>
+                {item.status || 'unknown'}
+              </span>
+              {item.viewed_in_app && <span className="bp-history-viewed">Viewed</span>}
+              <span className="bp-history-narrative-preview">
+                {(item.ai_narrative || '').slice(0, 100)}
+                {(item.ai_narrative || '').length > 100 ? '...' : ''}
+              </span>
+              <span className="section-chevron">
+                {expandedId === item.id ? '\u25BE' : '\u25B8'}
+              </span>
+            </button>
+            {expandedId === item.id && (
+              <div className="bp-history-detail">
+                {item.ai_narrative && (
+                  <div className="briefing-narrative">
+                    <div className="narrative-text">{item.ai_narrative}</div>
+                  </div>
+                )}
+                {item.pipeline && (
+                  <div className="bp-detail-section">
+                    <h4>Pipeline</h4>
+                    <p>Active: {item.pipeline.active_count}, Volume: {formatVolume(item.pipeline.total_volume)}</p>
+                  </div>
+                )}
+                {item.at_risk && item.at_risk.length > 0 && (
+                  <div className="bp-detail-section">
+                    <h4>At Risk ({item.at_risk.length})</h4>
+                    <ul className="briefing-list">
+                      {item.at_risk.map((loan, i) => (
+                        <li key={i}>{loan.borrower} - {loan.reason}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {item.stale_leads && item.stale_leads.length > 0 && (
+                  <div className="bp-detail-section">
+                    <h4>Stale Leads ({item.stale_leads.length})</h4>
+                    <ul className="briefing-list">
+                      {item.stale_leads.map((lead, i) => (
+                        <li key={i}>{lead.name} - {Math.round(lead.days_silent || 0)} days</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      {hasMore && (
+        <div className="bp-load-more">
+          <button className="bp-btn bp-btn-secondary" onClick={loadMore} disabled={loading}>
+            {loading ? 'Loading...' : 'Load More'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Preferences Tab
+// ---------------------------------------------------------------------------
+
+const SECTION_TOGGLES = [
+  { key: 'pipeline', label: 'Pipeline Health' },
+  { key: 'at_risk', label: 'At-Risk / SLA Alerts' },
+  { key: 'stale_leads', label: 'Stale Leads' },
+  { key: 'appointments', label: 'Appointments' },
+  { key: 'conditions', label: 'Open Conditions' },
+  { key: 'yesterday', label: 'Yesterday Recap' },
+];
+
+const TONE_OPTIONS = [
+  { value: 'concise', label: 'Concise' },
+  { value: 'balanced', label: 'Balanced' },
+  { value: 'detailed', label: 'Detailed' },
+];
+
+function PreferencesTab() {
+  const [prefs, setPrefs] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const fetchPrefs = useCallback(async () => {
+    try {
+      const res = await api.get('/api/v1/briefing/preferences');
+      setPrefs(res.data || {});
+    } catch (err) {
+      toast.error('Failed to load preferences');
+      setPrefs({});
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchPrefs(); }, [fetchPrefs]);
+
+  const handleChange = (field, value) => {
+    setPrefs(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSectionToggle = (key) => {
+    const sections = { ...(prefs.sections || {}) };
+    sections[key] = !sections[key];
+    setPrefs(prev => ({ ...prev, sections }));
+  };
+
+  const handleThresholdChange = (key, value) => {
+    const thresholds = { ...(prefs.thresholds || {}) };
+    thresholds[key] = parseInt(value, 10) || 0;
+    setPrefs(prev => ({ ...prev, thresholds }));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await api.put('/api/v1/briefing/preferences', prefs);
+      toast.success('Preferences saved');
+    } catch (err) {
+      toast.error('Failed to save preferences');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="briefing-page-loading">Loading preferences...</div>;
+  }
+
+  const sections = prefs.sections || {};
+  const thresholds = prefs.thresholds || {};
+
+  return (
+    <div className="bp-preferences">
+      <div className="bp-pref-group">
+        <h3>General</h3>
+        <label className="bp-toggle-row">
+          <span>Briefing Enabled</span>
+          <input
+            type="checkbox"
+            checked={prefs.briefing_enabled !== false}
+            onChange={(e) => handleChange('briefing_enabled', e.target.checked)}
+          />
+        </label>
+        <label className="bp-field-row">
+          <span>Briefing Hour (0-23)</span>
+          <input
+            type="number"
+            min="0"
+            max="23"
+            value={prefs.briefing_hour ?? 7}
+            onChange={(e) => handleChange('briefing_hour', parseInt(e.target.value, 10) || 0)}
+            className="bp-input-number"
+          />
+        </label>
+        <label className="bp-field-row">
+          <span>AI Tone</span>
+          <select
+            value={prefs.ai_tone || 'balanced'}
+            onChange={(e) => handleChange('ai_tone', e.target.value)}
+            className="bp-select"
+          >
+            {TONE_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="bp-pref-group">
+        <h3>Sections</h3>
+        {SECTION_TOGGLES.map(({ key, label }) => (
+          <label key={key} className="bp-toggle-row">
+            <span>{label}</span>
+            <input
+              type="checkbox"
+              checked={sections[key] !== false}
+              onChange={() => handleSectionToggle(key)}
+            />
+          </label>
+        ))}
+      </div>
+
+      <div className="bp-pref-group">
+        <h3>Thresholds</h3>
+        <label className="bp-field-row">
+          <span>At-Risk Days</span>
+          <input
+            type="number"
+            min="1"
+            max="90"
+            value={thresholds.at_risk_days ?? 7}
+            onChange={(e) => handleThresholdChange('at_risk_days', e.target.value)}
+            className="bp-input-number"
+          />
+        </label>
+        <label className="bp-field-row">
+          <span>Stale Lead Days</span>
+          <input
+            type="number"
+            min="1"
+            max="90"
+            value={thresholds.stale_lead_days ?? 14}
+            onChange={(e) => handleThresholdChange('stale_lead_days', e.target.value)}
+            className="bp-input-number"
+          />
+        </label>
+        <label className="bp-field-row">
+          <span>Stale Lead (High Score) Days</span>
+          <input
+            type="number"
+            min="1"
+            max="90"
+            value={thresholds.stale_lead_high_score_days ?? 7}
+            onChange={(e) => handleThresholdChange('stale_lead_high_score_days', e.target.value)}
+            className="bp-input-number"
+          />
+        </label>
+        <label className="bp-field-row">
+          <span>Lock Expiring Days</span>
+          <input
+            type="number"
+            min="1"
+            max="30"
+            value={thresholds.lock_expiring_days ?? 5}
+            onChange={(e) => handleThresholdChange('lock_expiring_days', e.target.value)}
+            className="bp-input-number"
+          />
+        </label>
+      </div>
+
+      <div className="bp-pref-actions">
+        <button className="bp-btn bp-btn-primary" onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving...' : 'Save Preferences'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main BriefingPage
+// ---------------------------------------------------------------------------
+
+const TABS = [
+  { key: 'today', label: 'Today' },
+  { key: 'history', label: 'History' },
+  { key: 'preferences', label: 'Preferences' },
+];
+
+export default function BriefingPage() {
+  const [activeTab, setActiveTab] = useState('today');
+
+  return (
+    <div className="briefing-page">
+      <div className="bp-page-header">
+        <h1>Morning Briefing</h1>
+      </div>
+
+      <div className="bp-tabs">
+        {TABS.map(tab => (
+          <button
+            key={tab.key}
+            className={`bp-tab ${activeTab === tab.key ? 'active' : ''}`}
+            onClick={() => setActiveTab(tab.key)}
+            type="button"
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="bp-tab-content">
+        {activeTab === 'today' && <TodayTab />}
+        {activeTab === 'history' && <HistoryTab />}
+        {activeTab === 'preferences' && <PreferencesTab />}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/aria/AriaMortgageCalculator.css
+++ b/frontend/src/pages/aria/AriaMortgageCalculator.css
@@ -1,11 +1,53 @@
 /* Aria Mortgage Calculator — Mobile-first input form */
 
 .aria-calc-page {
+  /* White-label theme variables — override per tenant */
+  --aria-color-primary: #111827;
+  --aria-color-primary-hover: #374151;
+  --aria-color-bg: #ffffff;
+  --aria-color-bg-secondary: #f9fafb;
+  --aria-color-bg-tertiary: #f3f4f6;
+  --aria-color-border: #e5e7eb;
+  --aria-color-border-light: #d1d5db;
+  --aria-color-text-primary: #111827;
+  --aria-color-text-secondary: #374151;
+  --aria-color-text-tertiary: #6b7280;
+  --aria-color-text-muted: #9ca3af;
+  --aria-color-accent: #1a73e8;
+  --aria-color-accent-light: rgba(26, 115, 232, 0.15);
+  --aria-color-success: #059669;
+  --aria-color-warning: #d97706;
+  --aria-color-error: #dc2626;
+  --aria-color-error-light: #fef2f2;
+  --aria-color-error-border: #fecaca;
+
+  /* Workflow status colors */
+  --aria-workflow-active-bg: #f0fdf4;
+  --aria-workflow-active-border: #bbf7d0;
+  --aria-workflow-failed-bg: #fef2f2;
+  --aria-workflow-failed-border: #fecaca;
+  --aria-workflow-expired-opacity: 0.6;
+
+  /* Touch targets */
+  --aria-touch-target-min: 44px;
+
+  /* Border radius */
+  --aria-radius-sm: 8px;
+  --aria-radius-md: 10px;
+  --aria-radius-lg: 12px;
+  --aria-radius-xl: 16px;
+
+  /* Shadows */
+  --aria-shadow-sm: rgba(0, 0, 0, 0.2);
+
+  /* Calc-specific body text (slightly different shade than primary) */
+  --aria-calc-body-text: #1f2937;
+
   min-height: 100vh;
   min-height: -webkit-fill-available;
-  background: #fff;
+  background: var(--aria-color-bg);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  color: #1f2937;
+  color: var(--aria-calc-body-text);
   padding-bottom: calc(72px + env(safe-area-inset-bottom, 0px));
 }
 
@@ -28,7 +70,7 @@
 }
 
 .aria-calc-back:active {
-  background: #f3f4f6;
+  background: var(--aria-color-bg-tertiary);
 }
 
 /* Content */
@@ -39,13 +81,13 @@
 .aria-calc-title {
   font-size: 28px;
   font-weight: 800;
-  color: #111827;
+  color: var(--aria-color-text-primary);
   margin: 0 0 6px;
 }
 
 .aria-calc-subtitle {
   font-size: 15px;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary);
   margin: 0 0 24px;
   line-height: 1.4;
 }
@@ -62,7 +104,7 @@
   margin-bottom: 20px;
   font-size: 16px;
   font-weight: 700;
-  color: #111827;
+  color: var(--aria-color-text-primary);
 }
 
 .aria-calc-section-icon {
@@ -84,21 +126,21 @@
   display: block;
   font-size: 14px;
   font-weight: 500;
-  color: #374151;
+  color: var(--aria-color-text-secondary);
   margin-bottom: 6px;
 }
 
 .aria-calc-label-hint {
   font-weight: 400;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted);
 }
 
 /* Toggle group (Purchase / Refinance, loan term) */
 .aria-calc-toggle-group {
   display: flex;
   gap: 0;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
+  border: 1px solid var(--aria-color-border-light);
+  border-radius: var(--aria-radius-md);
   overflow: hidden;
 }
 
@@ -110,14 +152,14 @@
   gap: 8px;
   padding: 12px 16px;
   border: none;
-  background: #fff;
+  background: var(--aria-color-bg);
   font-size: 15px;
   font-weight: 500;
-  color: #374151;
+  color: var(--aria-color-text-secondary);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   transition: background 0.15s ease;
-  border-right: 1px solid #d1d5db;
+  border-right: 1px solid var(--aria-color-border-light);
 }
 
 .aria-calc-toggle:last-child {
@@ -125,7 +167,7 @@
 }
 
 .aria-calc-toggle--active {
-  background: #f3f4f6;
+  background: var(--aria-color-bg-tertiary);
   font-weight: 600;
 }
 
@@ -133,14 +175,14 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  border: 2px solid #d1d5db;
+  border: 2px solid var(--aria-color-border-light);
   flex-shrink: 0;
 }
 
 .aria-calc-toggle__radio--checked {
-  border-color: #111827;
-  background: #111827;
-  box-shadow: inset 0 0 0 3px #fff;
+  border-color: var(--aria-color-primary);
+  background: var(--aria-color-primary);
+  box-shadow: inset 0 0 0 3px var(--aria-color-bg);
 }
 
 /* Select dropdown */
@@ -151,11 +193,11 @@
 .aria-calc-select {
   width: 100%;
   padding: 12px 40px 12px 14px;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
-  background: #fff;
+  border: 1px solid var(--aria-color-border-light);
+  border-radius: var(--aria-radius-md);
+  background: var(--aria-color-bg);
   font-size: 16px;
-  color: #111827;
+  color: var(--aria-color-text-primary);
   appearance: none;
   -webkit-appearance: none;
   cursor: pointer;
@@ -163,8 +205,8 @@
 
 .aria-calc-select:focus {
   outline: none;
-  border-color: #1a73e8;
-  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.15);
+  border-color: var(--aria-color-accent);
+  box-shadow: 0 0 0 2px var(--aria-color-accent-light);
 }
 
 .aria-calc-select-arrow {
@@ -173,7 +215,7 @@
   top: 50%;
   transform: translateY(-50%);
   pointer-events: none;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary);
   font-size: 14px;
 }
 
@@ -187,24 +229,24 @@
   border: none;
   background: transparent;
   font-size: 13px;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }
 
 .aria-calc-info-link:active {
-  color: #374151;
+  color: var(--aria-color-text-secondary);
 }
 
 .aria-calc-info-box {
   margin-top: 8px;
   padding: 12px;
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
+  background: var(--aria-color-bg-secondary);
+  border: 1px solid var(--aria-color-border);
+  border-radius: var(--aria-radius-md);
   font-size: 14px;
   line-height: 1.5;
-  color: #374151;
+  color: var(--aria-color-text-secondary);
 }
 
 .aria-calc-info-box strong {
@@ -220,28 +262,28 @@
 .aria-calc-currency-input {
   display: flex;
   align-items: center;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
+  border: 1px solid var(--aria-color-border-light);
+  border-radius: var(--aria-radius-md);
   overflow: hidden;
-  background: #fff;
+  background: var(--aria-color-bg);
 }
 
 .aria-calc-currency-input:focus-within {
-  border-color: #1a73e8;
-  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.15);
+  border-color: var(--aria-color-accent);
+  box-shadow: 0 0 0 2px var(--aria-color-accent-light);
 }
 
 .aria-calc-currency-prefix {
   padding: 12px 0 12px 14px;
   font-size: 16px;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted);
   flex-shrink: 0;
 }
 
 .aria-calc-currency-suffix {
   padding: 12px 14px 12px 0;
   font-size: 16px;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted);
   flex-shrink: 0;
 }
 
@@ -252,7 +294,7 @@
   border: none;
   background: transparent;
   font-size: 16px;
-  color: #111827;
+  color: var(--aria-color-text-primary);
   outline: none;
 }
 
@@ -268,7 +310,7 @@
   margin: 10px 0 4px;
   -webkit-appearance: none;
   appearance: none;
-  background: #e5e7eb;
+  background: var(--aria-color-border);
   border-radius: 3px;
   outline: none;
 }
@@ -278,9 +320,9 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: #111827;
-  border: 3px solid #fff;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  background: var(--aria-color-primary);
+  border: 3px solid var(--aria-color-bg);
+  box-shadow: 0 1px 4px var(--aria-shadow-sm);
   cursor: pointer;
 }
 
@@ -288,9 +330,9 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: #111827;
-  border: 3px solid #fff;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  background: var(--aria-color-primary);
+  border: 3px solid var(--aria-color-bg);
+  box-shadow: 0 1px 4px var(--aria-shadow-sm);
   cursor: pointer;
 }
 
@@ -298,12 +340,12 @@
   display: flex;
   justify-content: space-between;
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--aria-color-text-muted);
 }
 
 .aria-calc-slider-value {
   font-weight: 700;
-  color: #111827;
+  color: var(--aria-color-text-primary);
   font-size: 16px;
 }
 
@@ -312,9 +354,9 @@
   width: 100%;
   padding: 16px;
   border: none;
-  border-radius: 12px;
-  background: #111827;
-  color: #fff;
+  border-radius: var(--aria-radius-lg);
+  background: var(--aria-color-primary);
+  color: var(--aria-color-bg);
   font-size: 16px;
   font-weight: 600;
   cursor: pointer;
@@ -324,27 +366,27 @@
 }
 
 .aria-calc-submit:active {
-  background: #374151;
+  background: var(--aria-color-primary-hover);
 }
 
 /* Results */
 .aria-calc-results {
   margin-top: 24px;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
+  border: 1px solid var(--aria-color-border);
+  border-radius: var(--aria-radius-xl);
   overflow: hidden;
 }
 
 .aria-calc-results__total {
   padding: 20px;
-  background: #f9fafb;
+  background: var(--aria-color-bg-secondary);
   text-align: center;
 }
 
 .aria-calc-results__total-label {
   display: block;
   font-size: 14px;
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary);
   margin-bottom: 4px;
 }
 
@@ -352,7 +394,7 @@
   display: block;
   font-size: 36px;
   font-weight: 800;
-  color: #111827;
+  color: var(--aria-color-text-primary);
 }
 
 .aria-calc-results__breakdown {
@@ -365,17 +407,17 @@
   align-items: center;
   padding: 8px 0;
   font-size: 15px;
-  color: #374151;
+  color: var(--aria-color-text-secondary);
 }
 
 .aria-calc-results__row--loan {
-  color: #6b7280;
+  color: var(--aria-color-text-tertiary);
   font-size: 14px;
 }
 
 .aria-calc-results__divider {
   height: 1px;
-  background: #e5e7eb;
+  background: var(--aria-color-border);
   margin: 4px 0;
 }
 


### PR DESCRIPTION
## Summary

- **Morning Briefing Page** (`/briefing`): Standalone page with Today, History, and Preferences tabs. Rich MorningBriefingCard with health indicators and animations
- **Voice Workflow State Machine**: Re-wired voice tool handler to VoiceWorkflow state machine for better call flow management
- **Voice CI Bridge**: Improved call intelligence bridge service with intent routing refinements
- **Demo Data Seeding**: `seed_demo_org.py` script for sales demos with cleanup capability
- **Aria Mobile**: Capacitor config updates, mortgage calculator CSS refinements

## Files Changed (23 files, +3,930 / -373 lines)

### Backend
- Voice tool handlers, intent router, deepgram agent, telnyx webhooks
- Voice CI bridge service improvements
- Demo data seeding script + admin ops routes
- New test: `test_voice_tool_handler_scheduling.py` (303 lines)

### Frontend
- New `/briefing` page (814 lines JS + 723 lines CSS)
- Enhanced MorningBriefingCard with health indicators
- Capacitor config and Aria calculator mobile fixes
- Role config updates

## Test Plan
- [x] Production build compiles clean
- [ ] Navigate to `/briefing` — verify tabs load
- [ ] Test voice call flow with scheduling intent
- [ ] Run `python backend/scripts/seed_demo_org.py` to verify demo seeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)