### PR TITLE
fix: aria-mobile voice silence — autoplay unlock, backend error propagation, LiveKit watchdog

### DIFF
--- a/backend/mobile_voice_routes.py
+++ b/backend/mobile_voice_routes.py
@@ -233,7 +233,7 @@ class ElevenLabsTTSClient:
                 if response.status_code != 200:
                     error_text = await response.aread()
                     logger.error(f"[ElevenLabsTTS] Error: {response.status_code} - {error_text}")
-                    return
+                    raise RuntimeError(f"ElevenLabs returned {response.status_code}")
 
                 async for chunk in response.aiter_bytes(chunk_size=4096):
                     yield chunk
@@ -274,8 +274,8 @@ class OpenAITTSClient:
             response = await client.post(url, json=payload, headers=headers, timeout=30.0)
 
             if response.status_code != 200:
-                logger.error(f"[OpenAITTS] Error: {response.status_code}")
-                return b""
+                logger.error(f"[OpenAITTS] Error: {response.status_code} - {response.text[:200]}")
+                raise RuntimeError(f"OpenAI TTS returned {response.status_code}")
 
             return response.content
 
@@ -1078,16 +1078,25 @@ async def synthesize_text(request: Request, db: Session = Depends(get_db)):
     try:
         audio = await tts.synthesize(text)
 
-        logger.info(f"[TTS] Synthesized with provider={provider}, voice_id={voice_id}")
+        if not audio:
+            logger.error(f"[TTS] Provider returned empty audio (provider={type(tts).__name__})")
+            raise HTTPException(502, "TTS provider returned empty audio")
+
+        logger.info(
+            f"[TTS] Synthesized {len(audio)} bytes "
+            f"(client={type(tts).__name__}, provider_param={provider}, voice_id={voice_id})"
+        )
 
         return {
             "audio": base64.b64encode(audio).decode("utf-8"),
             "format": "mp3"
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"[TTS] Error: {e}")
-        raise HTTPException(500, "TTS synthesis failed")
+        logger.error(f"[TTS] Error: {e}", exc_info=True)
+        raise HTTPException(502, f"TTS synthesis failed: {type(e).__name__}")
 
 
 @router.get("/voices")

--- a/backend/mobile_voice_routes.py
+++ b/backend/mobile_voice_routes.py
@@ -13,6 +13,7 @@ import json
 import asyncio
 import base64
 import os
+import re
 import time
 import httpx
 from typing import Optional, Dict, Any, AsyncGenerator, List, TYPE_CHECKING
@@ -1082,9 +1083,13 @@ async def synthesize_text(request: Request, db: Session = Depends(get_db)):
             logger.error(f"[TTS] Provider returned empty audio (provider={type(tts).__name__})")
             raise HTTPException(502, "TTS provider returned empty audio")
 
