### PR TITLE
Add token recovery endpoint for builder portal submissions

### DIFF
--- a/backend/routes/builder_portal_routes.py
+++ b/backend/routes/builder_portal_routes.py
@@ -5,6 +5,7 @@ API endpoints for the CMG Builder Portal (static HTML on GitHub Pages).
 
 Public endpoints (builder-facing, token-authenticated):
 - POST /api/v1/builder-portal/register           Register + get submission token
+- POST /api/v1/builder-portal/recover-token      Recover token for existing draft (lo_slug + email)
 - POST /api/v1/builder-portal/documents/upload    Initiate S3 presigned upload
 - POST /api/v1/builder-portal/documents/confirm   Confirm S3 upload
 - POST /api/v1/builder-portal/submit              Submit completed application
@@ -133,6 +134,17 @@ class RegisterResponse(BaseModel):
     submission_token: str
     lo_name: str
     lo_company: Optional[str] = None
+
+
+class RecoverTokenRequest(BaseModel):
+    lo_slug: str = Field(..., min_length=1, max_length=100)
+    email: str = Field(..., min_length=3, max_length=255)
+
+
+class RecoverTokenResponse(BaseModel):
+    application_id: int
+    submission_token: str
+    status: str
 
 
 class InitiateUploadRequest(BaseModel):
