### PR TITLE
fix(security): drop user-controlled fields from TTS log line

### DIFF
--- a/backend/mobile_voice_routes.py
+++ b/backend/mobile_voice_routes.py
@@ -13,7 +13,6 @@ import json
 import asyncio
 import base64
 import os
-import re
 import time
 import httpx
 from typing import Optional, Dict, Any, AsyncGenerator, List, TYPE_CHECKING
@@ -1083,13 +1082,12 @@ async def synthesize_text(request: Request, db: Session = Depends(get_db)):
             logger.error(f"[TTS] Provider returned empty audio (provider={type(tts).__name__})")
             raise HTTPException(502, "TTS provider returned empty audio")
 
-        # Sanitize user-supplied values before logging to avoid log injection
-        # (CodeQL: log entries should not contain unescaped user input).
-        safe_provider = re.sub(r"[^A-Za-z0-9_\-]", "", str(provider))[:32] if provider else "auto"
-        safe_voice_id = re.sub(r"[^A-Za-z0-9_\-]", "", str(voice_id))[:64] if voice_id else "default"
+        # Log only trusted values: byte count + TTS client class name.
+        # User-supplied provider/voice_id are intentionally omitted to avoid
+        # log injection (CodeQL flags any user input in log lines).
         logger.info(
-            "[TTS] Synthesized %d bytes (client=%s, provider_param=%s, voice_id=%s)",
-            len(audio), type(tts).__name__, safe_provider, safe_voice_id,
+            "[TTS] Synthesized %d bytes (client=%s)",
+            len(audio), type(tts).__name__,
         )
 
         return {


### PR DESCRIPTION
Follow-up to #61. CodeQL persistently flagged the TTS success log line as a log-injection sink even after my regex-allowlist sanitization (`re.sub(r"[^A-Za-z0-9_\-]", "", …)`), because the default CodeQL sanitizer set doesn't recognize `re.sub()` as a clean barrier — the data-flow taint from user JSON to log call still trips two separate findings (security alerts 9178 and 9179).

The user-supplied `provider`/`voice_id` aren't critical for diagnostics: the resolved TTS client class name (`ElevenLabsTTSClient` / `OpenAITTSClient` / `GoogleTTSClient`) already tells us which provider answered. Dropping them from the log entirely is the simplest way to clear CodeQL.

- Remove `provider_param=%s, voice_id=%s` from the log line.
- Drop the `safe_provider`/`safe_voice_id` sanitization block.
- Remove the now-unused `import re`.

https://claude.ai/code/session_01STgpFWMC7RWz8aYKB2CYyR

---
_Generated by [Claude Code](https://claude.ai/code/session_01STgpFWMC7RWz8aYKB2CYyR)_