+        # Sanitize user-supplied values before logging to avoid log injection
+        # (CodeQL: log entries should not contain unescaped user input).
+        safe_provider = re.sub(r"[^A-Za-z0-9_\-]", "", str(provider))[:32] if provider else "auto"
+        safe_voice_id = re.sub(r"[^A-Za-z0-9_\-]", "", str(voice_id))[:64] if voice_id else "default"
         logger.info(
-            f"[TTS] Synthesized {len(audio)} bytes "
-            f"(client={type(tts).__name__}, provider_param={provider}, voice_id={voice_id})"
+            "[TTS] Synthesized %d bytes (client=%s, provider_param=%s, voice_id=%s)",
+            len(audio), type(tts).__name__, safe_provider, safe_voice_id,
         )
 
         return {

--- a/frontend/src/pages/aria-mobile/AriaVoiceHome.jsx
+++ b/frontend/src/pages/aria-mobile/AriaVoiceHome.jsx
@@ -95,12 +95,26 @@ function DisconnectIcon() {
 // LiveKit Voice Agent UI — renders inside LiveKitRoom context
 // ---------------------------------------------------------------------------
 
-function LiveKitVoiceUI({ onDisconnect, ciPanelOpen, setCiPanelOpen }) {
+function LiveKitVoiceUI({ onDisconnect, onAgentMissing, ciPanelOpen, setCiPanelOpen }) {
   const voiceAssistant = useVoiceAssistant();
   const room = useRoomContext();
 
   // Map LiveKit agent state to our UI states
   const agentState = voiceAssistant?.state || 'idle';
+
+  // Watchdog: if no agent audio track shows up within 8s of connecting,
+  // assume the aria-voice worker isn't running (or Cartesia is misconfigured)
+  // and fall back to SSE mode so the user gets a working assistant.
+  useEffect(() => {
+    if (voiceAssistant?.audioTrack) return;
+    const t = setTimeout(() => {
+      if (!voiceAssistant?.audioTrack) {
+        console.warn('[LiveKit] No agent audio track after 8s — falling back to SSE');
+        onAgentMissing?.();
+      }
+    }, 8000);
+    return () => clearTimeout(t);
+  }, [voiceAssistant?.audioTrack, onAgentMissing]);
 
   // voiceAssistant.state can be: 'idle' | 'listening' | 'thinking' | 'speaking'
   const voiceState = (() => {
@@ -239,28 +253,35 @@ function unlockAudioPlayback() {
 
 function _speakViaBrowser(text, abortedRef) {
   return new Promise((resolve) => {
-    if (!window.speechSynthesis) { resolve(); return; }
+    if (!window.speechSynthesis || typeof SpeechSynthesisUtterance === 'undefined') {
+      resolve(false);
+      return;
+    }
     try {
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.rate = 1.0;
       utterance.pitch = 1.0;
-      utterance.onend = resolve;
-      utterance.onerror = resolve;
-      if (abortedRef?.()) { resolve(); return; }
+      let settled = false;
+      const finish = (ok) => { if (!settled) { settled = true; resolve(ok); } };
+      utterance.onend = () => finish(true);
+      utterance.onerror = () => finish(false);
+      if (abortedRef?.()) { finish(false); return; }
       window.speechSynthesis.speak(utterance);
     } catch {
-      resolve();
+      resolve(false);
     }
   });
 }
 
 class TTSQueue {
-  constructor() {
+  constructor({ onFailure } = {}) {
     this._queue = [];
     this._playing = false;
     this._aborted = false;
     this._currentBlobUrl = null;
     this._onAllDone = null;
+    this._onFailure = onFailure;
+    this._failureNotified = false;
   }
 
   enqueue(text) {
@@ -319,12 +340,22 @@ class TTSQueue {
       playedViaApi = playOk;
     } catch (err) {
       if (this._aborted) return;
-      console.warn('[TTSQueue] TTS API failed:', err.message);
+      const status = err?.response?.status;
+      const detail = err?.response?.data?.detail || err?.message || 'unknown';
+      console.warn(`[TTSQueue] TTS API failed (status=${status}):`, detail);
+      if (!this._failureNotified && this._onFailure) {
+        this._failureNotified = true;
+        this._onFailure({ status, detail });
+      }
     }
     if (!this._aborted && !playedViaApi) {
       // Fall through to browser speechSynthesis when API failed OR audio
       // playback was blocked (mobile autoplay policy).
-      await _speakViaBrowser(text, () => this._aborted);
+      const spokeOk = await _speakViaBrowser(text, () => this._aborted);
+      if (!spokeOk && !this._failureNotified && this._onFailure) {
+        this._failureNotified = true;
+        this._onFailure({ status: 0, detail: 'Audio playback blocked and no speech synthesis available' });
+      }
     }
     if (!this._aborted) this._playNext();
   }
@@ -488,7 +519,18 @@ export default function AriaVoiceHome() {
     streamRef.current?.abort();
     ttsQueueRef.current?.stop();
 
-    const queue = new TTSQueue();
+    const queue = new TTSQueue({
+      onFailure: ({ status, detail }) => {
+        const msg = status === 502
+          ? 'Voice service is down — showing text response.'
+          : status === 401
+            ? 'Voice service auth error — showing text response.'
+            : `Audio failed (${detail || 'unknown'}) — showing text response.`;
+        clearTimeout(actionToastTimerRef.current);
+        setActionToast(msg);
+        actionToastTimerRef.current = setTimeout(() => setActionToast(null), 8000);
+      },
+    });
     ttsQueueRef.current = queue;
     queue.onAllDone(() => {
       setVoiceState('idle');
@@ -663,6 +705,11 @@ export default function AriaVoiceHome() {
       {lkConnected && LiveKitRoom && lkToken && lkUrl ? (
         <LiveKitVoiceUI
           onDisconnect={disconnectLiveKit}
+          onAgentMissing={() => {
+            disconnectLiveKit();
+            setLkAvailable(false);
+            setLkError('Voice agent unavailable — using text-to-speech mode');
+          }}
           ciPanelOpen={ciPanelOpen}
           setCiPanelOpen={setCiPanelOpen}
         />

--- a/frontend/src/pages/aria-mobile/AriaVoiceHome.jsx
+++ b/frontend/src/pages/aria-mobile/AriaVoiceHome.jsx
@@ -200,12 +200,65 @@ function extractSentences(buffer) {
   return { sentences, leftover: leftover.replace(/\x00/g, '.') };
 }
 
+// Shared <audio> element kept hot from the user gesture so iOS Safari /
+// mobile Chrome don't reject playback later when the TTS response arrives.
+// A single element reused across plays keeps the autoplay grant alive.
+let _sharedAudioEl = null;
+
+function _getSharedAudio() {
+  if (_sharedAudioEl) return _sharedAudioEl;
+  const a = new Audio();
+  a.preload = 'auto';
+  a.playsInline = true;
+  a.setAttribute('playsinline', 'true');
+  a.setAttribute('webkit-playsinline', 'true');
+  _sharedAudioEl = a;
+  return a;
+}
+
+// Call from inside a user gesture (mic tap). Plays a silent data URI to
+// satisfy mobile autoplay policy so subsequent .play() calls succeed.
+function unlockAudioPlayback() {
+  try {
+    const a = _getSharedAudio();
+    // Tiny silent MP3 (44 bytes) — enough to mark the element as user-activated.
+    a.src = 'data:audio/mp3;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4Ljc2LjEwMAAAAAAAAAAAAAAA//tQxAADB8AhSmxhIIEVCSiJrDCQBTcu3UrAIwUdkRgQbFAZC1CQEwTJ9mjRvBA4UOLD8nKVOWfh+UlK3z/177OXrfOdKl7097LFr89j9xC0fXmHkxpe/2T29c8w1+t4Hgv/0M3l+B+f/r8eHQEoBgAEoCwAAQ8AAAAA//tQxAQAB+wTKsCEYDDfA+ToEMwIA8AAAAA';
+    a.muted = true;
+    const p = a.play();
+    if (p && typeof p.then === 'function') {
+      p.then(() => {
+        a.pause();
+        a.muted = false;
+        try { a.currentTime = 0; } catch { /* noop */ }
+      }).catch(() => {
+        a.muted = false;
+      });
+    }
+  } catch { /* best effort */ }
+}
+
+function _speakViaBrowser(text, abortedRef) {
+  return new Promise((resolve) => {
+    if (!window.speechSynthesis) { resolve(); return; }
+    try {
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.rate = 1.0;
+      utterance.pitch = 1.0;
+      utterance.onend = resolve;
+      utterance.onerror = resolve;
+      if (abortedRef?.()) { resolve(); return; }
+      window.speechSynthesis.speak(utterance);
+    } catch {
+      resolve();
+    }
+  });
+}
+
 class TTSQueue {
   constructor() {
     this._queue = [];
     this._playing = false;
     this._aborted = false;
-    this._currentAudio = null;
     this._currentBlobUrl = null;
     this._onAllDone = null;
   }
@@ -225,6 +278,7 @@ class TTSQueue {
     this._playing = true;
     const batch = this._queue.splice(0, Math.min(2, this._queue.length));
     const text = batch.join(' ');
+    let playedViaApi = false;
     try {
       const res = await api.post('/api/v1/mobile-voice/tts/synthesize', {
         text,
@@ -239,28 +293,38 @@ class TTSQueue {
       const blob = new Blob([bytes], { type: 'audio/mpeg' });
       const url = URL.createObjectURL(blob);
       this._currentBlobUrl = url;
-      await new Promise((resolve) => {
-        const audio = new Audio(url);
-        this._currentAudio = audio;
-        const cleanup = () => { URL.revokeObjectURL(url); this._currentAudio = null; this._currentBlobUrl = null; };
-        audio.onended = () => { cleanup(); resolve(); };
-        audio.onerror = () => { cleanup(); resolve(); };
-        audio.play().catch(() => { cleanup(); resolve(); });
+      const audio = _getSharedAudio();
+      audio.muted = false;
+      audio.volume = 1.0;
+      audio.src = url;
+      try { audio.load(); } catch { /* noop */ }
+      const playOk = await new Promise((resolve) => {
+        const cleanup = () => {
+          URL.revokeObjectURL(url);
+          if (this._currentBlobUrl === url) this._currentBlobUrl = null;
+          audio.onended = null;
+          audio.onerror = null;
+        };
+        audio.onended = () => { cleanup(); resolve(true); };
+        audio.onerror = () => { cleanup(); resolve(false); };
+        const p = audio.play();
+        if (p && typeof p.then === 'function') {
+          p.catch((err) => {
+            console.warn('[TTSQueue] audio.play() rejected:', err?.name || err);
+            cleanup();
+            resolve(false);
+          });
+        }
       });
+      playedViaApi = playOk;
     } catch (err) {
       if (this._aborted) return;
-      console.warn('[TTSQueue] TTS API failed, falling back to browser speech:', err.message);
-      // Fallback: use browser's built-in speech synthesis
-      if (window.speechSynthesis) {
-        await new Promise((resolve) => {
-          const utterance = new SpeechSynthesisUtterance(text);
-          utterance.rate = 1.0;
-          utterance.pitch = 1.0;
-          utterance.onend = resolve;
-          utterance.onerror = resolve;
-          window.speechSynthesis.speak(utterance);
-        });
-      }
+      console.warn('[TTSQueue] TTS API failed:', err.message);
+    }
+    if (!this._aborted && !playedViaApi) {
+      // Fall through to browser speechSynthesis when API failed OR audio
+      // playback was blocked (mobile autoplay policy).
+      await _speakViaBrowser(text, () => this._aborted);
     }
     if (!this._aborted) this._playNext();
   }
@@ -268,14 +332,18 @@ class TTSQueue {
   stop() {
     this._aborted = true;
     this._queue = [];
-    if (this._currentAudio) {
-      this._currentAudio.pause();
-      this._currentAudio.currentTime = 0;
-      this._currentAudio = null;
+    if (_sharedAudioEl) {
+      try {
+        _sharedAudioEl.pause();
+        _sharedAudioEl.currentTime = 0;
+      } catch { /* noop */ }
     }
     if (this._currentBlobUrl) {
       URL.revokeObjectURL(this._currentBlobUrl);
       this._currentBlobUrl = null;
+    }
+    if (window.speechSynthesis) {
+      try { window.speechSynthesis.cancel(); } catch { /* noop */ }
     }
   }
 
@@ -513,6 +581,10 @@ export default function AriaVoiceHome() {
 
   // ---- Mic tap handler ----
   const handleMicTap = useCallback(() => {
+    // Unlock audio inside the user gesture so iOS Safari / mobile Chrome
+    // permit the deferred TTS playback that arrives later via SSE.
+    unlockAudioPlayback();
+
     // LiveKit mode
     if (lkAvailable) {
       if (lkConnected) {


### PR DESCRIPTION
Aria was silent on `/aria-mobile` because of three independent failures, all of which masked each other:

## Root causes

1. **Mobile autoplay policy was rejecting `audio.play()`** once the SSE response arrived, and the rejection was silently swallowed by `audio.play().catch(() => resolve())`. The `speechSynthesis` fallback only fired on TTS API errors, not on playback rejection — so Aria stayed mute with no error.
2. **Backend `/api/v1/mobile-voice/tts/synthesize` was returning HTTP 200 with an empty audio string** when ElevenLabs/OpenAI returned a non-200 (the streaming clients used bare `return` / `return b""`). Empty audio → silent.
3. **In LiveKit mode the SSE/TTS code never runs at all** — the `aria-voice` agent worker is responsible for audio over WebRTC. If that worker isn't running (or `CARTESIA_API_KEY` is missing) the user sits in an empty room indefinitely.

## Changes

**Frontend (`AriaVoiceHome.jsx`)**
- Unlock audio in the mic-tap user gesture via a shared `<audio>` element (silent MP3 + `playsinline`).
- Reuse that hot element for every TTS chunk so the autoplay grant carries across the SSE → TTS round-trip.
- Treat a rejected `audio.play()` the same as a TTS API failure — fall through to `window.speechSynthesis`.
- Cancel pending utterances on `stop()`.
- 8s LiveKit watchdog: if the agent never publishes an audio track, drop LiveKit and fall back to SSE+TTS.
- Surface TTS failures to the user via the existing action toast ("Voice service is down — showing text response") instead of failing silently.

**Backend (`mobile_voice_routes.py`)**
- `ElevenLabsTTSClient` and `OpenAITTSClient` now `raise` on non-200 responses instead of returning empty audio.
- `/tts/synthesize` rejects empty-audio responses with HTTP 502 and includes the exception class in the error detail.
- Success log now includes byte count + the chosen TTS client class so you can grep logs to see which provider answered.

## Test plan

- [ ] Deploy to staging/prod, hard-reload `/aria-mobile` on iOS Safari and mobile Chrome.
- [ ] Tap mic → speak → confirm Aria responds with audio.
- [ ] If audio is still blocked, check browser console for `[TTSQueue] audio.play() rejected:` (means the gesture chain is still being broken — investigate further) or `[TTSQueue] TTS API failed (status=502)` (means the backend provider is misconfigured — check Railway logs for `[ElevenLabsTTS] Error: …`).
- [ ] In LiveKit mode: if the agent worker is down, confirm the watchdog drops LiveKit after 8s and SSE mode takes over.
- [ ] Server logs should show `[TTS] Synthesized N bytes (client=ElevenLabsTTSClient, …)` on every successful synth.

https://claude.ai/code/session_01STgpFWMC7RWz8aYKB2CYyR

---
_Generated by [Claude Code](https://claude.ai/code/session_01STgpFWMC7RWz8aYKB2CYyR)_