### PR TITLE
Aria Unified Brain — Phase 1: shared services foundation

### DIFF
--- a/backend/agents/orchestration/__init__.py
+++ b/backend/agents/orchestration/__init__.py
@@ -17,6 +17,7 @@ from .context_manager import ContextManager
 from .prompt_builder import AgentPromptBuilder, ConversationStyle, SalesMethodology
 from .performance_tracker import PerformanceTracker
 from .quality_analyzer import QualityAnalyzer
+from .llm_circuit_breaker import LLMCircuitBreaker, CircuitState
 from .config.agent_configs import AgentPersona, ConversationRules, QualificationCriteria
 
 __all__ = [
@@ -26,6 +27,8 @@ __all__ = [
     "SalesMethodology",
     "PerformanceTracker",
     "QualityAnalyzer",
+    "LLMCircuitBreaker",
+    "CircuitState",
     "AgentPersona",
     "ConversationRules",
     "QualificationCriteria",

--- a/backend/agents/orchestration/llm_circuit_breaker.py
+++ b/backend/agents/orchestration/llm_circuit_breaker.py
@@ -1,0 +1,72 @@
+"""
+Shared LLM circuit breaker.
+
+Single source of truth, extracted from agents/orchestrator.py (CircuitBreaker)
+and aria/core/conversation_engine.py (_AriaCircuitBreaker), which were identical.
+Thread-safe; fast-fails LLM calls during Anthropic outages.
+"""
+import logging
+import threading
+import time as _time_module
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitState(Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class LLMCircuitBreaker:
+    """Thread-safe circuit breaker for LLM API calls."""
+
+    def __init__(self, failure_threshold: int = 5, cooldown_seconds: float = 30.0, name: str = "llm"):
+        self.failure_threshold = failure_threshold
+        self.cooldown_seconds = cooldown_seconds
+        self.name = name
+        self._state = CircuitState.CLOSED
+        self._consecutive_failures = 0
+        self._last_failure_time: float = 0.0
+        self._lock = threading.Lock()
+
+    @property
+    def state(self) -> CircuitState:
+        with self._lock:
+            if self._state == CircuitState.OPEN:
+                elapsed = _time_module.monotonic() - self._last_failure_time
+                if elapsed >= self.cooldown_seconds:
+                    self._state = CircuitState.HALF_OPEN
+                    logger.warning("[CIRCUIT-BREAKER:%s] OPEN -> HALF_OPEN (cooldown %.1fs elapsed)",
+                                   self.name, self.cooldown_seconds)
+            return self._state
+
+    def allow_request(self) -> bool:
+        current = self.state
+        if current == CircuitState.CLOSED:
+            return True
+        if current == CircuitState.HALF_OPEN:
+            return True
+        return False
+
+    def record_success(self) -> None:
+        with self._lock:
+            prev = self._state
+            self._consecutive_failures = 0
+            self._state = CircuitState.CLOSED
+            if prev != CircuitState.CLOSED:
+                logger.warning("[CIRCUIT-BREAKER:%s] %s -> CLOSED (success)", self.name, prev.value)
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._consecutive_failures += 1
+            self._last_failure_time = _time_module.monotonic()
+            if self._state == CircuitState.HALF_OPEN:
+                self._state = CircuitState.OPEN
+                logger.warning("[CIRCUIT-BREAKER:%s] HALF_OPEN -> OPEN (probe failed)", self.name)
+            elif (self._state == CircuitState.CLOSED
+                  and self._consecutive_failures >= self.failure_threshold):
+                self._state = CircuitState.OPEN
+                logger.warning("[CIRCUIT-BREAKER:%s] CLOSED -> OPEN (%d consecutive failures)",
+                               self.name, self._consecutive_failures)

--- a/backend/agents/orchestration/model_router.py
+++ b/backend/agents/orchestration/model_router.py
@@ -1,0 +1,56 @@
+"""
+ModelRouter — single source for tier -> LLM client mapping.
+
+Tiers:
+  "haiku"  — classification/extraction/routing (cheap, fast)
+  "sonnet" — open-ended reasoning and final responses
+
+Model ids are env-tunable:
+  ANTHROPIC_MODEL   (default claude-sonnet-4-6)
+  ARIA_HAIKU_MODEL  (default claude-haiku-4-5-20251001)
+"""
+import os
+import logging
+from typing import Dict
+
+from langchain_anthropic import ChatAnthropic
+
+logger = logging.getLogger(__name__)
+
+_SONNET_DEFAULT = "claude-sonnet-4-6"
+_HAIKU_DEFAULT = "claude-haiku-4-5-20251001"
+
+
+class ModelRouter:
+    """Maps a tier name to a cached, configured ChatAnthropic client."""
+
+    def __init__(self, temperature: float = 0.3, max_tokens: int = 1024):
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+        self._cache: Dict[str, ChatAnthropic] = {}
+
+    def _model_id(self, tier: str) -> str:
+        if tier == "haiku":
+            return os.getenv("ARIA_HAIKU_MODEL", _HAIKU_DEFAULT)
+        if tier == "sonnet":
+            return os.getenv("ANTHROPIC_MODEL", _SONNET_DEFAULT)
+        raise ValueError(f"Unknown model tier: {tier!r} (expected 'haiku' or 'sonnet')")
+
+    def get(self, tier: str) -> ChatAnthropic:
+        if tier not in self._cache:
+            model_id = self._model_id(tier)
+            self._cache[tier] = ChatAnthropic(
+                model=model_id,
+                temperature=self._temperature,
+                max_tokens=self._max_tokens,
+            )
+            logger.info("[MODEL-ROUTER] tier=%s -> %s", tier, model_id)
+        return self._cache[tier]
+
+
+# Module-level shared router (mirrors the circuit-breaker singleton pattern).
+_router = ModelRouter()
+
+
+def get_model_router() -> ModelRouter:
+    return _router

--- a/backend/agents/orchestration/model_router.py
+++ b/backend/agents/orchestration/model_router.py
@@ -37,6 +37,8 @@ class ModelRouter:
         raise ValueError(f"Unknown model tier: {tier!r} (expected 'haiku' or 'sonnet')")
 
     def get(self, tier: str) -> ChatAnthropic:
+        # No lock needed: a double-init on a concurrent race is harmless — the
+        # ChatAnthropic is a pure config object and both racers build it identically.
         if tier not in self._cache:
             model_id = self._model_id(tier)
             self._cache[tier] = ChatAnthropic(
@@ -48,7 +50,8 @@ class ModelRouter:
         return self._cache[tier]
 
 
-# Module-level shared router (mirrors the circuit-breaker singleton pattern).
+# Module-level shared router — instantiated once; get() is idempotent per tier
+# after the first call. Callers use get_model_router() to share the cache.
 _router = ModelRouter()
 
 

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -39,6 +39,7 @@ from .nodes.respond import format_structured_response
 from .hallucination_verifier import get_hallucination_verifier
 from .orchestration.quality_analyzer import QualityAnalyzer
 from .checkpointer import get_checkpointer
+from agents.orchestration.llm_circuit_breaker import LLMCircuitBreaker, CircuitState
 
 # Enterprise modules: budget, rate limiting, audit, correlation IDs
 from .token_budget import get_token_budget, get_rate_limiter
@@ -51,107 +52,15 @@ logger = logging.getLogger(__name__)
 # CIRCUIT BREAKER
 # =============================================================================
 
-class CircuitState(Enum):
-    CLOSED = "closed"          # Normal operation — requests flow through
-    OPEN = "open"              # Failing — reject requests immediately
-    HALF_OPEN = "half_open"    # Testing recovery — allow one probe request
-
-
-class CircuitBreaker:
-    """
-    Thread-safe circuit breaker for LLM API calls.
-
-    Prevents cascading failures during Anthropic outages by fast-failing
-    requests instead of letting each one timeout individually.
-
-    State transitions:
-        CLOSED  -> OPEN:      after `failure_threshold` consecutive failures
-        OPEN    -> HALF_OPEN: after `cooldown_seconds` elapse
-        HALF_OPEN -> CLOSED:  if the probe request succeeds
-        HALF_OPEN -> OPEN:    if the probe request fails
-    """
-
-    def __init__(
-        self,
-        failure_threshold: int = 5,
-        cooldown_seconds: float = 30.0,
-        name: str = "llm",
-    ):
-        self.failure_threshold = failure_threshold
-        self.cooldown_seconds = cooldown_seconds
-        self.name = name
-
-        self._state = CircuitState.CLOSED
-        self._consecutive_failures = 0
-        self._last_failure_time: float = 0.0
-        self._lock = threading.Lock()
-
-    @property
-    def state(self) -> CircuitState:
-        with self._lock:
-            if self._state == CircuitState.OPEN:
-                # Check if cooldown has elapsed -> transition to HALF_OPEN
-                elapsed = _time_module.monotonic() - self._last_failure_time
-                if elapsed >= self.cooldown_seconds:
-                    self._state = CircuitState.HALF_OPEN
-                    logger.warning(
-                        f"[CIRCUIT-BREAKER:{self.name}] OPEN -> HALF_OPEN "
-                        f"(cooldown {self.cooldown_seconds}s elapsed)"
-                    )
-            return self._state
-
-    def allow_request(self) -> bool:
-        """Return True if the request should be allowed through."""
-        current = self.state  # triggers OPEN->HALF_OPEN check
-        if current == CircuitState.CLOSED:
-            return True
-        if current == CircuitState.HALF_OPEN:
-            # Allow exactly one probe request
-            return True
-        # OPEN — reject
-        return False
-
-    def record_success(self) -> None:
-        """Record a successful call — reset failure count, close circuit."""
-        with self._lock:
-            prev = self._state
-            self._consecutive_failures = 0
-            self._state = CircuitState.CLOSED
-            if prev != CircuitState.CLOSED:
-                logger.warning(
-                    f"[CIRCUIT-BREAKER:{self.name}] {prev.value} -> CLOSED (success)"
-                )
-
-    def record_failure(self) -> None:
-        """Record a failed call — increment counter, potentially open circuit."""
-        with self._lock:
-            self._consecutive_failures += 1
-            self._last_failure_time = _time_module.monotonic()
-
-            if self._state == CircuitState.HALF_OPEN:
-                # Probe failed — go back to OPEN
-                self._state = CircuitState.OPEN
-                logger.warning(
-                    f"[CIRCUIT-BREAKER:{self.name}] HALF_OPEN -> OPEN "
-                    f"(probe request failed)"
-                )
-            elif (
-                self._state == CircuitState.CLOSED
-                and self._consecutive_failures >= self.failure_threshold
-            ):
-                self._state = CircuitState.OPEN
-                logger.warning(
-                    f"[CIRCUIT-BREAKER:{self.name}] CLOSED -> OPEN "
-                    f"({self._consecutive_failures} consecutive failures)"
-                )
-
+# Alias so test files importing `CircuitBreaker` from this module keep working.
+CircuitBreaker = LLMCircuitBreaker
 
 # Module-level circuit breaker instance shared across all orchestrator calls.
 # Single instance is fine — the LLM backend is the same for all requests.
-_llm_circuit_breaker = CircuitBreaker(failure_threshold=5, cooldown_seconds=30.0)
+_llm_circuit_breaker = LLMCircuitBreaker(failure_threshold=5, cooldown_seconds=30.0, name="orchestrator")
 
 
-def _get_circuit_breaker() -> CircuitBreaker:
+def _get_circuit_breaker() -> LLMCircuitBreaker:
     """Return the module-level circuit breaker (useful for testing)."""
     return _llm_circuit_breaker
 

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -36,7 +36,7 @@ from .nodes.respond import format_structured_response
 from .hallucination_verifier import get_hallucination_verifier
 from .orchestration.quality_analyzer import QualityAnalyzer
 from .checkpointer import get_checkpointer
-from .orchestration.llm_circuit_breaker import LLMCircuitBreaker, CircuitState
+from .orchestration.llm_circuit_breaker import LLMCircuitBreaker, CircuitState  # noqa: F401 — CircuitState re-exported for backward-compat test imports
 
 # Enterprise modules: budget, rate limiting, audit, correlation IDs
 from .token_budget import get_token_budget, get_rate_limiter

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -13,11 +13,8 @@ OPTIMIZATION v3: Intent-Based Tool Loading
 import asyncio
 import logging
 import os
-import threading
-import time as _time_module
 from typing import Any, Callable, Dict, Optional, Literal
 from datetime import datetime, timezone
-from enum import Enum
 
 from langgraph.graph import StateGraph, END
 from anthropic import Anthropic
@@ -39,7 +36,7 @@ from .nodes.respond import format_structured_response
 from .hallucination_verifier import get_hallucination_verifier
 from .orchestration.quality_analyzer import QualityAnalyzer
 from .checkpointer import get_checkpointer
-from agents.orchestration.llm_circuit_breaker import LLMCircuitBreaker, CircuitState
+from .orchestration.llm_circuit_breaker import LLMCircuitBreaker, CircuitState
 
 # Enterprise modules: budget, rate limiting, audit, correlation IDs
 from .token_budget import get_token_budget, get_rate_limiter

--- a/backend/agents/tools/base.py
+++ b/backend/agents/tools/base.py
@@ -532,6 +532,8 @@ class ToolDefinition:
     agent_roles: List[str]
     risk_level: str = "low"
     requires_confirmation: bool = False
+    side_effect: bool = False
+    surface_constraints: List[str] = field(default_factory=list)
     examples: List[str] = field(default_factory=list)
     parameters: Dict[str, Any] = field(default_factory=dict)
 
@@ -662,6 +664,33 @@ class ToolRegistry:
     def __iter__(self):
         """Iterate over tool names."""
         return iter(self._tools)
+
+
+_HIGH_RISK_LEVELS = {"high", "critical"}
+
+
+def requires_confirmation_for(tool_or_name) -> bool:
+    """
+    Default-deny confirmation policy.
+
+    Returns True (confirmation required) when the tool is side-effecting,
+    high/critical risk, explicitly flagged, OR unknown. Read-only, low-risk,
+    known tools return False.
+
+    Accepts a ToolDefinition or a tool name (str). An unrecognised name is
+    treated as requiring confirmation — fail safe.
+    """
+    if isinstance(tool_or_name, str):
+        td = ToolRegistry().get(tool_or_name)
+        if td is None:
+            return True  # unknown -> default-deny
+    else:
+        td = tool_or_name
+    if td.requires_confirmation or td.side_effect:
+        return True
+    if (td.risk_level or "").lower() in _HIGH_RISK_LEVELS:
+        return True
+    return False
 
 
 # =============================================================================

--- a/backend/agents/tools/base.py
+++ b/backend/agents/tools/base.py
@@ -533,6 +533,9 @@ class ToolDefinition:
     risk_level: str = "low"
     requires_confirmation: bool = False
     side_effect: bool = False
+    # surface_constraints: capability gates (e.g. "lo_assistant") consumed by the
+    # confirmation/surface gate in a later phase; defined here with side_effect as
+    # tool-behavior metadata.
     surface_constraints: List[str] = field(default_factory=list)
     examples: List[str] = field(default_factory=list)
     parameters: Dict[str, Any] = field(default_factory=dict)
@@ -681,7 +684,7 @@ def requires_confirmation_for(tool_or_name) -> bool:
     treated as requiring confirmation — fail safe.
     """
     if isinstance(tool_or_name, str):
-        td = ToolRegistry().get(tool_or_name)
+        td = ToolRegistry.get(tool_or_name)
         if td is None:
             return True  # unknown -> default-deny
     else:

--- a/backend/aria/core/conversation_engine.py
+++ b/backend/aria/core/conversation_engine.py
@@ -26,13 +26,14 @@ from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Optional, Annotated
 from enum import Enum
 
-from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langgraph.graph import StateGraph, END
 from langgraph.graph.message import add_messages
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
+from agents.orchestration.llm_circuit_breaker import LLMCircuitBreaker
+from agents.orchestration.model_router import get_model_router
 from aria.core.intent_registry import IntentRegistry, Intent, SlotSpec
 from aria.core.context_loader import AriaContextLoader
 from aria.core.mode_router import classify_mode, AriaMode
@@ -59,108 +60,26 @@ def _create_tracked_task(coro, label: str = "background"):
 
 
 # ─── Circuit Breaker ────────────────────────────────────────────────────────
-# Modeled after backend/agents/orchestrator.py CircuitBreaker.
+# Uses the shared LLMCircuitBreaker from agents/orchestration/.
 # Prevents cascading failures when Anthropic is down by fast-failing
 # instead of letting every Aria message block until timeout.
 
-class _CircuitState(str, Enum):
-    CLOSED = "closed"          # Normal operation
-    OPEN = "open"              # Failing — reject immediately
-    HALF_OPEN = "half_open"    # Testing recovery — allow one probe
-
-class _AriaCircuitBreaker:
-    """
-    Thread-safe circuit breaker for Aria LLM calls.
-
-    State transitions:
-        CLOSED    -> OPEN:      after failure_threshold consecutive failures
-        OPEN      -> HALF_OPEN: after cooldown_seconds elapse
-        HALF_OPEN -> CLOSED:    if probe request succeeds
-        HALF_OPEN -> OPEN:      if probe request fails
-    """
-
-    def __init__(self, failure_threshold: int = 5, cooldown_seconds: float = 30.0):
-        self.failure_threshold = failure_threshold
-        self.cooldown_seconds = cooldown_seconds
-        self._state = _CircuitState.CLOSED
-        self._consecutive_failures = 0
-        self._last_failure_time: float = 0.0
-        self._lock = threading.Lock()
-
-    @property
-    def state(self) -> _CircuitState:
-        with self._lock:
-            if self._state == _CircuitState.OPEN:
-                elapsed = _time_module.monotonic() - self._last_failure_time
-                if elapsed >= self.cooldown_seconds:
-                    self._state = _CircuitState.HALF_OPEN
-                    logger.warning(
-                        "[ARIA-CIRCUIT-BREAKER] OPEN -> HALF_OPEN "
-                        "(cooldown %.1fs elapsed)", self.cooldown_seconds
-                    )
-            return self._state
-
-    def allow_request(self) -> bool:
-        """Return True if the request should be allowed through."""
-        current = self.state  # triggers OPEN->HALF_OPEN check
-        if current == _CircuitState.CLOSED:
-            return True
-        if current == _CircuitState.HALF_OPEN:
-            return True  # Allow one probe request
-        return False  # OPEN — reject
-
-    def record_success(self) -> None:
-        """Reset failure count and close circuit."""
-        with self._lock:
-            prev = self._state
-            self._consecutive_failures = 0
-            self._state = _CircuitState.CLOSED
-            if prev != _CircuitState.CLOSED:
-                logger.warning(
-                    "[ARIA-CIRCUIT-BREAKER] %s -> CLOSED (success)", prev.value
-                )
-
-    def record_failure(self) -> None:
-        """Increment failure counter, potentially open circuit."""
-        with self._lock:
-            self._consecutive_failures += 1
-            self._last_failure_time = _time_module.monotonic()
-
-            if self._state == _CircuitState.HALF_OPEN:
-                self._state = _CircuitState.OPEN
-                logger.warning(
-                    "[ARIA-CIRCUIT-BREAKER] HALF_OPEN -> OPEN (probe request failed)"
-                )
-            elif (
-                self._state == _CircuitState.CLOSED
-                and self._consecutive_failures >= self.failure_threshold
-            ):
-                self._state = _CircuitState.OPEN
-                logger.warning(
-                    "[ARIA-CIRCUIT-BREAKER] CLOSED -> OPEN "
-                    "(%d consecutive failures)", self._consecutive_failures
-                )
-
-
-_circuit_breaker = _AriaCircuitBreaker(failure_threshold=5, cooldown_seconds=30.0)
+_circuit_breaker = LLMCircuitBreaker(failure_threshold=5, cooldown_seconds=30.0, name="aria-chat")
 
 # Request timeout for individual LLM calls (seconds)
 _LLM_TIMEOUT = 30.0
 
 
-# ─── LLM (lazy-initialized) ─────────────────────────────────────────────────
-_llm = None
+# ─── LLM via shared ModelRouter ─────────────────────────────────────────────
 
-def _get_llm():
-    """Lazy-initialize the LLM client on first use."""
-    global _llm
-    if _llm is None:
-        _llm = ChatAnthropic(
-            model="claude-sonnet-4-6",
-            temperature=0.3,
-            max_tokens=1024,
-        )
-    return _llm
+def _get_llm(tier: str = "sonnet"):
+    """Return the tier-appropriate LLM client.
+
+    'haiku' for classification/extraction nodes (NLU, slot-fill, slot-answer,
+    confirmation), 'sonnet' for the chitchat/response node. Default 'sonnet'
+    preserves prior behaviour for any unmodified caller.
+    """
+    return get_model_router().get(tier)
 
 # ─── State ────────────────────────────────────────────────────────────────────
 class DialoguePhase(str, Enum):
@@ -470,7 +389,7 @@ Respond ONLY with valid JSON in this exact format:
 
     try:
         response = await asyncio.wait_for(
-            _get_llm().ainvoke([
+            _get_llm("haiku").ainvoke([
                 SystemMessage(content="You are a precise NLU system. Respond only with the JSON object."),
                 HumanMessage(content=extraction_prompt)
             ]),
@@ -554,7 +473,7 @@ present them as options. Keep it brief and warm.
 
     try:
         response = await asyncio.wait_for(
-            _get_llm().ainvoke([
+            _get_llm("haiku").ainvoke([
                 SystemMessage(content="You are Aria, a warm and direct AI mortgage assistant."),
                 HumanMessage(content=question_prompt)
             ]),
@@ -606,7 +525,7 @@ Respond ONLY with JSON: {{"value": "extracted_value_or_null", "confident": true_
     else:
         try:
             response = await asyncio.wait_for(
-                _get_llm().ainvoke([
+                _get_llm("haiku").ainvoke([
                     SystemMessage(content="Extract the slot value. JSON only."),
                     HumanMessage(content=extraction_prompt)
                 ]),
@@ -682,7 +601,7 @@ Keep it conversational and under 100 words unless showing a document preview.
 
     try:
         response = await asyncio.wait_for(
-            _get_llm().ainvoke([
+            _get_llm("haiku").ainvoke([
                 SystemMessage(content="You are Aria. Write a natural confirmation message."),
                 HumanMessage(content=preview_prompt)
             ]),

--- a/backend/aria/core/conversation_engine.py
+++ b/backend/aria/core/conversation_engine.py
@@ -19,8 +19,6 @@ import asyncio
 import json
 import logging
 import re
-import threading
-import time as _time_module
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Optional, Annotated

--- a/backend/tests/test_conversation_engine_tiering.py
+++ b/backend/tests/test_conversation_engine_tiering.py
@@ -14,3 +14,11 @@ def test_get_llm_default_is_sonnet():
 def test_uses_shared_circuit_breaker():
     from agents.orchestration.llm_circuit_breaker import LLMCircuitBreaker
     assert isinstance(ce._circuit_breaker, LLMCircuitBreaker)
+
+
+def test_llm_preserves_temperature_and_max_tokens():
+    # Behavioural-equivalence guard: the ModelRouter path must keep the same
+    # generation params the old _get_llm() used directly (temperature 0.3, 1024).
+    client = ce._get_llm()
+    assert client.temperature == 0.3
+    assert client.max_tokens == 1024

--- a/backend/tests/test_conversation_engine_tiering.py
+++ b/backend/tests/test_conversation_engine_tiering.py
@@ -1,0 +1,16 @@
+from aria.core import conversation_engine as ce
+
+
+def test_get_llm_haiku_tier_returns_haiku_model():
+    client = ce._get_llm("haiku")
+    assert "haiku" in client.model.lower()
+
+
+def test_get_llm_default_is_sonnet():
+    client = ce._get_llm()
+    assert "sonnet" in client.model.lower()
+
+
+def test_uses_shared_circuit_breaker():
+    from agents.orchestration.llm_circuit_breaker import LLMCircuitBreaker
+    assert isinstance(ce._circuit_breaker, LLMCircuitBreaker)

--- a/backend/tests/test_llm_circuit_breaker.py
+++ b/backend/tests/test_llm_circuit_breaker.py
@@ -1,0 +1,38 @@
+import time
+import pytest
+from agents.orchestration.llm_circuit_breaker import LLMCircuitBreaker, CircuitState
+
+
+def test_starts_closed_and_allows():
+    cb = LLMCircuitBreaker(failure_threshold=3, cooldown_seconds=0.1)
+    assert cb.state == CircuitState.CLOSED
+    assert cb.allow_request() is True
+
+
+def test_opens_after_threshold_failures():
+    cb = LLMCircuitBreaker(failure_threshold=3, cooldown_seconds=0.1)
+    for _ in range(3):
+        cb.record_failure()
+    assert cb.state == CircuitState.OPEN
+    assert cb.allow_request() is False
+
+
+def test_half_open_after_cooldown_then_closes_on_success():
+    cb = LLMCircuitBreaker(failure_threshold=2, cooldown_seconds=0.05)
+    cb.record_failure()
+    cb.record_failure()
+    assert cb.state == CircuitState.OPEN
+    time.sleep(0.06)
+    assert cb.state == CircuitState.HALF_OPEN
+    assert cb.allow_request() is True
+    cb.record_success()
+    assert cb.state == CircuitState.CLOSED
+
+
+def test_half_open_probe_failure_reopens():
+    cb = LLMCircuitBreaker(failure_threshold=1, cooldown_seconds=0.05)
+    cb.record_failure()
+    time.sleep(0.06)
+    assert cb.state == CircuitState.HALF_OPEN
+    cb.record_failure()
+    assert cb.state == CircuitState.OPEN

--- a/backend/tests/test_llm_circuit_breaker.py
+++ b/backend/tests/test_llm_circuit_breaker.py
@@ -1,5 +1,4 @@
 import time
-import pytest
 from agents.orchestration.llm_circuit_breaker import LLMCircuitBreaker, CircuitState
 
 

--- a/backend/tests/test_model_router.py
+++ b/backend/tests/test_model_router.py
@@ -1,0 +1,33 @@
+import pytest
+from agents.orchestration.model_router import ModelRouter
+
+
+def test_haiku_tier_uses_haiku_model(monkeypatch):
+    monkeypatch.delenv("ARIA_HAIKU_MODEL", raising=False)
+    r = ModelRouter()
+    client = r.get("haiku")
+    assert "haiku" in client.model.lower()
+
+
+def test_sonnet_tier_uses_sonnet_model(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
+    r = ModelRouter()
+    client = r.get("sonnet")
+    assert "sonnet" in client.model.lower()
+
+
+def test_env_overrides_model_id(monkeypatch):
+    monkeypatch.setenv("ARIA_HAIKU_MODEL", "claude-haiku-4-5-20251001")
+    r = ModelRouter()
+    assert r.get("haiku").model == "claude-haiku-4-5-20251001"
+
+
+def test_clients_are_cached(monkeypatch):
+    r = ModelRouter()
+    assert r.get("haiku") is r.get("haiku")
+
+
+def test_unknown_tier_raises():
+    r = ModelRouter()
+    with pytest.raises(ValueError):
+        r.get("turbo")

--- a/backend/tests/test_tool_confirmation_policy.py
+++ b/backend/tests/test_tool_confirmation_policy.py
@@ -31,5 +31,7 @@ def test_readonly_low_risk_does_not_require():
 
 
 def test_unknown_tool_name_defaults_to_require():
-    # default-deny: a name not in the registry is treated as needing confirmation
-    assert requires_confirmation_for("a_tool_that_does_not_exist") is True
+    # default-deny: a name not in the registry is treated as needing confirmation.
+    # Use a collision-proof name so a future registration can't silently turn this
+    # into a test of a registered tool's policy (ToolRegistry is a singleton).
+    assert requires_confirmation_for("__no_such_tool_xyzzy_98f3c1__") is True

--- a/backend/tests/test_tool_confirmation_policy.py
+++ b/backend/tests/test_tool_confirmation_policy.py
@@ -1,0 +1,35 @@
+import pytest
+from agents.tools.base import ToolDefinition, ToolRegistry, requires_confirmation_for
+
+
+def _td(**kw):
+    base = dict(func=lambda **_: None, name="t", description="d", agent_roles=["x"])
+    base.update(kw)
+    return ToolDefinition(**base)
+
+
+def test_new_fields_default_safe():
+    td = _td()
+    assert td.side_effect is False
+    assert td.surface_constraints == []
+
+
+def test_explicit_requires_confirmation_true():
+    assert requires_confirmation_for(_td(name="a", requires_confirmation=True)) is True
+
+
+def test_side_effect_requires_confirmation():
+    assert requires_confirmation_for(_td(name="b", side_effect=True)) is True
+
+
+def test_high_risk_requires_confirmation():
+    assert requires_confirmation_for(_td(name="c", risk_level="high")) is True
+
+
+def test_readonly_low_risk_does_not_require():
+    assert requires_confirmation_for(_td(name="d", risk_level="low")) is False
+
+
+def test_unknown_tool_name_defaults_to_require():
+    # default-deny: a name not in the registry is treated as needing confirmation
+    assert requires_confirmation_for("a_tool_that_does_not_exist") is True


### PR DESCRIPTION
## Summary

Phase 1 of collapsing Aria's three separate "brains" (chat `conversation_engine`, LiveKit `voice_agent`, `agents/orchestrator`) into one. This PR ships only the **shared-services foundation** — later phases build on it.

- **`LLMCircuitBreaker`** (`agents/orchestration/llm_circuit_breaker.py`): one shared breaker, extracted from two byte-identical duplicates (`orchestrator.py`'s `CircuitBreaker` and `conversation_engine.py`'s `_AriaCircuitBreaker`). A `CircuitBreaker = LLMCircuitBreaker` alias preserves two existing test imports.
- **`ModelRouter`** (`agents/orchestration/model_router.py`): maps `"haiku"`/`"sonnet"` tiers to cached `ChatAnthropic` clients; env-tunable via `ANTHROPIC_MODEL` / `ARIA_HAIKU_MODEL`.
- **Default-deny confirmation policy** (`agents/tools/base.py`): adds `side_effect` + `surface_constraints` to `ToolDefinition` and a `requires_confirmation_for()` helper. ⚠️ **Defined, NOT enforced** — no caller wires it yet (the confirm gate lands in Phase 2). **This PR changes zero confirmation behavior.**
- **Haiku tiering of chat classification** (`aria/core/conversation_engine.py`): the four classification nodes (NLU, slot-fill, slot-answer, confirmation) now run on Haiku via `ModelRouter`; **both** response-node branches stay on Sonnet. Generation params (`temperature=0.3, max_tokens=1024`) are preserved — guarded by a test. This is the only runtime behavior change.

The only intended runtime change is the cheaper model tier on those four classification nodes. No prompt, graph-edge, or slot-logic changes.

## Test Plan
- [x] 19 new unit tests pass locally (circuit breaker, ModelRouter, confirmation policy, chat tiering)
- [x] `conversation_engine` graph compiles; orchestrator + all new modules import
- [x] Regression: the only failing breaker/intent tests are **pre-existing** (verified byte-identical pass/fail counts at the pre-Phase-1 baseline; `test_ai_resilience` exercises a *different* breaker, `services/smart_docs/ai_resilience.py`, untouched here)
- [ ] **CI on Python 3.11**: full suite green (local env is 3.14 with missing optional deps — full suite could not be run locally)
- [ ] **CI/staging**: live NLU-on-Haiku correctness smoke — confirm the cheaper model still resolves intents correctly (wiring tests prove the model id; this proves comprehension)

## Notes for reviewers / Phase 2
- **Confirmation policy is defined, not enforced.** Do not read this as "confirmations hardened."
- **Follow-up for Phase 2/3:** `ModelRouter` fixes `(temperature, max_tokens)` at construction. Phase 3's voice path and the campaign LLM sites use different params; evolve `get(tier, *, temperature=None, max_tokens=None)` with the cache key including overrides before more callers route through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)