### PR TITLE
Aria Unified Brain — Phase 2A: grounding contract

### DIFF
--- a/backend/aria/core/conversation_engine.py
+++ b/backend/aria/core/conversation_engine.py
@@ -36,7 +36,7 @@ from agents.orchestration.model_router import get_model_router
 from aria.core.intent_registry import IntentRegistry, Intent, SlotSpec, intent_category
 from aria.core.context_loader import AriaContextLoader
 from aria.core.mode_router import classify_mode, AriaMode
-from aria.core.grounding import ground_answer, format_grounded_message, DISCLAIMER
+from aria.core.grounding import ground_answer, format_grounded_message, DISCLAIMER, looks_like_guideline_question
 from aria.tasks.task_executor import TaskExecutor
 
 logger = logging.getLogger(__name__)
@@ -890,6 +890,17 @@ async def query_mode_node(state: AriaState) -> AriaState:
     question = state["messages"][-1].content if state["messages"] else ""
     org_id = state["org_id"]
     user_id = state["user_id"]
+
+    if _grounding_enabled() and looks_like_guideline_question(question):
+        result = await ground_answer(question, org_id)
+        if result.grounded:
+            text = format_grounded_message(result.answer, result.sources)
+        else:
+            text = result.disclaimer or DISCLAIMER
+        return {
+            "messages": [AIMessage(content=text)],
+            "phase": DialoguePhase.RESPONDING,
+        }
 
     # Circuit breaker: fast-fail if LLM is unavailable
     if not _circuit_breaker.allow_request():

