### PR TITLE
fix(pos): preserve signup data + survivable per-section 401s on apply/v3

### DIFF
--- a/backend/middleware/purl_auth.py
+++ b/backend/middleware/purl_auth.py
@@ -97,6 +97,19 @@ async def get_purl_token(
             if token.startswith("purl_live_"):
                 return token
 
+    # Diagnostic: distinguish "header missing" from "header present but wrong scheme".
+    # Without this it's nearly impossible to tell a stripped-by-proxy header apart
+    # from a borrower who hit a PURL endpoint with a non-PURL JWT.
+    if not credentials and not authorization:
+        logger.debug("PURL token extraction: no Authorization header on request")
+    else:
+        cred_prefix = credentials.credentials[:10] if credentials and credentials.credentials else None
+        hdr_prefix = authorization[:20] if authorization else None
+        logger.warning(
+            "PURL token extraction failed: scheme/prefix mismatch (credentials_prefix=%r, header_prefix=%r)",
+            cred_prefix,
+            hdr_prefix,
+        )
     return None
 
 

--- a/backend/services/purl_token_service.py
+++ b/backend/services/purl_token_service.py
@@ -147,7 +147,11 @@ class PURLTokenService:
         """
         # Validate format
         if not PURLTokenGenerator.is_valid_format(token):
-            logger.warning(f"Invalid token format: {token[:20]}...")
+            logger.warning(
+                "PURL verify rejected: bad format (prefix=%r, len=%d)",
+                token[:10] if token else "",
+                len(token) if token else 0,
+            )
             return None
 
         # Hash the token for lookup
@@ -159,12 +163,16 @@ class PURLTokenService:
         ).first()
 
         if not token_record:
-            logger.warning(f"Token not found: {token[:20]}...")
+            logger.warning("PURL verify rejected: hash not found in purl_access_tokens (prefix=%s)", token[:16])
             return None
 
         # Check status
         if token_record.status != TokenStatus.ACTIVE.value:
-            logger.warning(f"Token {token_record.id} status is {token_record.status}")
+            logger.warning(
+                "PURL verify rejected: token %d status=%s (expected active)",
+                token_record.id,
+                token_record.status,
+            )
             return None
 
         # Check expiration
@@ -172,7 +180,11 @@ class PURLTokenService:
             # Auto-expire the token
             token_record.status = TokenStatus.EXPIRED.value
             self.db.commit()
-            logger.info(f"Token {token_record.id} auto-expired")
+            logger.info(
+                "PURL verify rejected: token %d auto-expired (expires_at=%s)",
+                token_record.id,
+                token_record.expires_at.isoformat(),
+            )
             return None
 
         # Get workspace
@@ -181,7 +193,11 @@ class PURLTokenService:
         ).first()
 
         if not workspace:
-            logger.error(f"Workspace {token_record.workspace_id} not found for token")
+            logger.error(
+                "PURL verify rejected: token %d references missing workspace %d",
+                token_record.id,
+                token_record.workspace_id,
+            )
             return None
 
         # Update last_used_at using raw SQL to avoid foreign key resolution issues

--- a/frontend/src/features/pos/hooks/usePOSApplication.ts
+++ b/frontend/src/features/pos/hooks/usePOSApplication.ts
@@ -90,8 +90,26 @@ export function usePOSApplication(loanId?: number) {
         setSections(prev => ({ ...prev, [sectionKey]: section }));
         return section;
       } catch (e) {
+        // Don't promote a per-section 401/403 to the global error state once
+        // the application has loaded. /applications/me already proved the
+        // token works; a section-scoped auth failure is either transient or
+        // a backend issue specific to that endpoint, and bouncing the user
+        // back to the signup screen would just wipe their session for no
+        // reason. Retry once after a short delay before giving up silently.
+        if (e instanceof APIError && [401, 403].includes(e.status)) {
+          console.warn('Section auth failed, retrying once', sectionKey, e.status);
+          try {
+            await new Promise(r => setTimeout(r, 400));
+            const section = await posApi.getSection(application.id, sectionKey);
+            setSections(prev => ({ ...prev, [sectionKey]: section }));
+            return section;
+          } catch (retryErr) {
+            console.error('Section auth failed after retry', sectionKey, retryErr);
+            return;
+          }
+        }
         console.error('Failed to load section', sectionKey, e);
-        if (e instanceof APIError && [400, 401, 403].includes(e.status)) {
+        if (e instanceof APIError && e.status === 400) {
           setError(e.message);
         }
       }

--- a/frontend/src/pages/pos/POSEntryPage.tsx
+++ b/frontend/src/pages/pos/POSEntryPage.tsx
@@ -34,6 +34,7 @@ interface VerifySession {
 }
 
 const SESSION_KEY = 'perennia_pos_verify';
+const SIGNUP_DRAFT_KEY = 'perennia_pos_signup_draft';
 
 const POSEntryPage: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -120,10 +121,15 @@ const POSEntryPage: React.FC = () => {
     }
   }, [tokenParam]);
 
+  const [authBounceError, setAuthBounceError] = useState<string | null>(null);
+
   const handleAuthError = () => {
     localStorage.removeItem('perennia_purl_token');
     setApiPurlToken(null);
     setPurlToken(null);
+    setAuthBounceError(
+      "We couldn't open your application. Your details below are saved — please try again, or contact your loan officer if this keeps happening.",
+    );
     setFlowStep('auth');
   };
 
@@ -138,8 +144,10 @@ const POSEntryPage: React.FC = () => {
     setApiPurlToken(token);
     setPurlToken(token);
     if (name) setBorrowerName(name);
+    setAuthBounceError(null);
     setFlowStep('app');
     sessionStorage.removeItem(SESSION_KEY);
+    sessionStorage.removeItem(SIGNUP_DRAFT_KEY);
   };
 
   const handleBack = () => {
@@ -198,7 +206,16 @@ const POSEntryPage: React.FC = () => {
     );
   }
 
-  return <AuthGate onStarted={handleStarted} onVerified={handleVerified} loSlug={loSlug} loProfile={loProfile} />;
+  return (
+    <AuthGate
+      onStarted={handleStarted}
+      onVerified={handleVerified}
+      loSlug={loSlug}
+      loProfile={loProfile}
+      bounceError={authBounceError}
+      onClearBounceError={() => setAuthBounceError(null)}
+    />
+  );
 };
 
 
@@ -211,11 +228,15 @@ function AuthGate({
   onVerified,
   loSlug,
   loProfile,
+  bounceError,
+  onClearBounceError,
 }: {
   onStarted: (session: VerifySession) => void;
   onVerified: (token: string, name?: string) => void;
   loSlug?: string | null;
   loProfile?: LOProfile | null;
+  bounceError?: string | null;
+  onClearBounceError?: () => void;
 }) {
   const [tab, setTab] = useState<AuthTab>('signup');
   const [variant, setVariant] = useState<DesignVariant>('conversational');
@@ -244,7 +265,14 @@ function AuthGate({
   );
 
   const formContent = tab === 'signup' ? (
-    <SignupForm onStarted={onStarted} onVerified={onVerified} onSwitchToLogin={() => setTab('login')} loSlug={loSlug} />
+    <SignupForm
+      onStarted={onStarted}
+      onVerified={onVerified}
+      onSwitchToLogin={() => setTab('login')}
+      loSlug={loSlug}
+      bounceError={bounceError ?? null}
+      onClearBounceError={onClearBounceError}
+    />
   ) : (
     <LoginForm onStarted={onStarted} onVerified={onVerified} onSwitchToSignup={() => setTab('signup')} />
   );
@@ -734,18 +762,41 @@ function SignupForm({
   onVerified,
   onSwitchToLogin,
   loSlug,
+  bounceError,
+  onClearBounceError,
 }: {
   onStarted: (session: VerifySession) => void;
   onVerified: (token: string, name?: string) => void;
   onSwitchToLogin: () => void;
   loSlug?: string | null;
+  bounceError?: string | null;
+  onClearBounceError?: () => void;
 }) {
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [email, setEmail] = useState('');
-  const [phone, setPhone] = useState('');
+  // Hydrate from sessionStorage so values survive a bounce back from a failed
+  // post-signup auth (POSContainer can unmount this form via onAuthError).
+  const draft = (() => {
+    try {
+      const raw = sessionStorage.getItem(SIGNUP_DRAFT_KEY);
+      if (raw) return JSON.parse(raw) as { firstName?: string; lastName?: string; email?: string; phone?: string };
+    } catch { /* ignore parse error */ }
+    return {} as { firstName?: string; lastName?: string; email?: string; phone?: string };
+  })();
+
+  const [firstName, setFirstName] = useState(draft.firstName || '');
+  const [lastName, setLastName] = useState(draft.lastName || '');
+  const [email, setEmail] = useState(draft.email || '');
+  const [phone, setPhone] = useState(draft.phone || '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(
+        SIGNUP_DRAFT_KEY,
+        JSON.stringify({ firstName, lastName, email, phone }),
+      );
+    } catch { /* storage full or disabled — fine */ }
+  }, [firstName, lastName, email, phone]);
 
   const isValid = firstName.trim() && lastName.trim() && email.trim();
 
@@ -753,6 +804,7 @@ function SignupForm({
     e.preventDefault();
     if (!isValid) return;
     setError('');
+    onClearBounceError?.();
     setSubmitting(true);
 
     try {
@@ -790,6 +842,9 @@ function SignupForm({
         Your progress saves automatically.
       </p>
 
+      {bounceError && !error && (
+        <div className="pos-start__error" role="alert">{bounceError}</div>
+      )}
       {error && <div className="pos-start__error">{error}</div>}
 
       <form onSubmit={handleSubmit}>


### PR DESCRIPTION
## Problem
On `/apply/v3/purchase`, after a borrower clicks "Start Application" the screen appears to refresh and the form fields go blank.

It isn't a true browser refresh — `e.preventDefault()` fires correctly. The actual sequence:
1. `POST /api/v1/pos/start-demo` returns a PURL token.
2. `POSEntryPage` flips `flowStep='app'` and mounts `<POSContainer>`.
3. `usePOSApplication` → `GET /applications/me` succeeds.
4. Follow-up `GET /applications/{id}/sections/personal` returns **401 "Invalid or missing PURL access token"**.
5. `POSContainer` treats that as a session error and calls `onAuthError`, which clears the token and flips `flowStep='auth'`.
6. `<AuthGate>` → `<SignupForm>` remounts with empty `useState` — looks like a refresh that wiped the fields.

## Changes

### Frontend
- **`POSEntryPage.tsx`**: Persist signup fields (first / last / email / phone) to `sessionStorage` (`perennia_pos_signup_draft`) and rehydrate on mount so they survive the unmount/remount loop. Surface a visible error banner when `onAuthError` bounces the user back, instead of a silent refresh. Clear the draft once the borrower successfully enters the application shell.
- **`usePOSApplication.ts`**: Once `application` has loaded, a per-section 401/403 is no longer promoted to the global error state. We retry once after 400ms and otherwise log silently. The borrower stays in the app with an empty panel instead of getting logged out. First-load `/applications/me` 401s still trigger `onAuthError` correctly.

### Backend (diagnostic only)
- **`purl_token_service.py`** — `verify_token` logs *which* check rejected the token: bad format, hash not found in DB, status ≠ active, expired, or workspace missing.
- **`purl_auth.py`** — `get_purl_token` distinguishes "no Authorization header" from "header present but wrong scheme". Together these will let us pin down the asymmetric 401 in Railway logs next time it reproduces.

## Test plan
- [ ] On `/apply/v3/purchase?lo=timothy-loss`, fill the signup form and click Start Application.
- [ ] If the post-signup section load 401s, confirm the borrower stays inside the app (panel may be empty) instead of being kicked back to a blank signup form.
- [ ] If the borrower *is* bounced (real session error), confirm the form rehydrates with their last values and shows the explanatory error banner.
- [ ] Trigger a known-bad PURL token and grep Railway logs for `PURL verify rejected` to confirm the new diagnostic lines fire.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjiquwpeQsAWzZx8tNCXjw)_