### PR TITLE
fix(pos): phase-tagged logging for start-demo 500s

### DIFF
--- a/backend/middleware/purl_auth.py
+++ b/backend/middleware/purl_auth.py
@@ -97,6 +97,19 @@ async def get_purl_token(
             if token.startswith("purl_live_"):
                 return token
 
+    # Diagnostic: distinguish "header missing" from "header present but wrong scheme".
+    # Without this it's nearly impossible to tell a stripped-by-proxy header apart
+    # from a borrower who hit a PURL endpoint with a non-PURL JWT.
+    if not credentials and not authorization:
+        logger.debug("PURL token extraction: no Authorization header on request")
+    else:
+        cred_prefix = credentials.credentials[:10] if credentials and credentials.credentials else None
+        hdr_prefix = authorization[:20] if authorization else None
+        logger.warning(
+            "PURL token extraction failed: scheme/prefix mismatch (credentials_prefix=%r, header_prefix=%r)",
+            cred_prefix,
+            hdr_prefix,
+        )
     return None
 
 

--- a/backend/routes/pos/start.py
+++ b/backend/routes/pos/start.py
@@ -793,84 +793,130 @@ class DemoStartResponse(BaseModel):
     summary="Demo start — creates application immediately without email verification",
 )
 def start_demo(body: DemoStartRequest, request: Request, db: Session = Depends(get_db)):
-    _ensure_table(db)
+    """Create-or-resume a borrower workspace and issue a PURL token.
 
+    Each phase is tagged so a 500 in production logs the exact failure
+    point (e.g. `POS demo start[create_workspace]: ...`). Without this it's
+    indistinguishable which DB step blew up.
+    """
+    phase = "ensure_table"
     try:
-        org_id = _resolve_organization_id(db, body.lo_slug)
+        _ensure_table(db)
+
+        phase = "resolve_org"
+        try:
+            org_id = _resolve_organization_id(db, body.lo_slug)
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.exception("POS demo start[resolve_org]: failed for lo_slug=%r: %s", body.lo_slug, e)
+            raise HTTPException(status_code=500, detail=f"Organization lookup failed: {type(e).__name__}")
+
+        email_lower = body.email.strip().lower()
+
+        phase = "find_existing_contact"
+        existing_contact = (
+            db.query(PURLContact)
+            .filter(PURLContact.email == email_lower)
+            .order_by(PURLContact.id.desc())
+            .first()
+        )
+
+        if existing_contact:
+            phase = "load_existing_workspace"
+            workspace = db.query(PURLWorkspace).filter(PURLWorkspace.id == existing_contact.workspace_id).first()
+            if workspace:
+                phase = "issue_token_existing"
+                token_service = PURLTokenService(db)
+                _token_id, full_token = token_service.create_token(
+                    organization_id=existing_contact.organization_id,
+                    workspace_id=workspace.id,
+                    scope=TokenScope.WRITE,
+                    contact_id=existing_contact.id,
+                    expires_in_days=90,
+                )
+                phase = "commit_existing"
+                db.commit()
+                logger.info(
+                    "POS demo start: returning existing workspace=%d contact=%d for email=%s",
+                    workspace.id, existing_contact.id, email_lower,
+                )
+                return DemoStartResponse(
+                    token=full_token,
+                    workspace_slug=workspace.slug,
+                    borrower_name=existing_contact.first_name or body.first_name,
+                )
+
+        slug = f"{body.first_name.strip().lower()}-{body.last_name.strip().lower()}-{uuid.uuid4().hex[:8]}"
+        display_name = f"{body.first_name.strip()} {body.last_name.strip()}"
+        phone_raw = body.phone.strip() if body.phone else ""
+
+        phase = "create_workspace"
+        workspace = PURLWorkspace(
+            organization_id=org_id,
+            slug=slug,
+            status=WorkspaceStatus.APPLICATION.value,
+            display_name=display_name,
+            source="pos_demo",
+            application_at=datetime.now(timezone.utc),
+        )
+        db.add(workspace)
+        db.flush()
+
+        phase = "create_contact"
+        contact = PURLContact(
+            organization_id=org_id,
+            workspace_id=workspace.id,
+            contact_type=ContactType.BORROWER.value,
+            first_name=body.first_name.strip(),
+            last_name=body.last_name.strip(),
+            email=email_lower,
+            phone=phone_raw,
+        )
+        db.add(contact)
+        db.flush()
+
+        phase = "issue_token_new"
+        token_service = PURLTokenService(db)
+        _token_id, full_token = token_service.create_token(
+            organization_id=org_id,
+            workspace_id=workspace.id,
+            scope=TokenScope.WRITE,
+            contact_id=contact.id,
+            expires_in_days=90,
+        )
+
+        phase = "commit_new"
+        db.commit()
+        logger.info(
+            "POS demo start: created workspace=%d contact=%d slug=%s for email=%s",
+            workspace.id, contact.id, slug, email_lower,
+        )
+        return DemoStartResponse(
+            token=full_token,
+            workspace_slug=slug,
+            borrower_name=body.first_name.strip(),
+        )
+
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception("POS demo start: failed to resolve organization: %s", e)
-        raise HTTPException(status_code=500, detail=f"Organization lookup failed: {type(e).__name__}")
-
-    email_lower = body.email.strip().lower()
-
-    existing_contact = (
-        db.query(PURLContact)
-        .filter(PURLContact.email == email_lower)
-        .order_by(PURLContact.id.desc())
-        .first()
-    )
-    if existing_contact:
-        workspace = db.query(PURLWorkspace).filter(PURLWorkspace.id == existing_contact.workspace_id).first()
-        if workspace:
-            token_service = PURLTokenService(db)
-            _token_id, full_token = token_service.create_token(
-                organization_id=existing_contact.organization_id,
-                workspace_id=workspace.id,
-                scope=TokenScope.WRITE,
-                contact_id=existing_contact.id,
-                expires_in_days=90,
-            )
-            db.commit()
-            return DemoStartResponse(
-                token=full_token,
-                workspace_slug=workspace.slug,
-                borrower_name=existing_contact.first_name or body.first_name,
-            )
-
-    slug = f"{body.first_name.strip().lower()}-{body.last_name.strip().lower()}-{uuid.uuid4().hex[:8]}"
-    display_name = f"{body.first_name.strip()} {body.last_name.strip()}"
-    phone_raw = body.phone.strip() if body.phone else ""
-
-    workspace = PURLWorkspace(
-        organization_id=org_id,
-        slug=slug,
-        status=WorkspaceStatus.APPLICATION.value,
-        display_name=display_name,
-        source="pos_demo",
-        application_at=datetime.now(timezone.utc),
-    )
-    db.add(workspace)
-    db.flush()
-
-    contact = PURLContact(
-        organization_id=org_id,
-        workspace_id=workspace.id,
-        contact_type=ContactType.BORROWER.value,
-        first_name=body.first_name.strip(),
-        last_name=body.last_name.strip(),
-        email=email_lower,
-        phone=phone_raw,
-    )
-    db.add(contact)
-    db.flush()
-
-    token_service = PURLTokenService(db)
-    _token_id, full_token = token_service.create_token(
-        organization_id=org_id,
-        workspace_id=workspace.id,
-        scope=TokenScope.WRITE,
-        contact_id=contact.id,
-        expires_in_days=90,
-    )
-    db.commit()
-
-    return DemoStartResponse(
-        token=full_token,
-        workspace_slug=slug,
-        borrower_name=body.first_name.strip(),
-    )
+        # Roll back so the next request on this connection isn't in a poisoned
+        # transaction. Log the phase tag + exception type so production logs
+        # tell us exactly which step blew up — the user-facing response is
+        # sanitized to "Internal server error" by the global handler.
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        logger.exception(
+            "POS demo start[%s] failed for email=%s lo_slug=%r: %s: %s",
+            phase, body.email, body.lo_slug, type(e).__name__, e,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"start-demo failed at phase={phase} error={type(e).__name__}",
+        )
 
 
 @router.post(

--- a/backend/services/purl_token_service.py
+++ b/backend/services/purl_token_service.py
@@ -147,7 +147,11 @@ class PURLTokenService:
         """
         # Validate format
         if not PURLTokenGenerator.is_valid_format(token):
-            logger.warning(f"Invalid token format: {token[:20]}...")
+            logger.warning(
+                "PURL verify rejected: bad format (prefix=%r, len=%d)",
+                token[:10] if token else "",
+                len(token) if token else 0,
+            )
             return None
 
         # Hash the token for lookup
@@ -159,12 +163,16 @@ class PURLTokenService:
         ).first()
 
         if not token_record:
-            logger.warning(f"Token not found: {token[:20]}...")
+            logger.warning("PURL verify rejected: hash not found in purl_access_tokens (prefix=%s)", token[:16])
             return None
 
         # Check status
         if token_record.status != TokenStatus.ACTIVE.value:
-            logger.warning(f"Token {token_record.id} status is {token_record.status}")
+            logger.warning(
+                "PURL verify rejected: token %d status=%s (expected active)",
+                token_record.id,
+                token_record.status,
+            )
             return None
 
         # Check expiration
@@ -172,7 +180,11 @@ class PURLTokenService:
             # Auto-expire the token
             token_record.status = TokenStatus.EXPIRED.value
             self.db.commit()
-            logger.info(f"Token {token_record.id} auto-expired")
+            logger.info(
+                "PURL verify rejected: token %d auto-expired (expires_at=%s)",
+                token_record.id,
+                token_record.expires_at.isoformat(),
+            )
             return None
 
         # Get workspace
@@ -181,7 +193,11 @@ class PURLTokenService:
         ).first()
 
         if not workspace:
-            logger.error(f"Workspace {token_record.workspace_id} not found for token")
+            logger.error(
+                "PURL verify rejected: token %d references missing workspace %d",
+                token_record.id,
+                token_record.workspace_id,
+            )
             return None
 
         # Update last_used_at using raw SQL to avoid foreign key resolution issues

--- a/frontend/src/features/pos/hooks/usePOSApplication.ts
+++ b/frontend/src/features/pos/hooks/usePOSApplication.ts
@@ -90,8 +90,26 @@ export function usePOSApplication(loanId?: number) {
         setSections(prev => ({ ...prev, [sectionKey]: section }));
         return section;
       } catch (e) {
+        // Don't promote a per-section 401/403 to the global error state once
+        // the application has loaded. /applications/me already proved the
+        // token works; a section-scoped auth failure is either transient or
+        // a backend issue specific to that endpoint, and bouncing the user
+        // back to the signup screen would just wipe their session for no
+        // reason. Retry once after a short delay before giving up silently.
+        if (e instanceof APIError && [401, 403].includes(e.status)) {
+          console.warn('Section auth failed, retrying once', sectionKey, e.status);
+          try {
+            await new Promise(r => setTimeout(r, 400));
+            const section = await posApi.getSection(application.id, sectionKey);
+            setSections(prev => ({ ...prev, [sectionKey]: section }));
+            return section;
+          } catch (retryErr) {
+            console.error('Section auth failed after retry', sectionKey, retryErr);
+            return;
+          }
+        }
         console.error('Failed to load section', sectionKey, e);
-        if (e instanceof APIError && [400, 401, 403].includes(e.status)) {
+        if (e instanceof APIError && e.status === 400) {
           setError(e.message);
         }
       }

--- a/frontend/src/pages/pos/POSEntryPage.tsx
+++ b/frontend/src/pages/pos/POSEntryPage.tsx
@@ -34,6 +34,7 @@ interface VerifySession {
 }
 
 const SESSION_KEY = 'perennia_pos_verify';
+const SIGNUP_DRAFT_KEY = 'perennia_pos_signup_draft';
 
 const POSEntryPage: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -120,10 +121,15 @@ const POSEntryPage: React.FC = () => {
     }
   }, [tokenParam]);
 
+  const [authBounceError, setAuthBounceError] = useState<string | null>(null);
+
   const handleAuthError = () => {
     localStorage.removeItem('perennia_purl_token');
     setApiPurlToken(null);
     setPurlToken(null);
+    setAuthBounceError(
+      "We couldn't open your application. Your details below are saved — please try again, or contact your loan officer if this keeps happening.",
+    );
     setFlowStep('auth');
   };
 
@@ -138,8 +144,10 @@ const POSEntryPage: React.FC = () => {
     setApiPurlToken(token);
     setPurlToken(token);
     if (name) setBorrowerName(name);
+    setAuthBounceError(null);
     setFlowStep('app');
     sessionStorage.removeItem(SESSION_KEY);
+    sessionStorage.removeItem(SIGNUP_DRAFT_KEY);
   };
 
   const handleBack = () => {
@@ -198,7 +206,16 @@ const POSEntryPage: React.FC = () => {
     );
   }
 
-  return <AuthGate onStarted={handleStarted} onVerified={handleVerified} loSlug={loSlug} loProfile={loProfile} />;
+  return (
+    <AuthGate
+      onStarted={handleStarted}
+      onVerified={handleVerified}
+      loSlug={loSlug}
+      loProfile={loProfile}
+      bounceError={authBounceError}
+      onClearBounceError={() => setAuthBounceError(null)}
+    />
+  );
 };
 
 
@@ -211,11 +228,15 @@ function AuthGate({
   onVerified,
   loSlug,
   loProfile,
+  bounceError,
+  onClearBounceError,
 }: {
   onStarted: (session: VerifySession) => void;
   onVerified: (token: string, name?: string) => void;
   loSlug?: string | null;
   loProfile?: LOProfile | null;
+  bounceError?: string | null;
+  onClearBounceError?: () => void;
 }) {
   const [tab, setTab] = useState<AuthTab>('signup');
   const [variant, setVariant] = useState<DesignVariant>('conversational');
@@ -244,7 +265,14 @@ function AuthGate({
   );
 
   const formContent = tab === 'signup' ? (
-    <SignupForm onStarted={onStarted} onVerified={onVerified} onSwitchToLogin={() => setTab('login')} loSlug={loSlug} />
+    <SignupForm
+      onStarted={onStarted}
+      onVerified={onVerified}
+      onSwitchToLogin={() => setTab('login')}
+      loSlug={loSlug}
+      bounceError={bounceError ?? null}
+      onClearBounceError={onClearBounceError}
+    />
   ) : (
     <LoginForm onStarted={onStarted} onVerified={onVerified} onSwitchToSignup={() => setTab('signup')} />
   );
@@ -734,18 +762,41 @@ function SignupForm({
   onVerified,
   onSwitchToLogin,
   loSlug,
+  bounceError,
+  onClearBounceError,
 }: {
   onStarted: (session: VerifySession) => void;
   onVerified: (token: string, name?: string) => void;
   onSwitchToLogin: () => void;
   loSlug?: string | null;
+  bounceError?: string | null;
+  onClearBounceError?: () => void;
 }) {
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [email, setEmail] = useState('');
-  const [phone, setPhone] = useState('');
+  // Hydrate from sessionStorage so values survive a bounce back from a failed
+  // post-signup auth (POSContainer can unmount this form via onAuthError).
+  const draft = (() => {
+    try {
+      const raw = sessionStorage.getItem(SIGNUP_DRAFT_KEY);
+      if (raw) return JSON.parse(raw) as { firstName?: string; lastName?: string; email?: string; phone?: string };
+    } catch { /* ignore parse error */ }
+    return {} as { firstName?: string; lastName?: string; email?: string; phone?: string };
+  })();
+
+  const [firstName, setFirstName] = useState(draft.firstName || '');
+  const [lastName, setLastName] = useState(draft.lastName || '');
+  const [email, setEmail] = useState(draft.email || '');
+  const [phone, setPhone] = useState(draft.phone || '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(
+        SIGNUP_DRAFT_KEY,
+        JSON.stringify({ firstName, lastName, email, phone }),
+      );
+    } catch { /* storage full or disabled — fine */ }
+  }, [firstName, lastName, email, phone]);
 
   const isValid = firstName.trim() && lastName.trim() && email.trim();
 
@@ -753,6 +804,7 @@ function SignupForm({
     e.preventDefault();
     if (!isValid) return;
     setError('');
+    onClearBounceError?.();
     setSubmitting(true);
 
     try {
@@ -790,6 +842,9 @@ function SignupForm({
         Your progress saves automatically.
       </p>
 
+      {bounceError && !error && (
+        <div className="pos-start__error" role="alert">{bounceError}</div>
+      )}
       {error && <div className="pos-start__error">{error}</div>}
 
       <form onSubmit={handleSubmit}>


### PR DESCRIPTION
## Problem
Follow-up to #65. With the form-data-loss bandage in place, the real error is now visible: `POST /api/v1/pos/start-demo` is returning **500**, not 401. The production exception handler strips the detail to "Internal server error", so we can't tell from the response which DB step in the create-workspace / create-contact / issue-token flow blew up.

## Change
`start_demo` now tags each phase (`ensure_table`, `resolve_org`, `find_existing_contact`, `load_existing_workspace`, `issue_token_existing`, `commit_existing`, `create_workspace`, `create_contact`, `issue_token_new`, `commit_new`). Any unhandled exception logs the phase name, exception type, email, and `lo_slug`. The session is rolled back on failure so the connection isn't left in a poisoned transaction. The HTTPException detail also embeds the phase tag — production strips it from the response, but `/health/recent-errors` (admin-key-protected ring buffer) and Railway logs will both show it.

## How to use after deploy
1. Reproduce by clicking Start Application on `/apply/v3/purchase?lo=timothy-loss`.
2. Either:
   - `curl -H "X-API-Key: $ADMIN_API_KEY" https://api.perenniaai.com/health/recent-errors | jq` and look at the most recent entry.
   - Or grep Railway logs for `POS demo start[`.
3. The phase name in the log line points directly at the broken step.

## Test plan
- [ ] Deploy to Railway.
- [ ] Reproduce the 500 on `/apply/v3/purchase`.
- [ ] Confirm a Railway log line of the form `POS demo start[<phase>] failed for email=... lo_slug=...: <ExcType>: <msg>` appears.
- [ ] Confirm `/health/recent-errors` shows the entry with a traceback.
- [ ] Forward the phase tag so the actual fix can be made.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjiquwpeQsAWzZx8tNCXjw)_