--- a/backend/aria/core/conversation_engine.py
+++ b/backend/aria/core/conversation_engine.py
@@ -1026,7 +1026,7 @@ def grounding_check_node(state: AriaState) -> AriaState:
         msg = state.get("grounding_disclaimer") or DISCLAIMER
     return {
         "messages": [AIMessage(content=msg)],
-        "phase": DialoguePhase.RESPONDING.value,
+        "phase": DialoguePhase.RESPONDING,
         "intent": None,
         "missing_slots": [],
         "current_slot_question": None,

--- a/backend/aria/core/conversation_engine.py
+++ b/backend/aria/core/conversation_engine.py
@@ -18,6 +18,7 @@ Architecture:
 import asyncio
 import json
 import logging
+import os
 import re
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
@@ -32,9 +33,10 @@ from typing_extensions import TypedDict
 
 from agents.orchestration.llm_circuit_breaker import LLMCircuitBreaker
 from agents.orchestration.model_router import get_model_router
-from aria.core.intent_registry import IntentRegistry, Intent, SlotSpec
+from aria.core.intent_registry import IntentRegistry, Intent, SlotSpec, intent_category
 from aria.core.context_loader import AriaContextLoader
 from aria.core.mode_router import classify_mode, AriaMode
+from aria.core.grounding import ground_answer, format_grounded_message, DISCLAIMER
 from aria.tasks.task_executor import TaskExecutor
 
 logger = logging.getLogger(__name__)
@@ -66,6 +68,10 @@ _circuit_breaker = LLMCircuitBreaker(failure_threshold=5, cooldown_seconds=30.0,
 
 # Request timeout for individual LLM calls (seconds)
 _LLM_TIMEOUT = 30.0
+
+
+def _grounding_enabled() -> bool:
+    return os.getenv("ARIA_GROUNDING_ENABLED", "false").lower() == "true"
 
 
 # ─── LLM via shared ModelRouter ─────────────────────────────────────────────
@@ -117,6 +123,13 @@ class AriaState(TypedDict):
     # Operational
     iteration_count: int
     error: Optional[str]
+
+    # Grounding (Phase 2A)
+    sources: Optional[List[Dict[str, Any]]]
+    citations: Optional[List[Dict[str, Any]]]
+    grounded: Optional[bool]
+    grounding_answer: Optional[str]
+    grounding_disclaimer: Optional[str]
 
 
 # ─── System prompt for Aria ───────────────────────────────────────────────────
@@ -871,7 +884,6 @@ async def query_mode_node(state: AriaState) -> AriaState:
     """Agentic query mode — Claude picks tools, chains queries, synthesizes answer."""
     import json as _json
     import anthropic
-    import os
 
     from aria.tools.crm_query_tools import QUERY_TOOL_DEFINITIONS, execute_query_tool
 
@@ -991,6 +1003,42 @@ async def query_mode_node(state: AriaState) -> AriaState:
     }
 
 
+async def ground_node(state: AriaState) -> AriaState:
+    """Retrieve grounded guideline context for a factual turn."""
+    question = (state.get("slots") or {}).get("question") \
+        or (state["messages"][-1].content if state.get("messages") else "")
+    result = await ground_answer(question, state["org_id"])
+    return {
+        "sources": result.sources,
+        "citations": result.citations,
+        "grounded": result.grounded,
+        "grounding_answer": result.answer,
+        "grounding_disclaimer": result.disclaimer or DISCLAIMER,
+    }
+
+
+def grounding_check_node(state: AriaState) -> AriaState:
+    """Blocking sufficiency gate: emit the cited answer, or a terminal disclaimer."""
+    if state.get("grounded"):
+        msg = format_grounded_message(state.get("grounding_answer") or "",
+                                      state.get("sources") or [])
+    else:
+        msg = state.get("grounding_disclaimer") or DISCLAIMER
+    return {
+        "messages": [AIMessage(content=msg)],
+        "phase": DialoguePhase.RESPONDING.value,
+        "intent": None,
+        "missing_slots": [],
+        "current_slot_question": None,
+        "slots": {},
+        "mode": None,
+        "task_result": None,
+        "confirmation_preview": None,
+        "error": None,
+        "iteration_count": 0,
+    }
+
+
 # ─── Entry router nodes ──────────────────────────────────────────────────────
 
 MAX_SLOT_ITERATIONS = 6
@@ -1078,12 +1126,16 @@ def route_after_nlu(state: AriaState) -> str:
         return "response"
     if state["missing_slots"]:
         return "slot_fill"
+    if _grounding_enabled() and intent_category(state.get("intent")) == "factual":
+        return "ground"
     return "confirmation"
 
 
 def route_after_slot_answer(state: AriaState) -> str:
     if state["missing_slots"]:
         return "slot_fill"
+    if _grounding_enabled() and intent_category(state.get("intent")) == "factual":
+        return "ground"
     return "confirmation"
 
 
@@ -1136,16 +1188,18 @@ def build_aria_graph() -> StateGraph:
     graph = StateGraph(AriaState)
 
     # Nodes
-    graph.add_node("dispatch",      dispatch_node)
-    graph.add_node("nlu",           nlu_node)
-    graph.add_node("slot_fill",     slot_fill_node)
-    graph.add_node("slot_answer",   slot_answer_node)
-    graph.add_node("confirmation",  confirmation_node)
-    graph.add_node("check_confirm", check_confirm_node)
-    graph.add_node("cancel",        cancel_node)
-    graph.add_node("execute",       execute_node)
-    graph.add_node("response",      response_node)
-    graph.add_node("query_mode",    query_mode_node)
+    graph.add_node("dispatch",         dispatch_node)
+    graph.add_node("nlu",              nlu_node)
+    graph.add_node("slot_fill",        slot_fill_node)
+    graph.add_node("slot_answer",      slot_answer_node)
+    graph.add_node("confirmation",     confirmation_node)
+    graph.add_node("check_confirm",    check_confirm_node)
+    graph.add_node("cancel",           cancel_node)
+    graph.add_node("execute",          execute_node)
+    graph.add_node("response",         response_node)
+    graph.add_node("query_mode",       query_mode_node)
+    graph.add_node("ground",           ground_node)
+    graph.add_node("grounding_check",  grounding_check_node)
 
     # Entry point — dispatch routes based on current dialogue phase
     graph.set_entry_point("dispatch")
@@ -1158,20 +1212,22 @@ def build_aria_graph() -> StateGraph:
         "query_mode":    "query_mode",
     })
 
