### PR TITLE
fix(portal): close 403 existence-disclosure + harden POS docs loan resolution

### DIFF
--- a/backend/portal_routes.py
+++ b/backend/portal_routes.py
@@ -1861,9 +1861,13 @@ def get_multi_loan_history(
     loan_ids = [loan["id"] for loan in borrower_loans]
 
     if loan_id not in loan_ids:
+        # 404 (not 403): a loan id outside the borrower's own workspace must not
+        # be confirmed to exist. 403 "does not belong to your account" leaks that
+        # the loan exists in another account — matches the 404-not-403 pattern the
+        # borrower-dashboard IDOR guard already uses.
         raise HTTPException(
-            status_code=403,
-            detail="Access denied. This loan does not belong to your account."
+            status_code=404,
+            detail="Loan not found."
         )
 
     lifecycle_service = MultiLoanLifecycleService(db)

--- a/backend/routes/pos/documents.py
+++ b/backend/routes/pos/documents.py
@@ -134,24 +134,29 @@ def get_pos_documents(
     """
 
     # -----------------------------------------------------------------------
-    # Verify borrower owns this loan via the PURL workspace
+    # Verify borrower owns this loan via the PURL workspace.
+    # Match the requested loan_id directly within the token's workspace rather
+    # than grabbing an arbitrary workspace loan with .first(): a workspace can
+    # hold more than one PURLLoan, and the unordered .first() would 404 a loan
+    # the borrower legitimately owns whenever it returned a different one.
+    # Still tenant-safe — the workspace_id filter scopes to this token.
     # -----------------------------------------------------------------------
     from models.purl import PURLLoan
+    from sqlalchemy import or_
 
     purl_loan = (
         db.query(PURLLoan)
         .filter(
             PURLLoan.workspace_id == purl_ctx.workspace_id,
+            or_(
+                PURLLoan.main_loan_id == loan_id,
+                PURLLoan.id == loan_id,
+            ),
         )
         .first()
     )
 
-    # The loan must belong to the borrower's workspace
-    resolved_loan_id = None
-    if purl_loan:
-        resolved_loan_id = purl_loan.main_loan_id or purl_loan.id
-
-    if resolved_loan_id is None or resolved_loan_id != loan_id:
+    if purl_loan is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Loan not found",

--- a/backend/routes/pos/upload.py
+++ b/backend/routes/pos/upload.py
@@ -15,14 +15,22 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Uplo
 from sqlalchemy.orm import Session
 
 from database import get_db
-from middleware.purl_auth import PURLAuthContext, require_purl_write_scope
+from middleware.purl_auth import PURLAuthContext, check_purl_rate_limit, require_purl_write_scope
 from database.models.pos import POSApplication
 from ._helpers import resolve_application_for_borrower_write, build_audit_context
 from services.pos.application_service import AuditContext
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1/pos/applications", tags=["pos-upload"])
+router = APIRouter(
+    prefix="/api/v1/pos/applications",
+    tags=["pos-upload"],
+    # Per-token rate limit, matching every other POS router (documents, tasks,
+    # application, etc.). Uploads are the most resource-intensive POS endpoint,
+    # so this was the most important one to gate — it was the only POS router
+    # missing it.
+    dependencies=[Depends(check_purl_rate_limit)],
+)
 
 ALLOWED_MIME_TYPES = {
     "application/pdf",


### PR DESCRIPTION
## Fix findings from the borrower-portal / POS audit (3 fixes)

All verified against the code. Backend-only.

### 1. MEDIUM — existence disclosure (403 → 404)
`GET /api/v1/portal/multi-loan/loans/{loan_id}/history` returned **403** `"This loan does not belong to your account"` for a `loan_id` outside the borrower's workspace — confirming the loan **exists** in another account (enumeration oracle). Now **404 "Loan not found"**, matching the 404-not-403 pattern the borrower-dashboard IDOR guard already uses.

### 2. LOW — POS document loan resolution
`GET /api/v1/pos/documents` resolved the workspace's loan with an **unordered `.first()`** then compared to the requested `loan_id`. A workspace can hold more than one `PURLLoan`, so a borrower's *legitimate* `loan_id` could 404 whenever `.first()` returned a different loan. Now matches `loan_id` directly within the token's workspace (`workspace_id` filter preserved — still tenant-scoped).

### 3. LOW — POS upload router missing rate limit
`upload.py` was the **only** POS router missing `dependencies=[Depends(check_purl_rate_limit)]` that all 7 siblings carry. Uploads are the most resource-intensive POS endpoint, so the gap mattered most here. Added; all 8 POS routers now gated.

### Not changed
The loan-id IDOR guard (`_assert_loan_belongs_to_purl_context` / `get_portal_loan_by_crm_deal_id`) is untouched. The borrower-dashboard 403 for a borrower's *own* portal-disabled loan is left as-is (not cross-tenant — audit over-flagged it).

### Verified
- Borrower-dashboard isolation suite: **10/10 pass** against Postgres (incl. cross-tenant + id-collision IDOR cases).
- All changed files compile; upload router import confirms `check_purl_rate_limit` is registered.

Leaving for review — touches live borrower-portal authorization.

### Audit LOW items deliberately NOT in this PR (need bigger, separate work)
- Deprecated plaintext `dob`/`co_dob` columns in `pos_application_pii` — needs a backfill-then-drop data migration on a live PII table.
- Portal token in `localStorage` vs `sessionStorage` — changes token-persistence UX (logout on tab close); product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