@@ -298,6 +310,52 @@ async def register_builder(body: RegisterRequest, request: Request, db: Session 
         submission_token=app.submission_token,
         lo_name=f"{lo.first_name or ''} {lo.last_name or ''}".strip() or lo.email,
         lo_company=getattr(lo, 'company', None),
+    )
+
+
+@router.post("/api/v1/builder-portal/recover-token", response_model=RecoverTokenResponse)
+async def recover_builder_token(
+    body: RecoverTokenRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """
+    Recover the submission token for an existing builder application.
+
+    Used when the builder's localStorage was cleared, they switched browsers,
+    or registration silently failed. Matches on lo_slug + email and returns
+    the token for the most recent non-terminal application.
+    """
+    _check_register_rate_limit(request)
+
+    from database.models.core import User
+    from database.models.builder_application import BuilderApplication
+
+    lo = db.query(User).filter(
+        User.slug == body.lo_slug,
+        User.is_active == True,
+    ).first()
+    if not lo:
+        raise HTTPException(status_code=404, detail="Loan officer not found")
+
+    app = db.query(BuilderApplication).filter(
+        BuilderApplication.lo_user_id == lo.id,
+        BuilderApplication.contact_email == body.email,
+        BuilderApplication.status.in_(("DRAFT", "SUBMITTED")),
+    ).order_by(BuilderApplication.created_at.desc()).first()
+
+    if not app:
+        raise HTTPException(status_code=404, detail="No application found for this email")
+
+    if app.created_at and (datetime.now(timezone.utc) - app.created_at) > timedelta(days=30):
+        raise HTTPException(status_code=410, detail="Application expired — please re-register")
+
+    logger.info(f"Builder token recovered for application {app.id} ({body.email})")
+
+    return RecoverTokenResponse(
+        application_id=app.id,
+        submission_token=app.submission_token,
+        status=app.status,
     )
 
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,36 @@
+# Builder Portal Submission Fix
+
+## What broke
+
+Builders completed all 9 review pages and clicked **Submit Packet**, but got:
+
+> No submission token — your application was not sent to the loan officer. Please re-register.
+
+`review.html` reads `localStorage.builderSubmissionToken` and dead-ends if it's missing. That token is only stored when `register.html` is opened with `?lo=<slug>` in the URL. If the builder landed on `register.html` without that param, cleared their cache, switched browsers, or used private mode, the token never made it to localStorage and the final submit always fails.
+
+## Fix
+
+### Backend (this repo — already applied)
+
+New endpoint that returns the existing draft's token given `lo_slug` + `email`:
+
+```
+POST /api/v1/builder-portal/recover-token
+{ "lo_slug": "...", "email": "..." }
+→ { application_id, submission_token, status }
+```
+
+Rate-limited per IP via the same limiter as `/register`. Returns 404 when no application exists and 410 when the application is older than 30 days. The endpoint is idempotent and has no side effects, so it's safe to call from public HTML.
+
+### Frontend (`tlossmtgboss-cyber/cmg-builder-portal` — patch in this directory)
+
+`cmg-builder-portal-review.patch` rewires `pushToBackend()` in `review.html` so that, when no token is in localStorage (or the token is rejected with 401), it calls `recover-token` with the stored `builderLOSlug` + `builderAccount.email`, stores the recovered token, and retries the submit once.
+
+Apply with:
+
+```sh
+cd cmg-builder-portal
+git apply /path/to/cmg-builder-portal-review.patch
+git commit -am "fix: recover submission token on submit when localStorage is empty"
+git push
+```

--- a/patches/cmg-builder-portal-review.patch
+++ b/patches/cmg-builder-portal-review.patch
@@ -1,0 +1,82 @@
+--- a/review.html	2026-05-22 15:29:06.588737495 +0000
++++ b/review.html	2026-05-22 15:29:44.455772150 +0000
+@@ -1555,11 +1555,46 @@
+     setTimeout(function() { t.style.opacity = '0'; setTimeout(function() { t.remove(); }, 300); }, 3500);
+   }
+ 
+-  function pushToBackend(sigData) {
++  function recoverSubmissionToken() {
++    // Last-resort recovery: ask the backend for the token using lo_slug + email
++    // stored in builderAccount. Used when localStorage was cleared, the browser
++    // changed, or registration silently failed (no ?lo= on register.html).
+     return new Promise(function(resolve, reject) {
+-      var token = getSubmissionToken();
+-      if (!token) { reject('no-token'); return; }
++      var loSlug = '';
++      var acct = {};
++      try { loSlug = localStorage.getItem('builderLOSlug') || ''; } catch(e) {}
++      try { acct = JSON.parse(localStorage.getItem('builderAccount') || '{}'); } catch(e) {}
++
++      if (!loSlug || !acct.email) { reject('no-token'); return; }
+ 
++      var xhr = new XMLHttpRequest();
++      xhr.open('POST', API_BASE + '/builder-portal/recover-token', true);
++      xhr.setRequestHeader('Content-Type', 'application/json');
++      xhr.onload = function() {
++        if (xhr.status >= 200 && xhr.status < 300) {
++          try {
++            var resp = JSON.parse(xhr.responseText);
++            if (resp && resp.submission_token) {
++              try { localStorage.setItem('builderSubmissionToken', resp.submission_token); } catch(e) {}
++              if (resp.application_id) {
++                try { localStorage.setItem('builderApplicationId', String(resp.application_id)); } catch(e) {}
++              }
++              resolve(resp.submission_token);
++              return;
++            }
++          } catch(e) {}
++          reject('no-token');
++        } else {
++          reject('no-token');
++        }
++      };
++      xhr.onerror = function() { reject('network-error'); };
++      xhr.send(JSON.stringify({ lo_slug: loSlug, email: acct.email }));
++    });
++  }
++
++  function submitWithToken(token, sigData) {
++    return new Promise(function(resolve, reject) {
+       var formData = {};
+       try { formData = JSON.parse(localStorage.getItem('builderFormData') || '{}'); } catch(e) {}
+ 
+@@ -1571,6 +1606,8 @@
+         if (xhr.status >= 200 && xhr.status < 300) {
+           try { localStorage.setItem('builderSubmitted', 'true'); } catch(e) {}
+           resolve();
++        } else if (xhr.status === 401) {
++          reject('invalid-token');
+         } else {
+           reject('server-error');
+         }
+@@ -1583,6 +1620,20 @@
+     });
+   }
+ 
++  function pushToBackend(sigData) {
++    var token = getSubmissionToken();
++    var attempt = token ? submitWithToken(token, sigData) : Promise.reject('no-token');
++
++    return attempt.catch(function(reason) {
++      if (reason !== 'no-token' && reason !== 'invalid-token') {
++        throw reason;
++      }
++      return recoverSubmissionToken().then(function(recoveredToken) {
++        return submitWithToken(recoveredToken, sigData);
++      });
++    });
++  }
++
+   window.submitPacket = function() {
+     var sigInput = document.getElementById('finalSignature');
+     if (!sigInput || sigInput.value.trim().length < 3) return;


### PR DESCRIPTION
## Summary
Fixes a critical issue where builders could not submit completed applications if their localStorage was cleared, they switched browsers, or registration silently failed. Adds a new backend endpoint and frontend logic to recover the submission token using stored loan officer slug and email.

## Changes

### Backend (`builder_portal_routes.py`)
- **New endpoint**: `POST /api/v1/builder-portal/recover-token`
  - Accepts `lo_slug` and `email` in request body
  - Queries for the most recent non-terminal (DRAFT or SUBMITTED) application matching those credentials
  - Returns `application_id`, `submission_token`, and `status`
  - Rate-limited via existing register limiter
  - Returns 404 if no application found, 410 if application older than 30 days
  - Idempotent with no side effects — safe to call from public HTML

- **New Pydantic models**:
  - `RecoverTokenRequest`: validates `lo_slug` (1–100 chars) and `email` (3–255 chars)
  - `RecoverTokenResponse`: returns application ID, token, and status

### Frontend (`review.html` patch)
- **Refactored `pushToBackend()`** to support token recovery:
  - Splits submission logic into `submitWithToken(token, sigData)` helper
  - New `recoverSubmissionToken()` function calls backend recovery endpoint with stored `builderLOSlug` and `builderAccount.email`
  - Implements fallback chain: try stored token → if missing or 401, recover token → retry submit once
  - Stores recovered token and application ID in localStorage for future use

- **Enhanced error handling**:
  - Detects 401 (invalid token) and treats it like missing token
  - Distinguishes between token errors (recoverable) and network/server errors (not recoverable)

## Implementation Details
- Recovery endpoint uses the same rate limiter as `/register` to prevent abuse
- 30-day expiration window prevents recovery of stale applications
- Frontend gracefully degrades: if recovery fails, original error message is shown
- All localStorage operations wrapped in try-catch to handle quota/access errors
- Patch file included in `patches/` directory with application instructions

https://claude.ai/code/session_011KncQPcTq61ZdJ1vkzCbbq