-    # NLU routes: chitchat → response, missing slots → slot_fill, ready → confirmation
+    # NLU routes: chitchat → response, missing slots → slot_fill, factual → ground, ready → confirmation
     graph.add_conditional_edges("nlu", route_after_nlu, {
         "slot_fill":    "slot_fill",
         "confirmation": "confirmation",
         "response":     "response",
+        "ground":       "ground",
     })
 
     # Slot fill asks question then returns to user (END)
     graph.add_edge("slot_fill", END)
 
-    # Slot answer: more slots needed → slot_fill, all done → confirmation
+    # Slot answer: more slots needed → slot_fill, factual → ground, all done → confirmation
     graph.add_conditional_edges("slot_answer", route_after_slot_answer, {
         "slot_fill":    "slot_fill",
         "confirmation": "confirmation",
+        "ground":       "ground",
     })
 
     # Confirmation: no-confirm intents → execute immediately; otherwise wait for user
@@ -1190,6 +1246,10 @@ def build_aria_graph() -> StateGraph:
 
     # Query mode → END
     graph.add_edge("query_mode", END)
+
+    # Grounding path: ground → grounding_check → END
+    graph.add_edge("ground", "grounding_check")
+    graph.add_edge("grounding_check", END)
 
     # Cancelled confirmation → END (acknowledged, nothing executed)
     graph.add_edge("cancel", END)

--- a/backend/aria/core/grounding.py
+++ b/backend/aria/core/grounding.py
@@ -1,0 +1,99 @@
+"""
+Grounding contract for Aria factual answers (Phase 2A).
+
+Wraps the existing KnowledgeTools/GuidelineSearchService RAG path and adds a
+deterministic sufficiency gate + citation formatting, so guideline answers are
+grounded-or-disclaimed rather than free-form LLM output.
+"""
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("aria.grounding")
+
+# Minimum average retrieval similarity to treat a RAG answer as sufficiently grounded.
+GROUNDING_MIN_CONFIDENCE = float(os.getenv("ARIA_GROUNDING_MIN_CONFIDENCE", "0.45"))
+
+DISCLAIMER = (
+    "I don't have this in the indexed official guidelines, so this is general "
+    "knowledge — please verify against the source guideline before relying on it."
+)
+
+
+@dataclass
+class GroundingResult:
+    answer: str
+    sources: List[Dict[str, Any]] = field(default_factory=list)
+    citations: List[Dict[str, Any]] = field(default_factory=list)
+    confidence: Optional[float] = None
+    grounded: bool = False
+    disclaimer: Optional[str] = None
+
+
+def is_sufficiently_grounded(result: "GroundingResult",
+                             min_confidence: float = GROUNDING_MIN_CONFIDENCE) -> bool:
+    """Blocking sufficiency gate: require >=1 source AND confidence at/above threshold."""
+    if not result.sources:
+        return False
+    if result.confidence is None:
+        return False
+    return result.confidence >= min_confidence
+
+
+async def ground_answer(question: str, org_id) -> "GroundingResult":
+    """Run the guideline RAG path and wrap the result in a GroundingResult.
+
+    Never raises — on any failure, returns an ungrounded result with a disclaimer.
+    """
+    from aria.tools.knowledge_tools import KnowledgeTools
+    try:
+        tenant_id = int(org_id) if org_id is not None else None
+    except (TypeError, ValueError):
+        tenant_id = None
+    try:
+        raw = await KnowledgeTools().search_guidelines_rag(question=question, tenant_id=tenant_id)
+    except Exception as e:
+        logger.exception("ground_answer RAG call failed: %s", e)
+        return GroundingResult(answer=DISCLAIMER, grounded=False, disclaimer=DISCLAIMER)
+
+    result = GroundingResult(
+        answer=raw.get("answer", "") or "",
+        sources=raw.get("sources", []) or [],
+        citations=raw.get("citations", []) or [],
+        confidence=raw.get("confidence"),
+        disclaimer=raw.get("disclaimer"),
+    )
+    result.grounded = is_sufficiently_grounded(result)
+    return result
+
+
+_GUIDELINE_HINTS = (
+    "fha", "usda", "conventional", "conforming", "guideline", "eligibility",
+    "reserve", "ltv", "dti", "credit score", "seasoning", "waiting period",
+    "down payment requirement", "occupancy requirement", "loan limit", "qualify",
+)
+
+
+def looks_like_guideline_question(text: str) -> bool:
+    """Heuristic: does this QUERY-mode turn look like a guideline question?
+
+    Intentionally conservative — only delegates QUERY turns that clearly mention
+    guideline concepts to the grounding path; operational queries fall through.
+    """
+    if not text:
+        return False
+    t = text.lower()
+    return any(hint in t for hint in _GUIDELINE_HINTS)
+
+
+def format_grounded_message(answer: str, sources: List[Dict[str, Any]]) -> str:
+    """Append a human-readable Sources list to a RAG answer (which already has [n] markers)."""
+    if not sources:
+        return answer
+    lines = []
+    for i, s in enumerate(sources, start=1):
+        name = s.get("guideline_name") or s.get("guideline_type") or "Guideline"
+        program = s.get("loan_program")
+        lines.append(f"[{i}] {name}" + (f" ({program})" if program else ""))
+    return f"{answer}\n\nSources:\n" + "\n".join(lines)

--- a/backend/aria/core/grounding.py
+++ b/backend/aria/core/grounding.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger("aria.grounding")
 
 # Minimum average retrieval similarity to treat a RAG answer as sufficiently grounded.
+# Read once at import time; callers needing dynamic tuning should pass min_confidence
+# to is_sufficiently_grounded() explicitly rather than mutating the env var at runtime.
 GROUNDING_MIN_CONFIDENCE = float(os.getenv("ARIA_GROUNDING_MIN_CONFIDENCE", "0.45"))
 
 DISCLAIMER = (
@@ -41,10 +43,11 @@ def is_sufficiently_grounded(result: "GroundingResult",
     return result.confidence >= min_confidence
 
 
-async def ground_answer(question: str, org_id) -> "GroundingResult":
+async def ground_answer(question: str, org_id: Any) -> "GroundingResult":
     """Run the guideline RAG path and wrap the result in a GroundingResult.
 
-    Never raises — on any failure, returns an ungrounded result with a disclaimer.
+    Never raises — on any failure (or an unexpected RAG return type), returns an
+    ungrounded result with a disclaimer.
     """
     from aria.tools.knowledge_tools import KnowledgeTools
     try:
@@ -53,8 +56,12 @@ async def ground_answer(question: str, org_id) -> "GroundingResult":
         tenant_id = None
     try:
         raw = await KnowledgeTools().search_guidelines_rag(question=question, tenant_id=tenant_id)
-    except Exception as e:
-        logger.exception("ground_answer RAG call failed: %s", e)
+    except Exception:
+        logger.exception("ground_answer RAG call failed")
+        return GroundingResult(answer=DISCLAIMER, grounded=False, disclaimer=DISCLAIMER)
+
+    if not isinstance(raw, dict):
+        logger.warning("ground_answer: unexpected RAG response type %s", type(raw))
         return GroundingResult(answer=DISCLAIMER, grounded=False, disclaimer=DISCLAIMER)
 
     result = GroundingResult(
@@ -71,15 +78,16 @@ async def ground_answer(question: str, org_id) -> "GroundingResult":
 _GUIDELINE_HINTS = (
     "fha", "usda", "conventional", "conforming", "guideline", "eligibility",
     "reserve", "ltv", "dti", "credit score", "seasoning", "waiting period",
-    "down payment requirement", "occupancy requirement", "loan limit", "qualify",
+    "down payment requirement", "occupancy requirement", "loan limit", "qualify for",
 )
 
 
 def looks_like_guideline_question(text: str) -> bool:
     """Heuristic: does this QUERY-mode turn look like a guideline question?
 
-    Intentionally conservative — only delegates QUERY turns that clearly mention
-    guideline concepts to the grounding path; operational queries fall through.
+    A first-cut substring match behind the grounding flag — a false positive only
+    costs an unnecessary RAG call (it does not produce a wrong answer), so the
+    hints favour recall. Operational queries with none of these terms fall through.
     """
     if not text:
         return False

--- a/backend/aria/core/intent_registry.py
+++ b/backend/aria/core/intent_registry.py
@@ -338,3 +338,18 @@ def _build_intents() -> List[Intent]:
             requires_confirmation=False,
         ),
     ]
+
+
+def intent_category(intent_name) -> str:
+    """Derive the Phase-2 grounding category from an intent's registry category.
+
+    'factual'     -> guideline/knowledge questions that must be grounded (RAG).
+    'chitchat'    -> no resolved intent (general conversation).
+    'operational' -> everything else (DB-backed actions/lookups; no RAG).
+    """
+    if not intent_name:
+        return "chitchat"
+    intent = IntentRegistry.get().get_intent(intent_name)
+    if intent is None:
+        return "chitchat"
+    return "factual" if intent.category == "knowledge" else "operational"

--- a/backend/aria/core/intent_registry.py
+++ b/backend/aria/core/intent_registry.py
@@ -340,12 +340,12 @@ def _build_intents() -> List[Intent]:
     ]
 
 
-def intent_category(intent_name) -> str:
+def intent_category(intent_name: Optional[str]) -> str:
     """Derive the Phase-2 grounding category from an intent's registry category.
 
     'factual'     -> guideline/knowledge questions that must be grounded (RAG).
     'chitchat'    -> no resolved intent (general conversation).
-    'operational' -> everything else (DB-backed actions/lookups; no RAG).
+    'operational' -> everything else (actions, lookups, reporting, analysis; no RAG).
     """
     if not intent_name:
         return "chitchat"

--- a/backend/tests/test_conversation_engine_grounding.py
+++ b/backend/tests/test_conversation_engine_grounding.py
@@ -75,13 +75,18 @@ async def test_query_mode_delegates_guideline_question(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_query_mode_operational_not_delegated(monkeypatch):
+    # An operational QUERY turn must run query_mode_node WITHOUT delegating to grounding.
     monkeypatch.setenv("ARIA_GROUNDING_ENABLED", "true")
     called = {"ground": False}
     async def fake_ground(question, org_id):
         called["ground"] = True
         return grounding.GroundingResult(answer="x", grounded=True)
     monkeypatch.setattr(ce, "ground_answer", fake_ground)
-    from aria.core.grounding import looks_like_guideline_question
-    # Operational lookups must NOT be classified as guideline questions:
-    assert looks_like_guideline_question("How many leads do I have today?") is False
+    # Force the circuit breaker open so the node returns its fast-fail fallback
+    # without making any real LLM/DB call — we only care that grounding was skipped.
+    monkeypatch.setattr(ce._circuit_breaker, "allow_request", lambda: False)
+    state = _base_state("How many leads do I have today?", intent=None, slots={})
+    state["mode"] = "query"
+    out = await ce.query_mode_node(state)
     assert called["ground"] is False
+    assert out["messages"][-1].content  # returned a (fallback) message, did not delegate

--- a/backend/tests/test_conversation_engine_grounding.py
+++ b/backend/tests/test_conversation_engine_grounding.py
@@ -57,3 +57,31 @@ async def test_grounding_check_emits_cited_answer_when_grounded(monkeypatch):
     text = final["messages"][-1].content
     assert "FHA requires X [1]." in text
     assert "FHA Handbook 4000.1" in text
+
+
+@pytest.mark.asyncio
+async def test_query_mode_delegates_guideline_question(monkeypatch):
+    monkeypatch.setenv("ARIA_GROUNDING_ENABLED", "true")
+    async def fake_ground(question, org_id):
+        return grounding.GroundingResult(answer="FHA X [1].",
+            sources=[{"guideline_name": "FHA Handbook 4000.1"}], confidence=0.8, grounded=True)
+    monkeypatch.setattr(ce, "ground_answer", fake_ground)
+    state = _base_state("What is the FHA reserve requirement?", intent=None, slots={})
+    state["mode"] = "query"
+    out = await ce.query_mode_node(state)
+    text = out["messages"][-1].content
+    assert "FHA X [1]." in text and "FHA Handbook 4000.1" in text
+
+
+@pytest.mark.asyncio
+async def test_query_mode_operational_not_delegated(monkeypatch):
+    monkeypatch.setenv("ARIA_GROUNDING_ENABLED", "true")
+    called = {"ground": False}
+    async def fake_ground(question, org_id):
+        called["ground"] = True
+        return grounding.GroundingResult(answer="x", grounded=True)
+    monkeypatch.setattr(ce, "ground_answer", fake_ground)
+    from aria.core.grounding import looks_like_guideline_question
+    # Operational lookups must NOT be classified as guideline questions:
+    assert looks_like_guideline_question("How many leads do I have today?") is False
+    assert called["ground"] is False

--- a/backend/tests/test_conversation_engine_grounding.py
+++ b/backend/tests/test_conversation_engine_grounding.py
@@ -1,0 +1,59 @@
+import pytest
+from aria.core import conversation_engine as ce
+from aria.core import grounding
+
+
+def _base_state(message, intent="mortgage_guideline_question", slots=None):
+    from langchain_core.messages import HumanMessage
+    return {
+        "messages": [HumanMessage(content=message)],
+        "intent": intent, "slots": slots if slots is not None else {"question": message},
+        "missing_slots": [], "current_slot_question": None,
+        "phase": ce.DialoguePhase.UNDERSTANDING.value,
+        "task_result": None, "confirmation_preview": None,
+        "user_id": "u1", "org_id": "1", "user_name": "Lo", "user_email": None,
+        "user_role": "loan_officer", "mode": None, "voice_preferences": None,
+        "iteration_count": 0, "error": None,
+    }
+
+
+def test_route_after_nlu_sends_factual_to_ground_when_flag_on(monkeypatch):
+    monkeypatch.setenv("ARIA_GROUNDING_ENABLED", "true")
+    state = _base_state("FHA reserves?")
+    assert ce.route_after_nlu(state) == "ground"
+
+
+def test_route_after_nlu_unchanged_when_flag_off(monkeypatch):
+    monkeypatch.setenv("ARIA_GROUNDING_ENABLED", "false")
+    state = _base_state("FHA reserves?")
+    assert ce.route_after_nlu(state) == "confirmation"
+
+
+@pytest.mark.asyncio
+async def test_grounding_check_emits_disclaimer_when_insufficient(monkeypatch):
+    async def fake_ground(question, org_id):
+        return grounding.GroundingResult(answer="x", sources=[], confidence=None,
+                                         grounded=False, disclaimer="DISC")
+    monkeypatch.setattr(ce, "ground_answer", fake_ground)
+    state = _base_state("obscure")
+    out = await ce.ground_node(state)
+    merged = {**state, **out}
+    final = ce.grounding_check_node(merged)
+    assert "DISC" in final["messages"][-1].content
+
+
+@pytest.mark.asyncio
+async def test_grounding_check_emits_cited_answer_when_grounded(monkeypatch):
+    async def fake_ground(question, org_id):
+        return grounding.GroundingResult(
+            answer="FHA requires X [1].",
+            sources=[{"guideline_name": "FHA Handbook 4000.1"}],
+            confidence=0.8, grounded=True)
+    monkeypatch.setattr(ce, "ground_answer", fake_ground)
+    state = _base_state("FHA reserves?")
+    out = await ce.ground_node(state)
+    merged = {**state, **out}
+    final = ce.grounding_check_node(merged)
+    text = final["messages"][-1].content
+    assert "FHA requires X [1]." in text
+    assert "FHA Handbook 4000.1" in text

--- a/backend/tests/test_conversation_engine_grounding.py
+++ b/backend/tests/test_conversation_engine_grounding.py
@@ -90,3 +90,24 @@ async def test_query_mode_operational_not_delegated(monkeypatch):
     out = await ce.query_mode_node(state)
     assert called["ground"] is False
     assert out["messages"][-1].content  # returned a (fallback) message, did not delegate
+
+
+def test_flag_off_factual_routes_legacy(monkeypatch):
+    monkeypatch.setenv("ARIA_GROUNDING_ENABLED", "false")
+    state = _base_state("FHA reserves?")
+    assert ce.route_after_nlu(state) == "confirmation"
+    assert ce.route_after_slot_answer(state) == "confirmation"
+
+
+def test_flag_on_factual_routes_ground_both_routers(monkeypatch):
+    monkeypatch.setenv("ARIA_GROUNDING_ENABLED", "true")
+    state = _base_state("FHA reserves?")
+    assert ce.route_after_nlu(state) == "ground"
+    assert ce.route_after_slot_answer(state) == "ground"
+
+
+def test_flag_off_operational_intent_routes_legacy(monkeypatch):
+    monkeypatch.setenv("ARIA_GROUNDING_ENABLED", "false")
+    state = _base_state("send a text", intent="send_sms", slots={})
+    # operational intent never grounds regardless of flag; legacy path is confirmation
+    assert ce.route_after_nlu(state) == "confirmation"

--- a/backend/tests/test_grounding.py
+++ b/backend/tests/test_grounding.py
@@ -1,0 +1,65 @@
+import pytest
+from aria.core import grounding
+from aria.core.grounding import (
+    GroundingResult,
+    is_sufficiently_grounded,
+    looks_like_guideline_question,
+    format_grounded_message,
+)
+
+
+def test_sufficient_when_sources_and_confidence_ok():
+    r = GroundingResult(answer="a", sources=[{"guideline_name": "FHA"}], confidence=0.7)
+    assert is_sufficiently_grounded(r, min_confidence=0.45) is True
+
+
+def test_insufficient_when_no_sources():
+    r = GroundingResult(answer="a", sources=[], confidence=0.9)
+    assert is_sufficiently_grounded(r, min_confidence=0.45) is False
+
+
+def test_insufficient_when_low_confidence():
+    r = GroundingResult(answer="a", sources=[{"guideline_name": "FHA"}], confidence=0.2)
+    assert is_sufficiently_grounded(r, min_confidence=0.45) is False
+
+
+def test_insufficient_when_confidence_none():
+    r = GroundingResult(answer="a", sources=[{"guideline_name": "FHA"}], confidence=None)
+    assert is_sufficiently_grounded(r, min_confidence=0.45) is False
+
+
+def test_looks_like_guideline_question():
+    assert looks_like_guideline_question("What is the FHA reserve requirement?") is True
+    assert looks_like_guideline_question("How many leads do I have today?") is False
+    assert looks_like_guideline_question("") is False
+
+
+def test_format_grounded_message_includes_sources():
+    msg = format_grounded_message("Answer body [1].", [{"guideline_name": "FHA Handbook 4000.1"}])
+    assert "Answer body [1]." in msg
+    assert "FHA Handbook 4000.1" in msg
+
+
+@pytest.mark.asyncio
+async def test_ground_answer_marks_grounded(monkeypatch):
+    async def fake_rag(self, question, loan_program=None, agency=None, include_overlays=True, tenant_id=None):
+        return {"answer": "FHA requires X [1].",
+                "sources": [{"guideline_name": "FHA Handbook 4000.1"}],
+                "citations": [{"index": 1, "guideline_name": "FHA Handbook 4000.1"}],
+                "confidence": 0.8, "rag_enabled": True, "query": question}
+    monkeypatch.setattr("aria.tools.knowledge_tools.KnowledgeTools.search_guidelines_rag", fake_rag)
+    result = await grounding.ground_answer("FHA reserves?", org_id=1)
+    assert result.grounded is True
+    assert result.sources and result.confidence == 0.8
+
+
+@pytest.mark.asyncio
+async def test_ground_answer_disclaimer_on_no_results(monkeypatch):
+    async def fake_rag(self, question, loan_program=None, agency=None, include_overlays=True, tenant_id=None):
+        return {"answer": "General knowledge answer.", "sources": [], "citations": [],
+                "confidence": None, "rag_enabled": False,
+                "disclaimer": "Answer based on general knowledge.", "query": question}
+    monkeypatch.setattr("aria.tools.knowledge_tools.KnowledgeTools.search_guidelines_rag", fake_rag)
+    result = await grounding.ground_answer("obscure question", org_id=1)
+    assert result.grounded is False
+    assert result.disclaimer

--- a/backend/tests/test_intent_category.py
+++ b/backend/tests/test_intent_category.py
@@ -1,0 +1,14 @@
+from aria.core.intent_registry import intent_category
+
+
+def test_knowledge_intent_is_factual():
+    assert intent_category("mortgage_guideline_question") == "factual"
+
+
+def test_action_intent_is_operational():
+    assert intent_category("send_sms") == "operational"
+
+
+def test_none_or_unknown_is_chitchat():
+    assert intent_category(None) == "chitchat"
+    assert intent_category("not_a_real_intent") == "chitchat"

--- a/backend/tests/test_intent_category.py
+++ b/backend/tests/test_intent_category.py
@@ -11,4 +11,5 @@ def test_action_intent_is_operational():
 
 def test_none_or_unknown_is_chitchat():
     assert intent_category(None) == "chitchat"
+    assert intent_category("") == "chitchat"
     assert intent_category("not_a_real_intent") == "chitchat"


### PR DESCRIPTION
## Summary

Phase 2A of the Aria unification: route guideline/knowledge answers through `GuidelineSearchService` with a deterministic sufficiency gate and enforced citations — closing the hallucination gap on the factual path. **Stacked on Phase 1 (#82)** — auto-retargets to `main` when #82 merges.

**Everything is behind `ARIA_GROUNDING_ENABLED` (default off). Flag off ⇒ behavior byte-identical to today** (proven by equivalence tests).

- **`intent_category()`** (`aria/core/intent_registry.py`) — derives `factual`/`operational`/`chitchat` from the existing `Intent.category` field. No new tagging system.
- **`aria/core/grounding.py`** — `GroundingResult`, `ground_answer()` (thin wrapper over the existing tested `KnowledgeTools.search_guidelines_rag`; **never raises**, even on a non-dict RAG return), `is_sufficiently_grounded()` (≥1 source AND confidence ≥ 0.45), `looks_like_guideline_question()`, `format_grounded_message()`.
- **`ground` + `grounding_check` graph nodes** (`conversation_engine.py`) — the `mortgage_guideline_question` (category `knowledge`) intent routes `nlu → ground → grounding_check`. Grounded → cited answer; insufficient → **terminal disclaimer, no loop**. The RAG answer (already carrying `[1]`/`[2]` markers) is emitted directly — no extra LLM regeneration.
- **`query_mode_node` delegation** — guideline-type QUERY turns delegate to the same grounding path; operational lookups ("how many leads") are untouched.

## Design notes
- Sufficiency is **threshold-based** (confidence + sources), not a Haiku check — cheaper/deterministic; the §4a Haiku check is deferred to Phase 2B as a quality enhancement.
- The 5 new `AriaState` grounding fields are single-turn transient; `session_store.save()` whitelists keys, so they aren't persisted (correct).

## Test Plan
- [x] 20 new tests pass (intent_category, grounding module, graph wiring, query-mode delegation, flag-off equivalence)
- [x] Phase 1 regression green (19/19); graph compiles with the flag both off and on
- [x] Flag-off equivalence: both routers return the legacy `confirmation` target; query-mode does not delegate
- [ ] **CI on Python 3.11**: full suite green (local env is 3.14 with pre-existing unrelated collection errors)
- [ ] **CI/staging live RAG smoke**: a real guideline question with `ARIA_GROUNDING_ENABLED=true` returns a cited answer; an out-of-corpus question returns the disclaimer

## Follow-ups for Phase 2B
- **Integration test:** drive the compiled graph across two turns for a factual intent that asks the `question` slot first (slot_fill → ground). Currently unit-tested at the router level; the full path is sound by inspection but lacks an end-to-end test (needs a mocked NLU LLM).
- `looks_like_guideline_question` (recall-favoring heuristic) is the swap point when 2B introduces the unified classifier.
- `GROUNDING_MIN_CONFIDENCE` is import-time; per-org tuning should plumb through `is_sufficiently_grounded(min_confidence=...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)