### PR TITLE
feat(recruit-platform): chatbot KB, website builder, clean landing page URLs

### DIFF
--- a/backend/database/init_db.py
+++ b/backend/database/init_db.py
@@ -2448,6 +2448,22 @@ def init_db():
         except Exception as e:
             logger.warning(f"⚠️ recruit platform admin seed note: {e}")
 
+        # Recruit Platform: chatbot KB + chat session tables
+        try:
+            from migrations.add_recruit_chatbot_tables import run_migration as run_chatbot_tables
+            run_chatbot_tables(_engine)
+            logger.info("✅ recruit chatbot tables ready")
+        except Exception as e:
+            logger.warning(f"⚠️ recruit chatbot tables note: {e}")
+
+        # Recruit Platform: landing pages (website builder)
+        try:
+            from migrations.add_recruit_landing_pages import run_migration as run_landing_pages
+            run_landing_pages(_engine)
+            logger.info("✅ recruit_landing_pages table ready")
+        except Exception as e:
+            logger.warning(f"⚠️ recruit_landing_pages migration note: {e}")
+
         return True
     except Exception as e:
         logger.error(f"❌ Database initialization failed: {e}")

--- a/backend/migrations/add_recruit_landing_pages.py
+++ b/backend/migrations/add_recruit_landing_pages.py
@@ -1,46 +1,57 @@
-"""Migration: create recruit_landing_pages table with RLS."""
+"""
+Recruit Landing Pages Migration
+
+Creates recruit_landing_pages table — stores configurable HTML landing pages
+for the recruiting platform (website builder).
+"""
+
 import logging
+from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 
 
-def run_migration(engine=None):
-    from sqlalchemy import text
+def run_migration(engine=None) -> None:
     if engine is None:
-        from database import engine as _engine
+        from db import engine as _engine
         engine = _engine
+
     with engine.connect() as conn:
         conn.execute(text("""
             CREATE TABLE IF NOT EXISTS recruit_landing_pages (
-                id SERIAL PRIMARY KEY,
-                organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
-                title VARCHAR(200) NOT NULL,
-                slug VARCHAR(100) NOT NULL UNIQUE,
-                status VARCHAR(20) NOT NULL DEFAULT 'draft',
-                config JSONB NOT NULL DEFAULT '{}',
-                view_count INTEGER NOT NULL DEFAULT 0,
-                submission_count INTEGER NOT NULL DEFAULT 0,
-                created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-                updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-                created_by INTEGER REFERENCES users(id)
-            )
-        """))
-        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_recruit_lp_org ON recruit_landing_pages(organization_id)"))
-        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_recruit_lp_slug ON recruit_landing_pages(slug)"))
-        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_recruit_lp_status ON recruit_landing_pages(status)"))
-        conn.execute(text("ALTER TABLE recruit_landing_pages ENABLE ROW LEVEL SECURITY"))
-        conn.execute(text("ALTER TABLE recruit_landing_pages FORCE ROW LEVEL SECURITY"))
-        conn.execute(text("""
-            DO $$ BEGIN
-                DROP POLICY IF EXISTS recruit_landing_pages_tenant ON recruit_landing_pages;
-                CREATE POLICY recruit_landing_pages_tenant ON recruit_landing_pages
-                    USING (organization_id = (
-                        SELECT id FROM organizations
-                        WHERE id = current_setting('app.current_tenant', true)::int
-                    ));
-            EXCEPTION WHEN others THEN NULL;
-            END $$
+                id              SERIAL          PRIMARY KEY,
+                organization_id INTEGER         NOT NULL,
+                title           VARCHAR(255)    NOT NULL,
+                slug            VARCHAR(100)    NOT NULL,
+                status          VARCHAR(20)     NOT NULL DEFAULT 'draft',
+                config          JSONB           NOT NULL DEFAULT '{}'::jsonb,
+                view_count      INTEGER         NOT NULL DEFAULT 0,
+                submission_count INTEGER        NOT NULL DEFAULT 0,
+                created_by      INTEGER,
+                created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+                updated_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+                CONSTRAINT uq_recruit_landing_pages_org_slug UNIQUE (organization_id, slug)
+            );
+
+            CREATE INDEX IF NOT EXISTS ix_recruit_lp_org
+                ON recruit_landing_pages (organization_id);
+            CREATE INDEX IF NOT EXISTS ix_recruit_lp_slug
+                ON recruit_landing_pages (slug);
+            CREATE INDEX IF NOT EXISTS ix_recruit_lp_status
+                ON recruit_landing_pages (status);
+
+            ALTER TABLE recruit_landing_pages ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE recruit_landing_pages FORCE ROW LEVEL SECURITY;
+
+            DROP POLICY IF EXISTS recruit_lp_tenant_isolation ON recruit_landing_pages;
+            CREATE POLICY recruit_lp_tenant_isolation ON recruit_landing_pages
+                USING (
+                    organization_id = (
+                        SELECT id FROM recruit_platform_tenants
+                        WHERE org_slug = current_setting('app.current_tenant', TRUE)
+                        LIMIT 1
+                    )
+                );
         """))
         conn.commit()
-    logger.info("✅ recruit_landing_pages table created/verified")
-    return {"created": True}
+        logger.info("✅ recruit_landing_pages table ready")

--- a/backend/routes/recruit_platform/__init__.py
+++ b/backend/routes/recruit_platform/__init__.py
@@ -10,7 +10,7 @@ from routes.recruit_platform.tenants import tenants_router
 from routes.recruit_platform.applicants import applicants_router
 from routes.recruit_platform.public_application import public_application_router
 from routes.recruit_platform.job_postings import job_postings_router, job_postings_public_router
-from routes.recruit_platform.landing_pages import router as lp_router, public_router as lp_public_router
+from routes.recruit_platform.landing_pages import landing_pages_router, landing_pages_public_router
 from routes.recruit_platform.chatbot import chatbot_router, chatbot_admin_router
 from routes.recruit_platform.knowledge_base import kb_router
 
@@ -18,12 +18,12 @@ router = APIRouter()
 router.include_router(tenants_router)
 router.include_router(applicants_router)
 router.include_router(job_postings_router)
-router.include_router(lp_router)
-router.include_router(chatbot_admin_router)
+router.include_router(landing_pages_router)
 router.include_router(kb_router)
+router.include_router(chatbot_admin_router)
 
 public_router = APIRouter()
 public_router.include_router(public_application_router)
 public_router.include_router(job_postings_public_router)
-public_router.include_router(lp_public_router)
+public_router.include_router(landing_pages_public_router)
 public_router.include_router(chatbot_router)

--- a/backend/routes/recruit_platform/landing_pages.py
+++ b/backend/routes/recruit_platform/landing_pages.py
@@ -1,270 +1,518 @@
 """
-Recruiting platform landing page routes.
+Recruit Platform — Landing Pages (Website Builder)
 
-router       — authenticated CRUD (create, edit, publish, preview)
-public_router — serve rendered HTML + track views
+Authenticated endpoints (admin, prefix /api/v1/recruit-platform/landing-pages):
+  GET    /                           list pages for org
+  POST   /                           create page
+  GET    /{page_id}                  get single page
+  PUT    /{page_id}                  update page
+  DELETE /{page_id}                  delete page
+  POST   /{page_id}/publish          publish page
+  POST   /{page_id}/unpublish        unpublish page
+  GET    /{page_id}/preview          render HTML preview
+
+Public endpoints (no auth, prefix /api/v1/recruit-platform):
+  GET    /p/{slug}                   serve published landing page HTML
+  POST   /public/apply/{org_slug}    receive lead application from form
+  POST   /public/schedule/{org_slug} receive calendar slot booking
 """
+
 import logging
 import os
-import json
-from typing import Optional, Any
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Response
-from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from database import get_db
+from auth.dependencies import get_current_user
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1/recruit-platform/landing-pages")
-public_router = APIRouter(prefix="/api/v1/recruit-platform")
+TEMPLATE_PATH = Path(__file__).resolve().parent.parent.parent / "templates" / "recruit_landing_page.html"
 
-# ── Lazy deps ──────────────────────────────────────────────────────────────────
-def _get_db():
-    from database import get_db
-    return next(get_db())
+API_BASE_URL = os.getenv("API_BASE_URL", "https://api.perenniaai.com")
 
-def _get_cu():
-    from auth.dependencies import get_current_user
-    return get_current_user
+# ---------------------------------------------------------------------------
+# Routers
+# ---------------------------------------------------------------------------
 
-# ── Template loading ───────────────────────────────────────────────────────────
-_TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'templates', 'recruit_landing_page.html')
-_TEMPLATE_CACHE: Optional[str] = None
+landing_pages_router = APIRouter(
+    prefix="/api/v1/recruit-platform/landing-pages",
+    tags=["recruit-landing-pages"],
+)
 
-def _load_template() -> str:
-    global _TEMPLATE_CACHE
-    if _TEMPLATE_CACHE is None:
-        try:
-            with open(_TEMPLATE_PATH, 'r', encoding='utf-8') as f:
-                _TEMPLATE_CACHE = f.read()
-        except FileNotFoundError:
-            logger.error("Landing page template not found at %s", _TEMPLATE_PATH)
-            raise HTTPException(status_code=500, detail="Template not configured")
-    return _TEMPLATE_CACHE
+landing_pages_public_router = APIRouter(
+    prefix="/api/v1/recruit-platform",
+    tags=["recruit-landing-pages-public"],
+)
 
-def _render_template(config: dict, org_slug: str, page_slug: str) -> str:
-    html = _load_template()
-    api_base = os.environ.get('API_BASE_URL', 'https://api.perenniaai.com')
-    subs = {
-        '{{PAGE_TITLE}}': config.get('page_title', 'Careers — Apply Now'),
-        '{{PRIMARY_COLOR}}': config.get('primary_color', '#6AAA26'),
-        '{{PRIMARY_COLOR_DARK}}': config.get('primary_color_dark', '#578F1E'),
-        '{{PRIMARY_COLOR_PALE}}': config.get('primary_color_pale', '#EFF7E1'),
-        '{{LOCATION_DISPLAY}}': config.get('location_display', ''),
-        '{{HERO_HEADLINE}}': config.get('hero_headline', 'Join Our Team'),
-        '{{HERO_SUBHEADLINE}}': config.get('hero_subheadline', ''),
-        '{{SIGNING_BONUS}}': config.get('signing_bonus', '$2,500'),
-        '{{SIGNING_BONUS_MONTH}}': config.get('signing_bonus_month', 'this month'),
-        '{{SIGNING_BONUS_DEADLINE}}': config.get('signing_bonus_deadline', 'this month'),
-        '{{YEAR1_RANGE}}': config.get('year1_range', '$65–90K'),
-        '{{YEAR2_TOP}}': config.get('year2_top', '$120,000+'),
-        '{{SENIOR_LO}}': config.get('senior_lo', '$180,000+'),
-        '{{TEAM_LEAD}}': config.get('team_lead', '$250,000+'),
-        '{{STAT_1_NUM}}': config.get('stat_1_num', '2,400+'),
-        '{{STAT_1_LABEL}}': config.get('stat_1_label', 'Loans closed last year'),
-        '{{STAT_2_NUM}}': config.get('stat_2_num', '94%'),
-        '{{STAT_2_LABEL}}': config.get('stat_2_label', 'Employees promoted within 18 months'),
-        '{{STAT_3_NUM}}': config.get('stat_3_num', '4.97 ★'),
-        '{{STAT_3_LABEL}}': config.get('stat_3_label', 'Team borrower rating'),
-        '{{STAT_4_NUM}}': config.get('stat_4_num', '8 Weeks'),
-        '{{STAT_4_LABEL}}': config.get('stat_4_label', 'Fully paid training program'),
-        '{{MANAGER_INITIALS}}': config.get('manager_initials', ''),
-        '{{MANAGER_NAME}}': config.get('manager_name', ''),
-        '{{MANAGER_TITLE}}': config.get('manager_title', ''),
-        '{{MANAGER_NMLS}}': config.get('manager_nmls', ''),
-        '{{CONTACT_PHONE_DISPLAY}}': config.get('contact_phone_display', ''),
-        '{{CONTACT_PHONE_TEL}}': config.get('contact_phone_tel', ''),
-        '{{COMPANY_NAME}}': config.get('company_name', ''),
-        '{{BRANCH_ADDRESS}}': config.get('branch_address', ''),
-        '{{BRANCH_NMLS}}': config.get('branch_nmls', ''),
-        '{{API_BASE_URL}}': api_base,
-        '{{ORG_SLUG}}': org_slug,
-        '{{PAGE_SLUG}}': page_slug,
-        '{{BASE_HREF}}': '/',
-    }
-    for placeholder, value in subs.items():
-        html = html.replace(placeholder, str(value))
-    return html
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
 
-# ── Pydantic models ────────────────────────────────────────────────────────────
+class LandingPageConfig(BaseModel):
+    primary_color: str = "#6AAA26"
+    primary_color_dark: str = "#578F1E"
+    primary_color_pale: str = "#EFF7E1"
+    company_name: str = ""
+    company_nmls_id: str = ""
+    location_display: str = ""
+    hero_headline: str = "Build a six-figure mortgage career from day one."
+    hero_headline_plain: str = "Build a six-figure mortgage career from day one."
+    signing_bonus: str = "$2,500 signing bonus for July hires"
+    signing_bonus_amount: str = "$2,500"
+    year1_range: str = "$65–90K"
+    year2_top: str = "$120,000+"
+    senior_lo: str = "$180,000+"
+    team_lead: str = "$250,000+"
+    stat_1_num: str = "2,400+"
+    stat_1_label: str = "Loans closed last year"
+    stat_2_num: str = "94%"
+    stat_2_label: str = "Employees promoted within 18 months"
+    stat_3_num: str = "4.97 ★"
+    stat_3_label: str = "Team borrower rating"
+    stat_4_num: str = "8 Weeks"
+    stat_4_label: str = "Fully paid training program"
+    manager_name: str = ""
+    manager_initials: str = ""
+    manager_title: str = "Branch Manager"
+    manager_nmls: str = ""
+    contact_phone_display: str = ""
+    contact_phone_tel: str = ""
+    branch_name: str = ""
+    branch_address: str = ""
+    branch_nmls: str = ""
+
+
 class LandingPageCreate(BaseModel):
     title: str
     slug: str
-    config: dict = {}
+    config: Optional[LandingPageConfig] = None
+
 
 class LandingPageUpdate(BaseModel):
     title: Optional[str] = None
     slug: Optional[str] = None
-    config: Optional[dict] = None
+    config: Optional[LandingPageConfig] = None
 
-class ScheduleRequest(BaseModel):
-    candidate_id: int
-    selected_time: str
-    selected_day: str
 
-# ── Auth endpoints (CRUD) ──────────────────────────────────────────────────────
+class ApplicationSubmission(BaseModel):
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    experience: Optional[str] = None
+    page_slug: Optional[str] = None
 
-@router.get("/")
-async def list_landing_pages(
-    db=Depends(_get_db),
-    current_user: Any = Depends(_get_cu),
+
+class ScheduleSlot(BaseModel):
+    slot: Optional[str] = None
+    page_slug: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_tenant_id(org_slug: str, db: Session) -> Optional[int]:
+    row = db.execute(
+        text("SELECT id FROM recruit_platform_tenants WHERE org_slug = :s LIMIT 1"),
+        {"s": org_slug},
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _render(config: dict, org_slug: str, page_slug: str) -> str:
+    if not TEMPLATE_PATH.exists():
+        raise HTTPException(status_code=500, detail="Landing page template not found")
+
+    with open(TEMPLATE_PATH) as f:
+        html = f.read()
+
+    subs = {
+        "{{PRIMARY_COLOR}}": config.get("primary_color", "#6AAA26"),
+        "{{PRIMARY_COLOR_DARK}}": config.get("primary_color_dark", "#578F1E"),
+        "{{PRIMARY_COLOR_PALE}}": config.get("primary_color_pale", "#EFF7E1"),
+        "{{COMPANY_NAME}}": config.get("company_name", ""),
+        "{{COMPANY_NMLS_ID}}": config.get("company_nmls_id", ""),
+        "{{LOCATION_DISPLAY}}": config.get("location_display", ""),
+        "{{HERO_HEADLINE}}": config.get("hero_headline", ""),
+        "{{HERO_HEADLINE_PLAIN}}": config.get("hero_headline_plain", config.get("hero_headline", "")),
+        "{{SIGNING_BONUS}}": config.get("signing_bonus", ""),
+        "{{SIGNING_BONUS_AMOUNT}}": config.get("signing_bonus_amount", ""),
+        "{{YEAR1_RANGE}}": config.get("year1_range", ""),
+        "{{YEAR2_TOP}}": config.get("year2_top", ""),
+        "{{SENIOR_LO}}": config.get("senior_lo", ""),
+        "{{TEAM_LEAD}}": config.get("team_lead", ""),
+        "{{STAT_1_NUM}}": config.get("stat_1_num", ""),
+        "{{STAT_1_LABEL}}": config.get("stat_1_label", ""),
+        "{{STAT_2_NUM}}": config.get("stat_2_num", ""),
+        "{{STAT_2_LABEL}}": config.get("stat_2_label", ""),
+        "{{STAT_3_NUM}}": config.get("stat_3_num", ""),
+        "{{STAT_3_LABEL}}": config.get("stat_3_label", ""),
+        "{{STAT_4_NUM}}": config.get("stat_4_num", ""),
+        "{{STAT_4_LABEL}}": config.get("stat_4_label", ""),
+        "{{MANAGER_NAME}}": config.get("manager_name", ""),
+        "{{MANAGER_INITIALS}}": config.get("manager_initials", ""),
+        "{{MANAGER_TITLE}}": config.get("manager_title", "Branch Manager"),
+        "{{MANAGER_NMLS}}": config.get("manager_nmls", ""),
+        "{{CONTACT_PHONE_DISPLAY}}": config.get("contact_phone_display", ""),
+        "{{CONTACT_PHONE_TEL}}": config.get("contact_phone_tel", ""),
+        "{{BRANCH_NAME}}": config.get("branch_name", ""),
+        "{{BRANCH_ADDRESS}}": config.get("branch_address", ""),
+        "{{BRANCH_NMLS}}": config.get("branch_nmls", ""),
+        "{{API_BASE_URL}}": API_BASE_URL,
+        "{{ORG_SLUG}}": org_slug,
+        "{{PAGE_SLUG}}": page_slug,
+    }
+
+    for placeholder, value in subs.items():
+        html = html.replace(placeholder, value)
+
+    return html
+
+
+def _page_row_to_dict(row) -> dict:
+    return {
+        "id": row[0],
+        "organization_id": row[1],
+        "title": row[2],
+        "slug": row[3],
+        "status": row[4],
+        "config": row[5] or {},
+        "view_count": row[6],
+        "submission_count": row[7],
+        "created_by": row[8],
+        "created_at": row[9].isoformat() if row[9] else None,
+        "updated_at": row[10].isoformat() if row[10] else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Authenticated endpoints
+# ---------------------------------------------------------------------------
+
+@landing_pages_router.get("")
+def list_landing_pages(
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
-    from sqlalchemy import text
-    rows = db.execute(text("""
-        SELECT id, title, slug, status, view_count, submission_count, created_at, updated_at
-        FROM recruit_landing_pages
-        ORDER BY created_at DESC
-    """)).fetchall()
-    return [dict(r._mapping) for r in rows]
+    org_id = getattr(current_user, "organization_id", None)
+    if not org_id:
+        raise HTTPException(status_code=403, detail="No organization")
+
+    rows = db.execute(
+        text("""
+            SELECT id, organization_id, title, slug, status, config,
+                   view_count, submission_count, created_by, created_at, updated_at
+            FROM recruit_landing_pages
+            WHERE organization_id = :oid
+            ORDER BY updated_at DESC
+        """),
+        {"oid": org_id},
+    ).fetchall()
+
+    return [_page_row_to_dict(r) for r in rows]
 
 
-@router.post("/", status_code=201)
-async def create_landing_page(
+@landing_pages_router.post("", status_code=201)
+def create_landing_page(
     body: LandingPageCreate,
-    db=Depends(_get_db),
-    current_user: Any = Depends(_get_cu),
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
-    from sqlalchemy import text
-    existing = db.execute(text("SELECT id FROM recruit_landing_pages WHERE slug = :s"), {"s": body.slug}).fetchone()
-    if existing:
-        raise HTTPException(status_code=409, detail="Slug already in use")
-    row = db.execute(text("""
-        INSERT INTO recruit_landing_pages (organization_id, title, slug, config, created_by)
-        VALUES (:org, :title, :slug, :cfg::jsonb, :uid)
-        RETURNING id, title, slug, status, config, created_at
-    """), {
-        "org": current_user.organization_id,
-        "title": body.title,
-        "slug": body.slug,
-        "cfg": json.dumps(body.config),
-        "uid": current_user.id,
-    }).fetchone()
-    db.commit()
-    return dict(row._mapping)
+    org_id = getattr(current_user, "organization_id", None)
+    if not org_id:
+        raise HTTPException(status_code=403, detail="No organization")
+
+    config = body.config.model_dump() if body.config else {}
+
+    try:
+        row = db.execute(
+            text("""
+                INSERT INTO recruit_landing_pages
+                    (organization_id, title, slug, status, config, created_by)
+                VALUES (:oid, :title, :slug, 'draft', :config::jsonb, :uid)
+                RETURNING id, organization_id, title, slug, status, config,
+                          view_count, submission_count, created_by, created_at, updated_at
+            """),
+            {
+                "oid": org_id,
+                "title": body.title,
+                "slug": body.slug.lower().strip(),
+                "config": __import__("json").dumps(config),
+                "uid": getattr(current_user, "id", None),
+            },
+        ).fetchone()
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        if "uq_recruit_landing_pages_org_slug" in str(e):
+            raise HTTPException(status_code=409, detail="Slug already exists")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return _page_row_to_dict(row)
 
 
-@router.get("/{page_id}")
-async def get_landing_page(
+@landing_pages_router.get("/{page_id}")
+def get_landing_page(
     page_id: int,
-    db=Depends(_get_db),
-    current_user: Any = Depends(_get_cu),
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
-    from sqlalchemy import text
-    row = db.execute(text("SELECT * FROM recruit_landing_pages WHERE id = :id"), {"id": page_id}).fetchone()
+    org_id = getattr(current_user, "organization_id", None)
+    row = db.execute(
+        text("""
+            SELECT id, organization_id, title, slug, status, config,
+                   view_count, submission_count, created_by, created_at, updated_at
+            FROM recruit_landing_pages
+            WHERE id = :pid AND organization_id = :oid
+        """),
+        {"pid": page_id, "oid": org_id},
+    ).fetchone()
+
     if not row:
-        raise HTTPException(status_code=404, detail="Landing page not found")
-    return dict(row._mapping)
+        raise HTTPException(status_code=404, detail="Page not found")
+
+    return _page_row_to_dict(row)
 
 
-@router.patch("/{page_id}")
-async def update_landing_page(
+@landing_pages_router.put("/{page_id}")
+def update_landing_page(
     page_id: int,
     body: LandingPageUpdate,
-    db=Depends(_get_db),
-    current_user: Any = Depends(_get_cu),
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
-    from sqlalchemy import text
-    if not db.execute(text("SELECT id FROM recruit_landing_pages WHERE id = :id"), {"id": page_id}).fetchone():
-        raise HTTPException(status_code=404, detail="Landing page not found")
-    updates, params = [], {"id": page_id}
+    import json
+    org_id = getattr(current_user, "organization_id", None)
+
+    existing = db.execute(
+        text("SELECT id, config FROM recruit_landing_pages WHERE id = :pid AND organization_id = :oid"),
+        {"pid": page_id, "oid": org_id},
+    ).fetchone()
+    if not existing:
+        raise HTTPException(status_code=404, detail="Page not found")
+
+    updates = {}
     if body.title is not None:
-        updates.append("title = :title"); params["title"] = body.title
+        updates["title"] = body.title
     if body.slug is not None:
-        updates.append("slug = :slug"); params["slug"] = body.slug
+        updates["slug"] = body.slug.lower().strip()
     if body.config is not None:
-        updates.append("config = :cfg::jsonb"); params["cfg"] = json.dumps(body.config)
-    if updates:
-        updates.append("updated_at = NOW()")
-        db.execute(text(f"UPDATE recruit_landing_pages SET {', '.join(updates)} WHERE id = :id"), params)
+        updates["config"] = json.dumps(body.config.model_dump())
+
+    if not updates:
+        return {"detail": "no changes"}
+
+    set_clauses = ", ".join(f"{k} = :{k}" for k in updates)
+    set_clauses += ", updated_at = NOW()"
+    params = {**updates, "pid": page_id, "oid": org_id}
+    if "config" in params:
+        set_clauses = set_clauses.replace("config = :config", "config = :config::jsonb")
+
+    try:
+        row = db.execute(
+            text(f"""
+                UPDATE recruit_landing_pages SET {set_clauses}
+                WHERE id = :pid AND organization_id = :oid
+                RETURNING id, organization_id, title, slug, status, config,
+                          view_count, submission_count, created_by, created_at, updated_at
+            """),
+            params,
+        ).fetchone()
         db.commit()
-    row = db.execute(text("SELECT * FROM recruit_landing_pages WHERE id = :id"), {"id": page_id}).fetchone()
-    return dict(row._mapping)
+    except Exception as e:
+        db.rollback()
+        if "uq_recruit_landing_pages_org_slug" in str(e):
+            raise HTTPException(status_code=409, detail="Slug already exists")
+        raise
+
+    return _page_row_to_dict(row)
 
 
-@router.post("/{page_id}/publish")
-async def publish_page(page_id: int, db=Depends(_get_db), current_user: Any = Depends(_get_cu)):
-    from sqlalchemy import text
-    db.execute(text("UPDATE recruit_landing_pages SET status='published', updated_at=NOW() WHERE id=:id"), {"id": page_id})
+@landing_pages_router.delete("/{page_id}", status_code=204)
+def delete_landing_page(
+    page_id: int,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    org_id = getattr(current_user, "organization_id", None)
+    result = db.execute(
+        text("DELETE FROM recruit_landing_pages WHERE id = :pid AND organization_id = :oid"),
+        {"pid": page_id, "oid": org_id},
+    )
     db.commit()
-    return {"status": "published"}
+    if result.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Page not found")
 
 
-@router.post("/{page_id}/unpublish")
-async def unpublish_page(page_id: int, db=Depends(_get_db), current_user: Any = Depends(_get_cu)):
-    from sqlalchemy import text
-    db.execute(text("UPDATE recruit_landing_pages SET status='draft', updated_at=NOW() WHERE id=:id"), {"id": page_id})
+@landing_pages_router.post("/{page_id}/publish")
+def publish_landing_page(
+    page_id: int,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    org_id = getattr(current_user, "organization_id", None)
+    row = db.execute(
+        text("""
+            UPDATE recruit_landing_pages SET status = 'published', updated_at = NOW()
+            WHERE id = :pid AND organization_id = :oid
+            RETURNING id, organization_id, title, slug, status, config,
+                      view_count, submission_count, created_by, created_at, updated_at
+        """),
+        {"pid": page_id, "oid": org_id},
+    ).fetchone()
     db.commit()
-    return {"status": "draft"}
-
-
-@router.delete("/{page_id}", status_code=204)
-async def delete_landing_page(page_id: int, db=Depends(_get_db), current_user: Any = Depends(_get_cu)):
-    from sqlalchemy import text
-    db.execute(text("DELETE FROM recruit_landing_pages WHERE id=:id"), {"id": page_id})
-    db.commit()
-
-
-@router.get("/{page_id}/preview", response_class=HTMLResponse)
-async def preview_landing_page(page_id: int, db=Depends(_get_db), current_user: Any = Depends(_get_cu)):
-    from sqlalchemy import text
-    row = db.execute(text("""
-        SELECT lp.*, o.slug as org_slug
-        FROM recruit_landing_pages lp
-        JOIN organizations o ON o.id = lp.organization_id
-        WHERE lp.id = :id
-    """), {"id": page_id}).fetchone()
     if not row:
-        raise HTTPException(status_code=404, detail="Landing page not found")
-    data = dict(row._mapping)
-    return HTMLResponse(_render_template(data.get('config') or {}, data['org_slug'], data['slug']))
+        raise HTTPException(status_code=404, detail="Page not found")
+    return _page_row_to_dict(row)
 
 
-# ── Public endpoints ───────────────────────────────────────────────────────────
+@landing_pages_router.post("/{page_id}/unpublish")
+def unpublish_landing_page(
+    page_id: int,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    org_id = getattr(current_user, "organization_id", None)
+    row = db.execute(
+        text("""
+            UPDATE recruit_landing_pages SET status = 'draft', updated_at = NOW()
+            WHERE id = :pid AND organization_id = :oid
+            RETURNING id, organization_id, title, slug, status, config,
+                      view_count, submission_count, created_by, created_at, updated_at
+        """),
+        {"pid": page_id, "oid": org_id},
+    ).fetchone()
+    db.commit()
+    if not row:
+        raise HTTPException(status_code=404, detail="Page not found")
+    return _page_row_to_dict(row)
 
-@public_router.get("/p/{slug}", response_class=HTMLResponse)
-async def serve_landing_page(slug: str):
-    from database import get_db
-    from sqlalchemy import text
-    db = next(get_db())
+
+@landing_pages_router.get("/{page_id}/preview")
+def preview_landing_page(
+    page_id: int,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    org_id = getattr(current_user, "organization_id", None)
+    row = db.execute(
+        text("""
+            SELECT rp.id, rp.slug, rp.config, t.org_slug
+            FROM recruit_landing_pages rp
+            JOIN recruit_platform_tenants t ON t.id = rp.organization_id
+            WHERE rp.id = :pid AND rp.organization_id = :oid
+        """),
+        {"pid": page_id, "oid": org_id},
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Page not found")
+
+    html = _render(row[2] or {}, row[3], row[1])
+    return Response(content=html, media_type="text/html")
+
+
+# ---------------------------------------------------------------------------
+# Public endpoints
+# ---------------------------------------------------------------------------
+
+@landing_pages_public_router.get("/p/{slug}")
+def serve_landing_page(slug: str, db: Session = Depends(get_db)):
+    row = db.execute(
+        text("""
+            SELECT rp.id, rp.slug, rp.config, t.org_slug
+            FROM recruit_landing_pages rp
+            JOIN recruit_platform_tenants t ON t.id = rp.organization_id
+            WHERE rp.slug = :slug AND rp.status = 'published'
+            LIMIT 1
+        """),
+        {"slug": slug},
+    ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Page not found")
+
+    # Increment view count asynchronously
     try:
-        row = db.execute(text("""
-            SELECT lp.*, o.slug as org_slug
-            FROM recruit_landing_pages lp
-            JOIN organizations o ON o.id = lp.organization_id
-            WHERE lp.slug = :slug AND lp.status = 'published'
-        """), {"slug": slug}).fetchone()
-        if not row:
-            return HTMLResponse("<h1>Page not found</h1>", status_code=404)
-        data = dict(row._mapping)
-        db.execute(text("UPDATE recruit_landing_pages SET view_count = view_count + 1 WHERE slug = :s"), {"s": slug})
-        db.commit()
-        return HTMLResponse(_render_template(data.get('config') or {}, data['org_slug'], data['slug']))
-    finally:
-        db.close()
-
-
-@public_router.post("/p/{slug}/view", status_code=204)
-async def track_view(slug: str):
-    return Response(status_code=204)
-
-
-@public_router.post("/public/apply/{org_slug}/schedule")
-async def schedule_interview(org_slug: str, body: ScheduleRequest):
-    from database import get_db
-    from sqlalchemy import text
-    db = next(get_db())
-    try:
-        db.execute(text("""
-            UPDATE mm_candidates
-            SET talent_profile = COALESCE(talent_profile, '{}')::jsonb
-                || :update::jsonb
-            WHERE id = :id
-        """), {
-            "id": body.candidate_id,
-            "update": json.dumps({"interview_slot": f"{body.selected_time} on {body.selected_day}"}),
-        })
+        db.execute(
+            text("UPDATE recruit_landing_pages SET view_count = view_count + 1 WHERE id = :pid"),
+            {"pid": row[0]},
+        )
         db.commit()
     except Exception:
-        pass
-    finally:
-        db.close()
-    return {"ok": True}
+        db.rollback()
+
+    html = _render(row[2] or {}, row[3], row[1])
+    return Response(content=html, media_type="text/html")
+
+
+@landing_pages_public_router.post("/public/apply/{org_slug}", status_code=201)
+def submit_application(
+    org_slug: str,
+    body: ApplicationSubmission,
+    db: Session = Depends(get_db),
+):
+    tenant_id = _get_tenant_id(org_slug, db)
+    if not tenant_id:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    # Increment submission count
+    if body.page_slug:
+        try:
+            db.execute(
+                text("""
+                    UPDATE recruit_landing_pages
+                    SET submission_count = submission_count + 1
+                    WHERE organization_id = :oid AND slug = :slug
+                """),
+                {"oid": tenant_id, "slug": body.page_slug},
+            )
+        except Exception:
+            pass
+
+    # Insert applicant record (reuse existing recruit_applicants table if it exists)
+    try:
+        db.execute(
+            text("""
+                INSERT INTO recruit_applicants
+                    (organization_id, first_name, last_name, email, phone,
+                     experience_level, source, stage, created_at)
+                VALUES (:oid, :fn, :ln, :email, :phone, :exp, :src, 'new', NOW())
+                ON CONFLICT (organization_id, email) DO NOTHING
+            """),
+            {
+                "oid": tenant_id,
+                "fn": body.first_name or "",
+                "ln": body.last_name or "",
+                "email": body.email or "",
+                "phone": body.phone or "",
+                "exp": body.experience or "",
+                "src": f"landing:{body.page_slug or 'unknown'}",
+            },
+        )
+    except Exception as e:
+        logger.warning(f"Could not insert applicant from landing page: {e}")
+
+    db.commit()
+    return {"status": "received"}
+
+
+@landing_pages_public_router.post("/public/schedule/{org_slug}", status_code=201)
+def submit_schedule(
+    org_slug: str,
+    body: ScheduleSlot,
+    db: Session = Depends(get_db),
+):
+    tenant_id = _get_tenant_id(org_slug, db)
+    if not tenant_id:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    logger.info(f"Schedule slot submitted for org {org_slug}: {body.slot}")
+    return {"status": "received"}

--- a/backend/templates/recruit_landing_page.html
+++ b/backend/templates/recruit_landing_page.html
@@ -2,17 +2,18 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<base href="{{BASE_HREF}}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{PAGE_TITLE}}</title>
+<title>{{HERO_HEADLINE_PLAIN}} | {{LOCATION_DISPLAY}}</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&family=Open+Sans:wght@400;500;600&display=swap" rel="stylesheet">
 <style>
   :root {
+    /* CMG brand navy — hero backgrounds, top bar, footers */
     --cmg-navy: #1B2A4A;
     --cmg-navy-mid: #223358;
     --cmg-navy-light: #2D4470;
+    /* CMG brand green — primary accent, CTAs (from logo #92C13B) */
     --cmg-red: {{PRIMARY_COLOR}};
     --cmg-red-dark: {{PRIMARY_COLOR_DARK}};
     --cmg-red-pale: {{PRIMARY_COLOR_PALE}};
@@ -34,246 +35,1997 @@
     --shadow-md: 0 4px 16px rgba(27,42,74,0.10);
     --shadow-lg: 0 8px 32px rgba(27,42,74,0.14);
   }
+
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'Open Sans', sans-serif; background: var(--off-white); color: var(--gray-800); line-height: 1.6; overflow-x: hidden; }
-  h1, h2, h3, h4, h5 { font-family: 'Montserrat', sans-serif; }
-  nav { background: white; position: sticky; top: 0; z-index: 100; border-bottom: 1px solid var(--gray-200); box-shadow: var(--shadow-sm); }
-  .nav-inner { display: flex; align-items: center; justify-content: space-between; padding: 0 48px; height: 72px; max-width: 1400px; margin: 0 auto; }
-  .nav-logo img { height: 48px; display: block; }
-  .nav-tabs { display: flex; gap: 2px; align-items: center; }
-  .nav-tab { background: none; border: none; font-family: 'Montserrat', sans-serif; font-size: 12px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; color: var(--gray-600); padding: 8px 14px; border-radius: var(--radius-sm); cursor: pointer; transition: all 0.18s; display: flex; align-items: center; gap: 7px; white-space: nowrap; }
+
+  body {
+    font-family: 'Open Sans', sans-serif;
+    background: var(--off-white);
+    color: var(--gray-800);
+    line-height: 1.6;
+    overflow-x: hidden;
+  }
+
+  h1, h2, h3, h4, h5 {
+    font-family: 'Montserrat', sans-serif;
+  }
+
+
+
+  /* ====== MAIN NAV ====== */
+  nav {
+    background: white;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    border-bottom: 1px solid var(--gray-200);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .nav-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 48px;
+    height: 72px;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+
+  .nav-logo img {
+    height: 48px;
+    display: block;
+  }
+
+  .nav-tabs {
+    display: flex;
+    gap: 2px;
+    align-items: center;
+  }
+
+  .nav-tab {
+    background: none;
+    border: none;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    color: var(--gray-600);
+    padding: 8px 14px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: all 0.18s;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    white-space: nowrap;
+  }
+
   .nav-tab:hover { color: var(--cmg-navy); background: var(--gray-50); }
-  .nav-tab.active { color: var(--cmg-navy); border-bottom: 3px solid var(--cmg-red); border-radius: 0; padding-bottom: 5px; }
-  .step-badge { width: 20px; height: 20px; background: var(--gray-100); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 10px; font-weight: 800; color: var(--gray-400); flex-shrink: 0; }
-  .nav-tab.active .step-badge { background: var(--cmg-red); color: white; }
-  .nav-cta { background: var(--cmg-red); color: white; border: none; font-family: 'Montserrat', sans-serif; font-size: 12px; font-weight: 700; letter-spacing: 0.8px; text-transform: uppercase; padding: 10px 22px; border-radius: var(--radius-sm); cursor: pointer; transition: background 0.2s; white-space: nowrap; }
+
+  .nav-tab.active {
+    color: var(--cmg-navy);
+    border-bottom: 3px solid var(--cmg-red);
+    border-radius: 0;
+    padding-bottom: 5px;
+  }
+
+  .step-badge {
+    width: 20px;
+    height: 20px;
+    background: var(--gray-100);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    font-weight: 800;
+    color: var(--gray-400);
+    flex-shrink: 0;
+  }
+
+  .nav-tab.active .step-badge {
+    background: var(--cmg-red);
+    color: white;
+  }
+
+  .nav-cta {
+    background: var(--cmg-red);
+    color: white;
+    border: none;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    padding: 10px 22px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background 0.2s;
+    white-space: nowrap;
+  }
+
   .nav-cta:hover { background: var(--cmg-red-dark); }
+
+  /* ====== PAGES ====== */
   .page { display: none; }
   .page.active { display: block; }
-  .hero { background: var(--cmg-navy); position: relative; overflow: hidden; }
-  .hero-content { max-width: 1320px; margin: 0 auto; padding: 80px 48px 0; display: grid; grid-template-columns: 1fr 420px; gap: 64px; align-items: end; }
-  .hero-eyebrow { display: inline-flex; align-items: center; gap: 8px; font-family: 'Montserrat', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: rgba(255,255,255,0.7); margin-bottom: 20px; }
-  .hero-eyebrow-line { display: inline-block; width: 28px; height: 2px; background: var(--cmg-red); flex-shrink: 0; }
-  .hero h1 { font-size: 58px; font-weight: 800; line-height: 1.05; color: white; margin-bottom: 24px; letter-spacing: -1.5px; }
+
+  /* ====== PAGE 1: OPPORTUNITY ====== */
+  .hero {
+    background: var(--cmg-navy);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .hero-content {
+    max-width: 1320px;
+    margin: 0 auto;
+    padding: 80px 48px 0;
+    display: grid;
+    grid-template-columns: 1fr 420px;
+    gap: 64px;
+    align-items: end;
+  }
+
+  .hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.7);
+    margin-bottom: 20px;
+  }
+
+  .hero-eyebrow-line {
+    display: inline-block;
+    width: 28px;
+    height: 2px;
+    background: var(--cmg-red);
+    flex-shrink: 0;
+  }
+
+  .hero h1 {
+    font-size: 58px;
+    font-weight: 800;
+    line-height: 1.05;
+    color: white;
+    margin-bottom: 24px;
+    letter-spacing: -1.5px;
+  }
+
   .hero h1 span.red { color: var(--cmg-red); }
   .hero h1 span.italic { font-style: italic; }
-  .hero-sub { color: rgba(255,255,255,0.62); font-size: 17px; line-height: 1.7; margin-bottom: 36px; max-width: 540px; }
-  .hero-checks { display: flex; flex-direction: column; gap: 10px; margin-bottom: 40px; }
-  .hero-check { display: flex; align-items: center; gap: 10px; font-size: 14px; color: rgba(255,255,255,0.8); font-family: 'Montserrat', sans-serif; font-weight: 500; }
-  .check-icon { width: 20px; height: 20px; background: var(--cmg-red); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 10px; color: white; flex-shrink: 0; }
-  .hero-btns { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; }
-  .btn-red { background: var(--cmg-red); color: white; border: none; font-family: 'Montserrat', sans-serif; font-size: 13px; font-weight: 700; letter-spacing: 0.8px; text-transform: uppercase; padding: 14px 28px; border-radius: var(--radius-sm); cursor: pointer; transition: background 0.2s; text-decoration: none; display: inline-block; }
+
+  .hero-sub {
+    color: rgba(255,255,255,0.62);
+    font-size: 17px;
+    line-height: 1.7;
+    margin-bottom: 36px;
+    max-width: 540px;
+  }
+
+  .hero-checks {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 40px;
+  }
+
+  .hero-check {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+    color: rgba(255,255,255,0.8);
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 500;
+  }
+
+  .check-icon {
+    width: 20px;
+    height: 20px;
+    background: var(--cmg-red);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    color: white;
+    flex-shrink: 0;
+  }
+
+  .hero-btns {
+    display: flex;
+    gap: 14px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .btn-red {
+    background: var(--cmg-red);
+    color: white;
+    border: none;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    padding: 14px 28px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background 0.2s;
+    text-decoration: none;
+    display: inline-block;
+  }
+
   .btn-red:hover { background: var(--cmg-red-dark); }
-  .btn-outline { background: transparent; color: rgba(255,255,255,0.8); border: 1.5px solid rgba(255,255,255,0.3); font-family: 'Montserrat', sans-serif; font-size: 13px; font-weight: 600; padding: 13px 24px; border-radius: var(--radius-sm); cursor: pointer; transition: all 0.2s; display: inline-flex; align-items: center; gap: 8px; }
+
+  .btn-outline {
+    background: transparent;
+    color: rgba(255,255,255,0.8);
+    border: 1.5px solid rgba(255,255,255,0.3);
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 13px 24px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: all 0.2s;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+
   .btn-outline:hover { border-color: rgba(255,255,255,0.65); color: white; }
-  .earnings-card { background: white; border-radius: var(--radius-lg); padding: 32px; box-shadow: var(--shadow-lg); position: relative; }
-  .earnings-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 4px; background: var(--cmg-red); border-radius: var(--radius-lg) var(--radius-lg) 0 0; }
-  .earnings-label { font-family: 'Montserrat', sans-serif; font-size: 10px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--gray-400); margin-bottom: 6px; }
-  .earnings-figure { font-family: 'Montserrat', sans-serif; font-size: 48px; font-weight: 800; color: var(--cmg-navy); line-height: 1; margin-bottom: 4px; }
-  .earnings-note { font-size: 12px; color: var(--gray-400); margin-bottom: 24px; }
-  .earnings-rows { border-top: 1px solid var(--gray-100); padding-top: 16px; display: flex; flex-direction: column; gap: 10px; }
-  .earnings-row { display: flex; justify-content: space-between; align-items: center; padding: 10px 12px; background: var(--gray-50); border-radius: var(--radius-sm); border-left: 3px solid var(--cmg-red); }
-  .earnings-row-label { font-size: 12px; color: var(--gray-600); font-family: 'Montserrat', sans-serif; font-weight: 500; }
-  .earnings-row-val { font-size: 14px; font-weight: 700; font-family: 'Montserrat', sans-serif; color: var(--green); }
-  .hero-stats { background: rgba(0,0,0,0.25); border-top: 1px solid rgba(255,255,255,0.08); margin-top: 60px; }
-  .hero-stats-inner { max-width: 1320px; margin: 0 auto; padding: 20px 48px; display: flex; gap: 0; }
-  .hero-stat { flex: 1; display: flex; flex-direction: column; padding-right: 40px; }
-  .hero-stat + .hero-stat { padding-left: 40px; border-left: 1px solid rgba(255,255,255,0.1); }
-  .hero-stat-num { font-family: 'Montserrat', sans-serif; font-size: 26px; font-weight: 800; color: white; line-height: 1; margin-bottom: 4px; }
-  .hero-stat-label { font-size: 12px; color: rgba(255,255,255,0.45); font-weight: 500; }
-  .section { padding: 80px 48px; max-width: 1320px; margin: 0 auto; }
-  .section-eyebrow { display: flex; align-items: center; gap: 10px; font-family: 'Montserrat', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--cmg-red); margin-bottom: 14px; }
-  .section-eyebrow::before { content: ''; display: inline-block; width: 24px; height: 2px; background: var(--cmg-red); }
-  .section-title { font-size: 36px; font-weight: 800; color: var(--cmg-navy); line-height: 1.15; margin-bottom: 14px; letter-spacing: -0.5px; }
-  .section-sub { font-size: 16px; color: var(--gray-600); line-height: 1.7; max-width: 600px; }
-  .path-track { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; margin-top: 48px; position: relative; }
-  .path-connector { position: absolute; top: 28px; left: calc(12.5% + 14px); right: calc(12.5% + 14px); height: 3px; background: linear-gradient(to right, var(--cmg-red), var(--cmg-navy)); z-index: 0; }
-  .path-step { text-align: center; padding: 0 16px; position: relative; z-index: 1; }
-  .path-node { width: 56px; height: 56px; background: var(--cmg-navy); border: 3px solid var(--cmg-red); border-radius: 50%; display: flex; align-items: center; justify-content: center; margin: 0 auto 16px; font-size: 22px; }
-  .path-timeline { font-family: 'Montserrat', sans-serif; font-size: 10px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--cmg-red); margin-bottom: 6px; }
-  .path-step h3 { font-size: 15px; font-weight: 700; color: var(--cmg-navy); margin-bottom: 6px; }
-  .path-step p { font-size: 12px; color: var(--gray-600); line-height: 1.55; }
-  .path-salary { font-family: 'Montserrat', sans-serif; font-size: 15px; font-weight: 800; color: var(--green); margin-top: 8px; }
-  .training-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 48px; }
-  .training-card { background: white; border: 1px solid var(--gray-200); border-radius: var(--radius-lg); padding: 28px; border-top: 3px solid var(--cmg-navy); box-shadow: var(--shadow-sm); transition: box-shadow 0.2s; }
+
+  /* Earnings card */
+  .earnings-card {
+    background: white;
+    border-radius: var(--radius-lg);
+    padding: 32px;
+    box-shadow: var(--shadow-lg);
+    position: relative;
+  }
+
+  .earnings-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 4px;
+    background: var(--cmg-red);
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  }
+
+  .earnings-label {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: var(--gray-400);
+    margin-bottom: 6px;
+  }
+
+  .earnings-figure {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 48px;
+    font-weight: 800;
+    color: var(--cmg-navy);
+    line-height: 1;
+    margin-bottom: 4px;
+  }
+
+  .earnings-note {
+    font-size: 12px;
+    color: var(--gray-400);
+    margin-bottom: 24px;
+  }
+
+  .earnings-rows {
+    border-top: 1px solid var(--gray-100);
+    padding-top: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .earnings-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 12px;
+    background: var(--gray-50);
+    border-radius: var(--radius-sm);
+    border-left: 3px solid var(--cmg-red);
+  }
+
+  .earnings-row-label {
+    font-size: 12px;
+    color: var(--gray-600);
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 500;
+  }
+
+  .earnings-row-val {
+    font-size: 14px;
+    font-weight: 700;
+    font-family: 'Montserrat', sans-serif;
+    color: var(--green);
+  }
+
+  /* Hero stats bar */
+  .hero-stats {
+    background: rgba(0,0,0,0.25);
+    border-top: 1px solid rgba(255,255,255,0.08);
+    margin-top: 60px;
+  }
+
+  .hero-stats-inner {
+    max-width: 1320px;
+    margin: 0 auto;
+    padding: 20px 48px;
+    display: flex;
+    gap: 0;
+  }
+
+  .hero-stat {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding-right: 40px;
+  }
+
+  .hero-stat + .hero-stat {
+    padding-left: 40px;
+    border-left: 1px solid rgba(255,255,255,0.1);
+  }
+
+  .hero-stat-num {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 26px;
+    font-weight: 800;
+    color: white;
+    line-height: 1;
+    margin-bottom: 4px;
+  }
+
+  .hero-stat-label {
+    font-size: 12px;
+    color: rgba(255,255,255,0.45);
+    font-weight: 500;
+  }
+
+  /* ====== CONTENT SECTIONS ====== */
+  .section {
+    padding: 80px 48px;
+    max-width: 1320px;
+    margin: 0 auto;
+  }
+
+  .section-eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: var(--cmg-red);
+    margin-bottom: 14px;
+  }
+
+  .section-eyebrow::before {
+    content: '';
+    display: inline-block;
+    width: 24px;
+    height: 2px;
+    background: var(--cmg-red);
+  }
+
+  .section-title {
+    font-size: 36px;
+    font-weight: 800;
+    color: var(--cmg-navy);
+    line-height: 1.15;
+    margin-bottom: 14px;
+    letter-spacing: -0.5px;
+  }
+
+  .section-sub {
+    font-size: 16px;
+    color: var(--gray-600);
+    line-height: 1.7;
+    max-width: 600px;
+  }
+
+  /* Career Path */
+  .path-track {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0;
+    margin-top: 48px;
+    position: relative;
+  }
+
+  .path-connector {
+    position: absolute;
+    top: 28px;
+    left: calc(12.5% + 14px);
+    right: calc(12.5% + 14px);
+    height: 3px;
+    background: linear-gradient(to right, var(--cmg-red), var(--cmg-navy));
+    z-index: 0;
+  }
+
+  .path-step {
+    text-align: center;
+    padding: 0 16px;
+    position: relative;
+    z-index: 1;
+  }
+
+  .path-node {
+    width: 56px;
+    height: 56px;
+    background: var(--cmg-navy);
+    border: 3px solid var(--cmg-red);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 16px;
+    font-size: 22px;
+  }
+
+  .path-timeline {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--cmg-red);
+    margin-bottom: 6px;
+  }
+
+  .path-step h3 {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--cmg-navy);
+    margin-bottom: 6px;
+  }
+
+  .path-step p {
+    font-size: 12px;
+    color: var(--gray-600);
+    line-height: 1.55;
+  }
+
+  .path-salary {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 15px;
+    font-weight: 800;
+    color: var(--green);
+    margin-top: 8px;
+  }
+
+  /* Training cards */
+  .training-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-top: 48px;
+  }
+
+  .training-card {
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: 28px;
+    border-top: 3px solid var(--cmg-navy);
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow 0.2s;
+  }
+
   .training-card:hover { box-shadow: var(--shadow-md); }
-  .training-week { font-family: 'Montserrat', sans-serif; font-size: 10px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--cmg-red); margin-bottom: 8px; }
-  .training-card h3 { font-size: 17px; color: var(--cmg-navy); margin-bottom: 10px; }
-  .training-card p { font-size: 13px; color: var(--gray-600); line-height: 1.6; margin-bottom: 16px; }
-  .training-list { display: flex; flex-direction: column; gap: 7px; }
-  .training-list-item { display: flex; gap: 8px; font-size: 13px; color: var(--gray-600); line-height: 1.4; }
-  .training-list-item::before { content: '✓'; color: var(--cmg-red); font-weight: 700; font-size: 11px; margin-top: 1px; flex-shrink: 0; }
-  .testimonials-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-top: 48px; }
-  .tcard { background: white; border: 1px solid var(--gray-200); border-radius: var(--radius-lg); padding: 28px; box-shadow: var(--shadow-sm); }
-  .tcard-stars { color: var(--cmg-red); font-size: 14px; margin-bottom: 14px; }
-  .tcard-quote { font-size: 14px; line-height: 1.7; color: var(--gray-800); margin-bottom: 20px; font-style: italic; }
-  .tcard-author { display: flex; align-items: center; gap: 12px; border-top: 1px solid var(--gray-100); padding-top: 16px; }
-  .tcard-avatar { width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: 'Montserrat', sans-serif; font-size: 13px; font-weight: 700; color: white; flex-shrink: 0; }
-  .tcard-name { font-family: 'Montserrat', sans-serif; font-size: 13px; font-weight: 700; color: var(--cmg-navy); }
+
+  .training-week {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: var(--cmg-red);
+    margin-bottom: 8px;
+  }
+
+  .training-card h3 {
+    font-size: 17px;
+    color: var(--cmg-navy);
+    margin-bottom: 10px;
+  }
+
+  .training-card p {
+    font-size: 13px;
+    color: var(--gray-600);
+    line-height: 1.6;
+    margin-bottom: 16px;
+  }
+
+  .training-list {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+  }
+
+  .training-list-item {
+    display: flex;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--gray-600);
+    line-height: 1.4;
+  }
+
+  .training-list-item::before {
+    content: '✓';
+    color: var(--cmg-red);
+    font-weight: 700;
+    font-size: 11px;
+    margin-top: 1px;
+    flex-shrink: 0;
+  }
+
+  /* Testimonials */
+  .testimonials-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    margin-top: 48px;
+  }
+
+  .tcard {
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: 28px;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .tcard-stars {
+    color: var(--cmg-red);
+    font-size: 14px;
+    margin-bottom: 14px;
+  }
+
+  .tcard-quote {
+    font-size: 14px;
+    line-height: 1.7;
+    color: var(--gray-800);
+    margin-bottom: 20px;
+    font-style: italic;
+  }
+
+  .tcard-author {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    border-top: 1px solid var(--gray-100);
+    padding-top: 16px;
+  }
+
+  .tcard-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    color: white;
+    flex-shrink: 0;
+  }
+
+  .tcard-name {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--cmg-navy);
+  }
+
   .tcard-detail { font-size: 12px; color: var(--gray-400); }
-  .noexp { background: var(--cmg-navy); border-radius: var(--radius-xl); padding: 64px; position: relative; overflow: hidden; }
-  .noexp::after { content: ''; position: absolute; right: -60px; bottom: -60px; width: 300px; height: 300px; border: 40px solid rgba(106,170,38,0.15); border-radius: 50%; pointer-events: none; }
-  .noexp h2 { font-size: 38px; color: white; text-align: center; margin-bottom: 12px; line-height: 1.2; }
+
+  /* No exp banner */
+  .noexp {
+    background: var(--cmg-navy);
+    border-radius: var(--radius-xl);
+    padding: 64px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .noexp::after {
+    content: '';
+    position: absolute;
+    right: -60px; bottom: -60px;
+    width: 300px; height: 300px;
+    border: 40px solid rgba(106,170,38,0.15);
+    border-radius: 50%;
+    pointer-events: none;
+  }
+
+  .noexp h2 {
+    font-size: 38px;
+    color: white;
+    text-align: center;
+    margin-bottom: 12px;
+    line-height: 1.2;
+  }
+
   .noexp h2 span { color: var(--cmg-red); }
-  .noexp > p { color: rgba(255,255,255,0.6); font-size: 17px; text-align: center; max-width: 580px; margin: 0 auto 40px; line-height: 1.65; }
-  .noexp-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
-  .noexp-card { background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.12); border-radius: var(--radius-lg); padding: 22px; }
+
+  .noexp > p {
+    color: rgba(255,255,255,0.6);
+    font-size: 17px;
+    text-align: center;
+    max-width: 580px;
+    margin: 0 auto 40px;
+    line-height: 1.65;
+  }
+
+  .noexp-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+  }
+
+  .noexp-card {
+    background: rgba(255,255,255,0.07);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: var(--radius-lg);
+    padding: 22px;
+  }
+
   .noexp-card-icon { font-size: 28px; margin-bottom: 10px; }
   .noexp-card h4 { color: white; font-size: 14px; font-weight: 700; margin-bottom: 6px; }
   .noexp-card p { color: rgba(255,255,255,0.5); font-size: 12px; line-height: 1.5; }
-  .video-block { display: grid; grid-template-columns: 1fr 1fr; gap: 0; background: white; border-radius: var(--radius-xl); overflow: hidden; border: 1px solid var(--gray-200); box-shadow: var(--shadow-md); margin-top: 48px; }
-  .video-thumb { background: var(--cmg-navy); min-height: 340px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px; cursor: pointer; position: relative; }
-  .play-circle { width: 68px; height: 68px; background: var(--cmg-red); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 24px; padding-left: 4px; transition: transform 0.2s, background 0.2s; }
+
+  /* Video section */
+  .video-block {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0;
+    background: white;
+    border-radius: var(--radius-xl);
+    overflow: hidden;
+    border: 1px solid var(--gray-200);
+    box-shadow: var(--shadow-md);
+    margin-top: 48px;
+  }
+
+  .video-thumb {
+    background: var(--cmg-navy);
+    min-height: 340px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    cursor: pointer;
+    position: relative;
+  }
+
+  .play-circle {
+    width: 68px;
+    height: 68px;
+    background: var(--cmg-red);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    padding-left: 4px;
+    transition: transform 0.2s, background 0.2s;
+  }
+
   .video-thumb:hover .play-circle { transform: scale(1.07); background: var(--cmg-red-dark); }
-  .video-thumb-label { color: rgba(255,255,255,0.55); font-size: 13px; text-align: center; }
-  .video-body { padding: 44px 40px; display: flex; flex-direction: column; justify-content: center; }
-  .video-body h3 { font-size: 24px; color: var(--cmg-navy); margin-bottom: 14px; line-height: 1.3; }
-  .video-body p { font-size: 14px; color: var(--gray-600); line-height: 1.7; margin-bottom: 12px; }
-  .leader-row { display: flex; align-items: center; gap: 14px; margin-top: 20px; padding-top: 20px; border-top: 1px solid var(--gray-100); }
-  .leader-ava { width: 48px; height: 48px; background: var(--cmg-navy); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: 'Montserrat', sans-serif; font-weight: 800; font-size: 16px; color: white; flex-shrink: 0; }
-  .leader-name { font-family: 'Montserrat', sans-serif; font-size: 14px; font-weight: 700; color: var(--cmg-navy); }
+
+  .video-thumb-label {
+    color: rgba(255,255,255,0.55);
+    font-size: 13px;
+    text-align: center;
+  }
+
+  .video-body {
+    padding: 44px 40px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .video-body h3 {
+    font-size: 24px;
+    color: var(--cmg-navy);
+    margin-bottom: 14px;
+    line-height: 1.3;
+  }
+
+  .video-body p {
+    font-size: 14px;
+    color: var(--gray-600);
+    line-height: 1.7;
+    margin-bottom: 12px;
+  }
+
+  .leader-row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid var(--gray-100);
+  }
+
+  .leader-ava {
+    width: 48px;
+    height: 48px;
+    background: var(--cmg-navy);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    font-size: 16px;
+    color: white;
+    flex-shrink: 0;
+  }
+
+  .leader-name {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--cmg-navy);
+  }
+
   .leader-title { font-size: 12px; color: var(--gray-400); }
-  .full-cta { background: var(--cmg-navy); text-align: center; padding: 64px 48px; }
-  .full-cta h2 { font-size: 36px; color: white; margin-bottom: 14px; line-height: 1.2; }
-  .full-cta p { color: rgba(255,255,255,0.6); font-size: 17px; max-width: 520px; margin: 0 auto 32px; line-height: 1.65; }
-  .why-hero { background: var(--cmg-navy); padding: 72px 48px; text-align: center; }
-  .why-hero h1 { font-size: 48px; font-weight: 800; color: white; margin-bottom: 14px; letter-spacing: -1px; line-height: 1.1; }
+
+  /* Full-width navy CTA */
+  .full-cta {
+    background: var(--cmg-navy);
+    text-align: center;
+    padding: 64px 48px;
+  }
+
+  .full-cta h2 {
+    font-size: 36px;
+    color: white;
+    margin-bottom: 14px;
+    line-height: 1.2;
+  }
+
+  .full-cta p {
+    color: rgba(255,255,255,0.6);
+    font-size: 17px;
+    max-width: 520px;
+    margin: 0 auto 32px;
+    line-height: 1.65;
+  }
+
+  /* ====== PAGE 2: WHY CMG ====== */
+  .why-hero {
+    background: var(--cmg-navy);
+    padding: 72px 48px;
+    text-align: center;
+  }
+
+  .why-hero h1 {
+    font-size: 48px;
+    font-weight: 800;
+    color: white;
+    margin-bottom: 14px;
+    letter-spacing: -1px;
+    line-height: 1.1;
+  }
+
   .why-hero h1 span { color: var(--cmg-red); }
-  .why-hero p { color: rgba(255,255,255,0.6); font-size: 17px; max-width: 540px; margin: 0 auto; line-height: 1.65; }
-  .pillars-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-top: 48px; }
-  .pillar { background: white; border: 1px solid var(--gray-200); border-radius: var(--radius-lg); padding: 32px 28px; box-shadow: var(--shadow-sm); transition: all 0.2s; }
+
+  .why-hero p {
+    color: rgba(255,255,255,0.6);
+    font-size: 17px;
+    max-width: 540px;
+    margin: 0 auto;
+    line-height: 1.65;
+  }
+
+  .pillars-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    margin-top: 48px;
+  }
+
+  .pillar {
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: 32px 28px;
+    box-shadow: var(--shadow-sm);
+    transition: all 0.2s;
+  }
+
   .pillar:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); }
-  .pillar-icon { width: 52px; height: 52px; background: var(--cmg-navy); border-radius: var(--radius-md); display: flex; align-items: center; justify-content: center; font-size: 24px; margin-bottom: 18px; }
-  .pillar h3 { font-size: 18px; color: var(--cmg-navy); margin-bottom: 10px; }
-  .pillar > p { font-size: 14px; color: var(--gray-600); line-height: 1.65; margin-bottom: 18px; }
-  .pillar-list { display: flex; flex-direction: column; gap: 7px; }
-  .pillar-item { display: flex; gap: 8px; font-size: 13px; color: var(--gray-600); line-height: 1.4; }
-  .pillar-dot { width: 5px; height: 5px; background: var(--cmg-red); border-radius: 50%; flex-shrink: 0; margin-top: 5px; }
-  .benefits-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; margin-top: 48px; }
-  .benefit { display: flex; gap: 16px; align-items: flex-start; padding: 20px; background: white; border: 1px solid var(--gray-200); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); }
-  .benefit-icon { width: 44px; height: 44px; background: var(--off-white); border: 1px solid var(--gray-200); border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: 20px; flex-shrink: 0; }
-  .benefit h4 { font-size: 14px; color: var(--cmg-navy); margin-bottom: 4px; }
+
+  .pillar-icon {
+    width: 52px;
+    height: 52px;
+    background: var(--cmg-navy);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    margin-bottom: 18px;
+  }
+
+  .pillar h3 {
+    font-size: 18px;
+    color: var(--cmg-navy);
+    margin-bottom: 10px;
+  }
+
+  .pillar > p {
+    font-size: 14px;
+    color: var(--gray-600);
+    line-height: 1.65;
+    margin-bottom: 18px;
+  }
+
+  .pillar-list {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+  }
+
+  .pillar-item {
+    display: flex;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--gray-600);
+    line-height: 1.4;
+  }
+
+  .pillar-dot {
+    width: 5px;
+    height: 5px;
+    background: var(--cmg-red);
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 5px;
+  }
+
+  .benefits-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    margin-top: 48px;
+  }
+
+  .benefit {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+    padding: 20px;
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .benefit-icon {
+    width: 44px;
+    height: 44px;
+    background: var(--off-white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    flex-shrink: 0;
+  }
+
+  .benefit h4 {
+    font-size: 14px;
+    color: var(--cmg-navy);
+    margin-bottom: 4px;
+  }
+
   .benefit p { font-size: 13px; color: var(--gray-600); line-height: 1.55; }
-  .culture-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-top: 48px; }
-  .culture-card { background: var(--cmg-navy); border-radius: var(--radius-lg); padding: 24px 20px; }
+
+  .culture-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+    margin-top: 48px;
+  }
+
+  .culture-card {
+    background: var(--cmg-navy);
+    border-radius: var(--radius-lg);
+    padding: 24px 20px;
+  }
+
   .culture-card-icon { font-size: 28px; margin-bottom: 12px; }
   .culture-card h4 { color: white; font-size: 15px; margin-bottom: 8px; }
   .culture-card p { color: rgba(255,255,255,0.5); font-size: 13px; line-height: 1.5; }
-  .apply-wrap { display: grid; grid-template-columns: 420px 1fr; min-height: calc(100vh - 72px); }
-  .apply-sidebar { background: var(--cmg-navy); padding: 60px 48px; position: sticky; top: 72px; height: calc(100vh - 72px); overflow-y: auto; }
-  .apply-sidebar h2 { font-size: 30px; color: white; line-height: 1.25; margin-bottom: 14px; }
+
+  /* ====== PAGE 3: APPLY ====== */
+  .apply-wrap {
+    display: grid;
+    grid-template-columns: 420px 1fr;
+    min-height: calc(100vh - 72px);
+  }
+
+  .apply-sidebar {
+    background: var(--cmg-navy);
+    padding: 60px 48px;
+    position: sticky;
+    top: 72px;
+    height: calc(100vh - 72px);
+    overflow-y: auto;
+  }
+
+  .apply-sidebar h2 {
+    font-size: 30px;
+    color: white;
+    line-height: 1.25;
+    margin-bottom: 14px;
+  }
+
   .apply-sidebar h2 span { color: var(--cmg-red); }
-  .apply-sidebar > p { color: rgba(255,255,255,0.6); font-size: 15px; line-height: 1.7; margin-bottom: 36px; }
-  .apply-points { display: flex; flex-direction: column; gap: 18px; margin-bottom: 36px; }
-  .apply-point { display: flex; gap: 14px; align-items: flex-start; }
-  .apply-point-icon { width: 38px; height: 38px; background: rgba(106,170,38,0.2); border: 1px solid rgba(106,170,38,0.4); border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: 16px; flex-shrink: 0; }
+
+  .apply-sidebar > p {
+    color: rgba(255,255,255,0.6);
+    font-size: 15px;
+    line-height: 1.7;
+    margin-bottom: 36px;
+  }
+
+  .apply-points {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    margin-bottom: 36px;
+  }
+
+  .apply-point {
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+  }
+
+  .apply-point-icon {
+    width: 38px;
+    height: 38px;
+    background: rgba(106,170,38,0.2);
+    border: 1px solid rgba(106,170,38,0.4);
+    border-radius: var(--radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    flex-shrink: 0;
+  }
+
   .apply-point h4 { color: white; font-size: 13px; margin-bottom: 3px; }
   .apply-point p { color: rgba(255,255,255,0.5); font-size: 12px; line-height: 1.5; margin: 0; }
-  .bonus-banner { padding: 18px; background: rgba(106,170,38,0.15); border: 1px solid rgba(106,170,38,0.3); border-radius: var(--radius-md); margin-top: 12px; }
+
+  .bonus-banner {
+    padding: 18px;
+    background: rgba(106,170,38,0.15);
+    border: 1px solid rgba(106,170,38,0.3);
+    border-radius: var(--radius-md);
+    margin-top: 12px;
+  }
+
   .bonus-banner-title { color: #B6E07A; font-size: 12px; font-weight: 700; margin-bottom: 4px; }
   .bonus-banner-body { color: rgba(255,255,255,0.55); font-size: 12px; line-height: 1.5; }
-  .apply-main { padding: 60px; background: var(--off-white); }
-  .apply-main h2 { font-size: 26px; color: var(--cmg-navy); margin-bottom: 6px; }
-  .apply-main-sub { color: var(--gray-400); font-size: 14px; margin-bottom: 32px; }
+
+  .apply-main {
+    padding: 60px;
+    background: var(--off-white);
+  }
+
+  .apply-main h2 {
+    font-size: 26px;
+    color: var(--cmg-navy);
+    margin-bottom: 6px;
+  }
+
+  .apply-main-sub {
+    color: var(--gray-400);
+    font-size: 14px;
+    margin-bottom: 32px;
+  }
+
   .form-group { margin-bottom: 18px; }
-  .form-label { display: block; font-family: 'Montserrat', sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.8px; text-transform: uppercase; color: var(--cmg-navy); margin-bottom: 6px; }
+
+  .form-label {
+    display: block;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: var(--cmg-navy);
+    margin-bottom: 6px;
+  }
+
   .form-label .req { color: var(--cmg-red); margin-left: 2px; }
-  .form-input { width: 100%; padding: 11px 14px; border: 1.5px solid var(--gray-200); border-radius: var(--radius-sm); font-family: 'Open Sans', sans-serif; font-size: 14px; color: var(--gray-800); background: white; transition: border-color 0.18s; outline: none; -webkit-appearance: none; }
+
+  .form-input {
+    width: 100%;
+    padding: 11px 14px;
+    border: 1.5px solid var(--gray-200);
+    border-radius: var(--radius-sm);
+    font-family: 'Open Sans', sans-serif;
+    font-size: 14px;
+    color: var(--gray-800);
+    background: white;
+    transition: border-color 0.18s;
+    outline: none;
+    -webkit-appearance: none;
+  }
+
   .form-input:focus { border-color: var(--cmg-navy); }
   .form-input::placeholder { color: var(--gray-400); }
+
   .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-  .upload-zone { border: 2px dashed var(--gray-200); border-radius: var(--radius-md); padding: 28px; text-align: center; cursor: pointer; background: white; transition: all 0.18s; }
+
+  .upload-zone {
+    border: 2px dashed var(--gray-200);
+    border-radius: var(--radius-md);
+    padding: 28px;
+    text-align: center;
+    cursor: pointer;
+    background: white;
+    transition: all 0.18s;
+  }
+
   .upload-zone:hover { border-color: var(--cmg-navy); background: var(--gray-50); }
   .upload-zone-icon { font-size: 26px; margin-bottom: 8px; }
   .upload-zone-title { font-family: 'Montserrat', sans-serif; font-size: 13px; font-weight: 700; color: var(--cmg-navy); margin-bottom: 4px; }
   .upload-zone-sub { font-size: 12px; color: var(--gray-400); }
-  .form-submit-btn { width: 100%; background: var(--cmg-red); color: white; border: none; font-family: 'Montserrat', sans-serif; font-size: 14px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; padding: 16px; border-radius: var(--radius-sm); cursor: pointer; margin-top: 22px; transition: background 0.2s; }
+
+  .form-submit-btn {
+    width: 100%;
+    background: var(--cmg-red);
+    color: white;
+    border: none;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    margin-top: 22px;
+    transition: background 0.2s;
+  }
+
   .form-submit-btn:hover { background: var(--cmg-red-dark); }
-  .form-disclaimer { text-align: center; font-size: 11px; color: var(--gray-400); margin-top: 12px; line-height: 1.6; }
-  .cal-widget { max-width: 500px; background: white; border: 1px solid var(--gray-200); border-radius: var(--radius-xl); overflow: hidden; box-shadow: var(--shadow-md); }
-  .cal-top { background: var(--cmg-navy); padding: 20px 24px; display: flex; align-items: center; gap: 14px; }
-  .cal-top-ava { width: 44px; height: 44px; background: var(--cmg-red); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: 'Montserrat', sans-serif; font-weight: 800; font-size: 16px; color: white; flex-shrink: 0; }
+
+  .form-disclaimer {
+    text-align: center;
+    font-size: 11px;
+    color: var(--gray-400);
+    margin-top: 12px;
+    line-height: 1.6;
+  }
+
+  /* ====== PAGE 4: SCHEDULE ====== */
+  .schedule-wrap {
+    display: grid;
+    grid-template-columns: 400px 1fr;
+    min-height: calc(100vh - 72px);
+  }
+
+  .schedule-left {
+    background: var(--off-white);
+    padding: 60px 40px;
+    border-right: 1px solid var(--gray-200);
+  }
+
+  .schedule-left h2 {
+    font-size: 28px;
+    color: var(--cmg-navy);
+    line-height: 1.25;
+    margin-bottom: 14px;
+  }
+
+  .schedule-left h2 span { color: var(--cmg-red); }
+
+  .schedule-left > p {
+    color: var(--gray-600);
+    font-size: 15px;
+    line-height: 1.7;
+    margin-bottom: 32px;
+  }
+
+  .interview-details {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 28px;
+  }
+
+  .interview-detail {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .interview-detail-icon {
+    width: 36px;
+    height: 36px;
+    background: var(--cmg-navy);
+    border-radius: var(--radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    flex-shrink: 0;
+  }
+
+  .interview-detail-label { font-size: 11px; color: var(--gray-400); margin-bottom: 1px; }
+  .interview-detail-val { font-family: 'Montserrat', sans-serif; font-size: 14px; font-weight: 700; color: var(--cmg-navy); }
+
+  .sms-badge {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    padding: 16px 18px;
+    background: var(--green-pale);
+    border: 1px solid #B8E08A;
+    border-radius: var(--radius-md);
+    margin-bottom: 20px;
+  }
+
+  .sms-badge-icon { font-size: 18px; flex-shrink: 0; margin-top: 1px; }
+  .sms-badge-title { font-family: 'Montserrat', sans-serif; font-size: 12px; font-weight: 700; color: var(--green); margin-bottom: 3px; }
+  .sms-badge-desc { font-size: 12px; color: #2D6B20; line-height: 1.55; }
+
+  .schedule-right {
+    padding: 60px;
+    background: white;
+  }
+
+  .cal-widget {
+    max-width: 500px;
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-xl);
+    overflow: hidden;
+    box-shadow: var(--shadow-md);
+  }
+
+  .cal-top {
+    background: var(--cmg-navy);
+    padding: 20px 24px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .cal-top-ava {
+    width: 44px;
+    height: 44px;
+    background: var(--cmg-red);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    font-size: 16px;
+    color: white;
+    flex-shrink: 0;
+  }
+
   .cal-top-title { color: white; font-size: 15px; font-weight: 700; margin-bottom: 2px; }
   .cal-top-sub { color: rgba(255,255,255,0.55); font-size: 12px; }
+
   .cal-body { padding: 24px; }
-  .cal-nav { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
-  .cal-nav-btn { background: var(--gray-100); border: none; border-radius: var(--radius-sm); width: 32px; height: 32px; cursor: pointer; font-size: 14px; transition: background 0.15s; }
+
+  .cal-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+  }
+
+  .cal-nav-btn {
+    background: var(--gray-100);
+    border: none;
+    border-radius: var(--radius-sm);
+    width: 32px;
+    height: 32px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background 0.15s;
+  }
+
   .cal-nav-btn:hover { background: var(--gray-200); }
-  .cal-month-label { font-family: 'Montserrat', sans-serif; font-size: 15px; font-weight: 700; color: var(--cmg-navy); }
-  .cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 3px; margin-bottom: 20px; }
-  .cal-dh { text-align: center; font-family: 'Montserrat', sans-serif; font-size: 10px; font-weight: 700; letter-spacing: 0.8px; text-transform: uppercase; color: var(--gray-400); padding: 4px 0; }
-  .cal-d { aspect-ratio: 1; display: flex; align-items: center; justify-content: center; border-radius: var(--radius-sm); font-size: 12px; font-weight: 500; cursor: pointer; transition: all 0.12s; }
+
+  .cal-month-label {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--cmg-navy);
+  }
+
+  .cal-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 3px;
+    margin-bottom: 20px;
+  }
+
+  .cal-dh {
+    text-align: center;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: var(--gray-400);
+    padding: 4px 0;
+  }
+
+  .cal-d {
+    aspect-ratio: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+
   .cal-d.avail { color: var(--cmg-navy); }
   .cal-d.avail:hover { background: var(--gray-100); }
   .cal-d.sel { background: var(--cmg-navy); color: white; font-weight: 700; }
   .cal-d.na { color: var(--gray-200); cursor: default; }
   .cal-d.today { background: var(--cmg-red); color: white; font-weight: 700; }
-  .cal-slots { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-top: 16px; }
-  .cal-slot { padding: 9px; text-align: center; border: 1.5px solid var(--gray-200); border-radius: var(--radius-sm); font-family: 'Montserrat', sans-serif; font-size: 12px; font-weight: 600; color: var(--cmg-navy); cursor: pointer; transition: all 0.12s; }
+
+  .cal-slots {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    margin-top: 16px;
+  }
+
+  .cal-slot {
+    padding: 9px;
+    text-align: center;
+    border: 1.5px solid var(--gray-200);
+    border-radius: var(--radius-sm);
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--cmg-navy);
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+
   .cal-slot:hover { border-color: var(--cmg-red); color: var(--cmg-red); background: var(--cmg-red-pale); }
   .cal-slot.sel { background: var(--cmg-navy); border-color: var(--cmg-navy); color: white; }
-  .apply-steps-indicator { display: flex; align-items: center; margin-bottom: 32px; gap: 0; }
-  .asi-step { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
-  .asi-num { width: 28px; height: 28px; border-radius: 50%; background: var(--gray-200); color: var(--gray-400); font-family: 'Montserrat', sans-serif; font-size: 12px; font-weight: 700; display: flex; align-items: center; justify-content: center; transition: all 0.2s; }
-  .asi-label { font-family: 'Montserrat', sans-serif; font-size: 11px; font-weight: 600; color: var(--gray-400); white-space: nowrap; transition: color 0.2s; }
+
+  .cal-confirm-btn {
+    width: 100%;
+    background: var(--cmg-red);
+    color: white;
+    border: none;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    padding: 14px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    margin-top: 18px;
+    transition: background 0.2s;
+  }
+
+  .cal-confirm-btn:hover { background: var(--cmg-red-dark); }
+
+  /* ====== PAGE 5: ASSESSMENT ====== */
+  .assessment-shell {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 64px 48px;
+  }
+
+  .assess-hdr { text-align: center; margin-bottom: 48px; }
+
+  .assess-hdr h2 {
+    font-size: 36px;
+    color: var(--cmg-navy);
+    margin-bottom: 10px;
+  }
+
+  .assess-hdr p {
+    color: var(--gray-600);
+    font-size: 16px;
+    max-width: 520px;
+    margin: 0 auto;
+    line-height: 1.65;
+  }
+
+  .assess-progress {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    margin-bottom: 48px;
+  }
+
+  .prog-step { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+
+  .prog-circle {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    border: 2px solid var(--gray-200);
+    color: var(--gray-400);
+  }
+
+  .prog-circle.active { background: var(--cmg-red); border-color: var(--cmg-red); color: white; }
+  .prog-circle.done { background: var(--green); border-color: var(--green); color: white; }
+
+  .prog-label {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    color: var(--gray-400);
+    text-align: center;
+    max-width: 72px;
+    text-transform: uppercase;
+  }
+
+  .prog-label.active { color: var(--cmg-red); }
+
+  .prog-line { width: 56px; height: 2px; background: var(--gray-200); margin-bottom: 22px; }
+  .prog-line.done { background: var(--green); }
+
+  .assess-card {
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-top: 4px solid var(--cmg-navy);
+    border-radius: var(--radius-lg);
+    padding: 36px;
+    margin-bottom: 20px;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .assess-tag {
+    display: inline-block;
+    background: var(--cmg-red-pale);
+    color: var(--cmg-red);
+    font-family: 'Montserrat', sans-serif;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    padding: 4px 12px;
+    border-radius: 100px;
+    margin-bottom: 14px;
+  }
+
+  .assess-card h3 {
+    font-size: 18px;
+    color: var(--cmg-navy);
+    margin-bottom: 8px;
+    line-height: 1.35;
+  }
+
+  .assess-card > p {
+    font-size: 14px;
+    color: var(--gray-600);
+    line-height: 1.65;
+    margin-bottom: 24px;
+  }
+
+  .disc-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+  }
+
+  .disc-tile {
+    border: 2px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: 20px 14px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.18s;
+  }
+
+  .disc-tile:hover { border-color: var(--cmg-navy); transform: translateY(-2px); }
+  .disc-tile.sel { border-color: var(--cmg-red); background: var(--cmg-red-pale); }
+
+  .disc-ltr {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 36px;
+    font-weight: 800;
+    color: var(--cmg-navy);
+    line-height: 1;
+    margin-bottom: 6px;
+  }
+
+  .disc-tile.sel .disc-ltr { color: var(--cmg-red); }
+
+  .disc-nm {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--cmg-navy);
+    margin-bottom: 5px;
+  }
+
+  .disc-desc { font-size: 11px; color: var(--gray-400); line-height: 1.4; }
+
+  .apts-list { display: flex; flex-direction: column; gap: 18px; }
+
+  .apt-q {
+    background: var(--gray-50);
+    border-radius: var(--radius-md);
+    padding: 18px 20px;
+  }
+
+  .apt-q-text {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--cmg-navy);
+    margin-bottom: 12px;
+    line-height: 1.5;
+  }
+
+  .apt-opts { display: flex; flex-direction: column; gap: 7px; }
+
+  .apt-opt {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 10px 14px;
+    background: white;
+    border: 1.5px solid var(--gray-200);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--gray-800);
+    transition: border-color 0.12s;
+    line-height: 1.45;
+  }
+
+  .apt-opt:hover { border-color: var(--cmg-navy); }
+
+  .apt-opt input[type="radio"] {
+    accent-color: var(--cmg-red);
+    width: 15px;
+    height: 15px;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .slider-q {
+    background: var(--gray-50);
+    border-radius: var(--radius-md);
+    padding: 18px 20px;
+    margin-bottom: 14px;
+  }
+
+  .slider-q-text {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--cmg-navy);
+    margin-bottom: 12px;
+    line-height: 1.5;
+  }
+
+  .slider-q input[type=range] { width: 100%; accent-color: var(--cmg-red); }
+
+  .slider-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 11px;
+    color: var(--gray-400);
+    margin-top: 4px;
+  }
+
+  .assess-submit {
+    width: 100%;
+    background: var(--cmg-navy);
+    color: white;
+    border: none;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    padding: 18px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background 0.2s;
+    margin-top: 6px;
+  }
+
+  .assess-submit:hover { background: var(--cmg-navy-mid); }
+
+  /* Completion */
+  #completion {
+    text-align: center;
+    padding: 60px 0;
+  }
+
+  #completion h2 { font-size: 34px; color: var(--cmg-navy); margin-bottom: 14px; }
+  #completion > p { color: var(--gray-600); font-size: 17px; max-width: 500px; margin: 0 auto 36px; line-height: 1.65; }
+
+  .next-steps-box {
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-top: 4px solid var(--cmg-red);
+    border-radius: var(--radius-lg);
+    padding: 28px 32px;
+    max-width: 420px;
+    margin: 0 auto 32px;
+    text-align: left;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .next-steps-title {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: var(--cmg-red);
+    margin-bottom: 14px;
+  }
+
+  .next-steps-items { display: flex; flex-direction: column; gap: 10px; }
+
+  .next-steps-item {
+    display: flex;
+    gap: 12px;
+    font-size: 14px;
+    color: var(--gray-800);
+    line-height: 1.45;
+  }
+
+  .next-steps-item-num {
+    width: 22px;
+    height: 22px;
+    background: var(--cmg-navy);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 11px;
+    font-weight: 700;
+    color: white;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  /* ====== FOOTER ====== */
+  footer {
+    background: var(--cmg-navy);
+    padding: 40px 48px;
+    margin-top: 80px;
+  }
+
+  .footer-inner {
+    max-width: 1320px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .footer-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 20px;
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+  }
+
+  .footer-logo img { height: 36px; filter: brightness(0) invert(1); opacity: 0.85; }
+
+  .footer-links {
+    display: flex;
+    gap: 20px;
+    align-items: center;
+  }
+
+  .footer-links a {
+    color: rgba(255,255,255,0.5);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    text-decoration: none;
+    transition: color 0.2s;
+  }
+
+  .footer-links a:hover { color: rgba(255,255,255,0.85); }
+
+  .footer-legal {
+    font-size: 10.5px;
+    color: rgba(255,255,255,0.35);
+    line-height: 1.7;
+  }
+
+  /* ====== HIRING PROCESS PAGE ====== */
+  .process-timeline {
+    margin-top: 52px;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .process-step {
+    display: grid;
+    grid-template-columns: 64px 1fr;
+    gap: 0 28px;
+  }
+
+  .process-step-last .process-line { display: none; }
+
+  .process-left {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .process-node {
+    width: 52px;
+    height: 52px;
+    background: var(--cmg-navy);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    position: relative;
+    z-index: 1;
+    box-shadow: 0 0 0 4px white, 0 0 0 6px var(--cmg-red);
+  }
+
+  .process-node-final {
+    background: var(--cmg-red);
+    box-shadow: 0 0 0 4px white, 0 0 0 6px var(--cmg-red);
+  }
+
+  .process-num {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 18px;
+    font-weight: 800;
+    color: white;
+    line-height: 1;
+  }
+
+  .process-line {
+    width: 2px;
+    flex: 1;
+    background: linear-gradient(to bottom, var(--cmg-red), var(--gray-200));
+    min-height: 40px;
+    margin: 4px 0;
+  }
+
+  .process-body {
+    padding-bottom: 44px;
+  }
+
+  .process-step-last .process-body { padding-bottom: 0; }
+
+  .process-timing {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    color: var(--cmg-red);
+    margin-bottom: 6px;
+    margin-top: 12px;
+  }
+
+  .process-body h3 {
+    font-size: 20px;
+    color: var(--cmg-navy);
+    margin-bottom: 10px;
+    line-height: 1.2;
+  }
+
+  .process-body > p {
+    font-size: 15px;
+    color: var(--gray-600);
+    line-height: 1.7;
+    max-width: 680px;
+  }
+
+  .process-detail-row {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-top: 16px;
+  }
+
+  .process-detail-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--cmg-navy);
+    background: var(--gray-100);
+    padding: 6px 12px;
+    border-radius: 100px;
+  }
+
+  .pdi-icon { font-size: 14px; }
+
+  .process-callout {
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+    background: var(--cmg-red-pale);
+    border: 1px solid rgba(106,170,38,0.3);
+    border-left: 4px solid var(--cmg-red);
+    border-radius: var(--radius-md);
+    padding: 18px 20px;
+    margin-top: 18px;
+    max-width: 680px;
+  }
+
+  .process-callout-icon { font-size: 22px; flex-shrink: 0; margin-top: 1px; }
+
+  .process-callout-title {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--cmg-navy);
+    margin-bottom: 5px;
+  }
+
+  .process-callout-desc {
+    font-size: 13px;
+    color: var(--gray-600);
+    line-height: 1.6;
+  }
+
+  /* FAQ */
+  .faq-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-top: 48px;
+  }
+
+  .faq-item {
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-top: 3px solid var(--cmg-red);
+    border-radius: var(--radius-lg);
+    padding: 24px 24px 22px;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .faq-item h4 {
+    font-size: 15px;
+    color: var(--cmg-navy);
+    margin-bottom: 10px;
+    line-height: 1.3;
+  }
+
+  .faq-item p {
+    font-size: 13px;
+    color: var(--gray-600);
+    line-height: 1.65;
+  }
+
+  /* Apply step indicator */
+  .apply-steps-indicator {
+    display: flex;
+    align-items: center;
+    margin-bottom: 32px;
+    gap: 0;
+  }
+
+  .asi-step {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .asi-num {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--gray-200);
+    color: var(--gray-400);
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+  }
+
+  .asi-label {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--gray-400);
+    white-space: nowrap;
+    transition: color 0.2s;
+  }
+
   .asi-active .asi-num { background: var(--cmg-red); color: white; }
   .asi-active .asi-label { color: var(--cmg-navy); }
   .asi-done .asi-num { background: var(--green); color: white; }
   .asi-done .asi-label { color: var(--green); }
-  .asi-line { flex: 1; height: 2px; background: var(--gray-200); margin: 0 10px; transition: background 0.2s; min-width: 20px; }
+
+  .asi-line {
+    flex: 1;
+    height: 2px;
+    background: var(--gray-200);
+    margin: 0 10px;
+    transition: background 0.2s;
+    min-width: 20px;
+  }
+
   .asi-line.done { background: var(--green); }
-  .apply-form-title { font-family: 'Montserrat', sans-serif; font-size: 24px; color: var(--cmg-navy); margin-bottom: 4px; font-weight: 800; }
-  .next-steps-box { background: white; border: 1px solid var(--gray-200); border-top: 4px solid var(--cmg-red); border-radius: var(--radius-lg); padding: 28px 32px; max-width: 420px; margin: 0 auto 32px; text-align: left; box-shadow: var(--shadow-sm); }
-  .next-steps-title { font-family: 'Montserrat', sans-serif; font-size: 10px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--cmg-red); margin-bottom: 14px; }
-  .next-steps-items { display: flex; flex-direction: column; gap: 10px; }
-  .next-steps-item { display: flex; gap: 12px; font-size: 14px; color: var(--gray-800); line-height: 1.45; }
-  .next-steps-item-num { width: 22px; height: 22px; background: var(--cmg-navy); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-family: 'Montserrat', sans-serif; font-size: 11px; font-weight: 700; color: white; flex-shrink: 0; margin-top: 1px; }
-  .faq-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 48px; }
-  .faq-item { background: white; border: 1px solid var(--gray-200); border-top: 3px solid var(--cmg-red); border-radius: var(--radius-lg); padding: 24px 24px 22px; box-shadow: var(--shadow-sm); }
-  .faq-item h4 { font-size: 15px; color: var(--cmg-navy); margin-bottom: 10px; line-height: 1.3; }
-  .faq-item p { font-size: 13px; color: var(--gray-600); line-height: 1.65; }
-  .process-timeline { margin-top: 52px; display: flex; flex-direction: column; gap: 0; }
-  .process-step { display: grid; grid-template-columns: 64px 1fr; gap: 0 28px; }
-  .process-step-last .process-line { display: none; }
-  .process-left { display: flex; flex-direction: column; align-items: center; }
-  .process-node { width: 52px; height: 52px; background: var(--cmg-navy); border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; position: relative; z-index: 1; box-shadow: 0 0 0 4px white, 0 0 0 6px var(--cmg-red); }
-  .process-node-final { background: var(--cmg-red); box-shadow: 0 0 0 4px white, 0 0 0 6px var(--cmg-red); }
-  .process-num { font-family: 'Montserrat', sans-serif; font-size: 18px; font-weight: 800; color: white; line-height: 1; }
-  .process-line { width: 2px; flex: 1; background: linear-gradient(to bottom, var(--cmg-red), var(--gray-200)); min-height: 40px; margin: 4px 0; }
-  .process-body { padding-bottom: 44px; }
-  .process-step-last .process-body { padding-bottom: 0; }
-  .process-timing { font-family: 'Montserrat', sans-serif; font-size: 10px; font-weight: 700; letter-spacing: 1.2px; text-transform: uppercase; color: var(--cmg-red); margin-bottom: 6px; margin-top: 12px; }
-  .process-body h3 { font-size: 20px; color: var(--cmg-navy); margin-bottom: 10px; line-height: 1.2; }
-  .process-body > p { font-size: 15px; color: var(--gray-600); line-height: 1.7; max-width: 680px; }
-  .process-detail-row { display: flex; gap: 16px; flex-wrap: wrap; margin-top: 16px; }
-  .process-detail-item { display: flex; align-items: center; gap: 6px; font-family: 'Montserrat', sans-serif; font-size: 12px; font-weight: 600; color: var(--cmg-navy); background: var(--gray-100); padding: 6px 12px; border-radius: 100px; }
-  .process-callout { display: flex; gap: 14px; align-items: flex-start; background: var(--cmg-red-pale); border: 1px solid rgba(106,170,38,0.3); border-left: 4px solid var(--cmg-red); border-radius: var(--radius-md); padding: 18px 20px; margin-top: 18px; max-width: 680px; }
-  .process-callout-icon { font-size: 22px; flex-shrink: 0; margin-top: 1px; }
-  .process-callout-title { font-family: 'Montserrat', sans-serif; font-size: 13px; font-weight: 700; color: var(--cmg-navy); margin-bottom: 5px; }
-  .process-callout-desc { font-size: 13px; color: var(--gray-600); line-height: 1.6; }
+
+  .apply-form-title {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 24px;
+    color: var(--cmg-navy);
+    margin-bottom: 4px;
+    font-weight: 800;
+  }
+
+  .apply-main-sub {
+    color: var(--gray-400);
+    font-size: 14px;
+    margin-bottom: 28px;
+  }
+
+
+  /* ====== FAQ PAGE ====== */
   .faq-category { margin-bottom: 52px; }
   .faq-category:last-child { margin-bottom: 0; }
-  .faq-cat-header { display: flex; align-items: center; gap: 14px; margin-bottom: 20px; padding-bottom: 16px; border-bottom: 2px solid var(--gray-200); }
-  .faq-cat-icon { width: 44px; height: 44px; background: var(--cmg-navy); border-radius: var(--radius-md); display: flex; align-items: center; justify-content: center; font-size: 20px; flex-shrink: 0; }
+
+  .faq-cat-header {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    margin-bottom: 20px;
+    padding-bottom: 16px;
+    border-bottom: 2px solid var(--gray-200);
+  }
+
+  .faq-cat-icon {
+    width: 44px;
+    height: 44px;
+    background: var(--cmg-navy);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    flex-shrink: 0;
+  }
+
   .faq-cat-title { font-size: 22px; color: var(--cmg-navy); font-weight: 800; margin: 0; }
-  .faq-accordion { display: flex; flex-direction: column; border: 1px solid var(--gray-200); border-radius: var(--radius-lg); overflow: hidden; box-shadow: var(--shadow-sm); }
+
+  .faq-accordion {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+  }
+
   .faq-acc-item { border-bottom: 1px solid var(--gray-200); background: white; }
   .faq-acc-item:last-child { border-bottom: none; }
-  .faq-acc-btn { width: 100%; background: none; border: none; padding: 20px 24px; display: flex; justify-content: space-between; align-items: center; gap: 16px; cursor: pointer; text-align: left; font-family: 'Montserrat', sans-serif; font-size: 15px; font-weight: 600; color: var(--cmg-navy); line-height: 1.4; transition: background 0.15s; }
+
+  .faq-acc-btn {
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 20px 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    cursor: pointer;
+    text-align: left;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--cmg-navy);
+    line-height: 1.4;
+    transition: background 0.15s;
+  }
+
   .faq-acc-btn:hover { background: var(--gray-50); }
-  .faq-acc-btn.open { background: var(--cmg-red-pale); border-left: 4px solid var(--cmg-red); padding-left: 20px; }
-  .faq-chevron { font-size: 22px; color: var(--cmg-red); flex-shrink: 0; transition: transform 0.25s; line-height: 1; font-weight: 400; }
+
+  .faq-acc-btn.open {
+    background: var(--cmg-red-pale);
+    border-left: 4px solid var(--cmg-red);
+    padding-left: 20px;
+  }
+
+  .faq-chevron {
+    font-size: 22px;
+    color: var(--cmg-red);
+    flex-shrink: 0;
+    transition: transform 0.25s;
+    line-height: 1;
+    font-weight: 400;
+  }
+
   .faq-acc-btn.open .faq-chevron { transform: rotate(90deg); }
-  .faq-acc-body { display: none; padding: 0 24px 22px; border-left: 4px solid var(--cmg-red); background: var(--cmg-red-pale); }
+
+  .faq-acc-body {
+    display: none;
+    padding: 0 24px 22px;
+    border-left: 4px solid var(--cmg-red);
+    background: var(--cmg-red-pale);
+  }
+
   .faq-acc-body.open { display: block; }
-  .faq-acc-body p { font-size: 14px; color: var(--gray-600); line-height: 1.75; margin: 0; }
-  footer { background: var(--cmg-navy); padding: 40px 48px; margin-top: 80px; }
-  .footer-inner { max-width: 1320px; margin: 0 auto; display: flex; flex-direction: column; gap: 20px; }
-  .footer-top { display: flex; justify-content: space-between; align-items: center; padding-bottom: 20px; border-bottom: 1px solid rgba(255,255,255,0.1); }
-  .footer-links { display: flex; gap: 20px; align-items: center; }
-  .footer-links a { color: rgba(255,255,255,0.5); font-size: 11px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; text-decoration: none; transition: color 0.2s; }
-  .footer-links a:hover { color: rgba(255,255,255,0.85); }
-  .footer-legal { font-size: 10.5px; color: rgba(255,255,255,0.35); line-height: 1.7; }
+
+  .faq-acc-body p {
+    font-size: 14px;
+    color: var(--gray-600);
+    line-height: 1.75;
+    margin: 0;
+  }
+
   @media (max-width: 960px) {
     .nav-inner { padding: 0 20px; }
     .nav-tabs { display: none; }
@@ -290,6 +2042,7 @@
     .video-block, .apply-wrap { grid-template-columns: 1fr; }
     .apply-sidebar { position: static; height: auto; padding: 48px 24px; }
     .apply-main { padding: 40px 24px; }
+    .process-detail-row { gap: 8px; }
     .footer-top { flex-direction: column; align-items: flex-start; gap: 16px; }
     .footer-links { flex-wrap: wrap; gap: 12px; }
   }
@@ -297,388 +2050,1232 @@
 </head>
 <body>
 
+
+
+<!-- Nav -->
 <nav>
   <div class="nav-inner">
     <a class="nav-logo" href="#" onclick="showPage('p1'); return false;" style="display:flex;align-items:center;">
-      <span style="font-family:'Montserrat',sans-serif;font-size:20px;font-weight:800;color:var(--cmg-navy);">{{COMPANY_NAME}}</span>
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1643.342 222.139" style="height:38px;width:auto;display:block;" aria-label="{{COMPANY_NAME}}">
+        <defs><clipPath id="clip-path"><rect width="1643.342" height="222.139" fill="none"/></clipPath></defs>
+        <g clip-path="url(#clip-path)">
+          <path d="M204.427,44.072,187.938,56.728a90.083,90.083,0,0,0-32.771-26.94,95.86,95.86,0,0,0-42.008-9.169A92.856,92.856,0,0,0,66.815,32.63,86.211,86.211,0,0,0,33.763,64.9q-11.724,20.26-11.723,45.56,0,38.244,26.228,63.832t66.172,25.585q43.928,0,73.5-34.4l16.489,12.508a105.418,105.418,0,0,1-39.025,30.78q-23.379,10.879-52.243,10.872-54.873,0-86.575-36.531Q.007,152.254,0,108.615,0,62.7,32.2,31.35T112.878,0q29.286,0,52.879,11.59a102.663,102.663,0,0,1,38.67,32.482" fill="#92c13b"/>
+          <path d="M213.84,219.636,243.777,10.517h3.4l85.013,171.589L416.38,10.517h3.352l30.092,209.119h-20.5L408.668,70.086l-73.942,149.55H329.39L254.567,68.947,234.03,219.636Z" fill="#92c13b"/>
+          <path d="M669.628,40.376,653.42,55.733a123.721,123.721,0,0,0-38.307-26.088q-20.826-8.881-40.586-8.889a96.859,96.859,0,0,0-46.848,12.086,87.794,87.794,0,0,0-34.473,32.771,84.663,84.663,0,0,0-12.226,43.71,86.356,86.356,0,0,0,12.655,44.849A89.875,89.875,0,0,0,528.6,187.579a100.616,100.616,0,0,0,48.9,12.16q32.273,0,54.589-18.2t26.443-47.195H591.867v-20.19h90.128q-.277,48.48-28.79,76.977-28.5,28.507-76.266,28.508-58,0-91.83-39.521-26.021-30.417-26.021-70.367a107.928,107.928,0,0,1,14.927-55.3,106.26,106.26,0,0,1,40.942-40.023Q540.979.008,573.816,0A130.892,130.892,0,0,1,623.854,9.6q23.457,9.6,45.774,30.78" fill="#92c13b"/>
+          <path d="M711.547,114.083h10.571v44.19h53.736v-44.19h10.571V219.5H775.854V168.552H722.118V219.5H711.547Z" fill="#4d4d4e"/>
+          <path d="M918.392,166.791c0,30.976-24.226,55.348-55.5,55.348-32.445,0-55.642-25.4-55.642-54.909,0-31.418,24.371-55.79,54.763-55.79,32,0,56.377,23.93,56.377,55.351m-100.13.439a44.08,44.08,0,0,0,44.34,44.632c24.665,0,44.778-18.793,44.778-45.219,0-26.721-21.435-44.926-44.778-44.926-23.2,0-44.34,18.5-44.34,45.513" fill="#4d4d4e"/>
+          <path d="M934.664,219.5l14.973-105.413H951.4l42.869,86.473,42.431-86.473h1.762L1053.436,219.5h-10.277l-10.277-75.463L995.591,219.5h-2.643l-37.878-76.05L944.939,219.5Z" fill="#4d4d4e"/>
+          <path d="M1074.4,114.083H1134.6V124.36h-49.623V157.4H1134.6v10.274h-49.623v41.55H1134.6V219.5H1074.4Z" fill="#4d4d4e"/>
+          <path d="M1193.738,114.083h10.571v95.136h40.521V219.5h-51.092Z" fill="#4d4d4e"/>
+          <path d="M1359.031,166.791c0,30.976-24.223,55.348-55.493,55.348-32.447,0-55.644-25.4-55.644-54.909,0-31.418,24.371-55.79,54.761-55.79,32.007,0,56.376,23.93,56.376,55.351m-100.125.439a44.079,44.079,0,0,0,44.336,44.632c24.665,0,44.779-18.793,44.779-45.219,0-26.721-21.434-44.926-44.779-44.926-23.195,0-44.336,18.5-44.336,45.513" fill="#4d4d4e"/>
+          <path d="M1414.06,114.083,1463.241,219.5h-11.306l-16.589-34.648h-45.512L1373.391,219.5h-11.746l49.917-105.413Zm-1.323,22.316-18.205,38.172h36.116Z" fill="#4d4d4e"/>
+          <path d="M1479.81,219.5V114.083h2.2l69.884,80.748V114.083h10.571V219.5h-2.349l-69.736-79.719V219.5Z" fill="#4d4d4e"/>
+          <path d="M1633.213,135.225c-5.727-7.489-10.719-12.92-19.38-12.92-9.1,0-14.242,6.46-14.242,13.362,0,5.724,3.376,11.745,9.4,16.295,19.819,14.681,34.355,24.813,34.355,41.843,0,14.827-12.478,28.334-29.657,28.334-14.533,0-24.077-8.076-31.86-22.316l8.957-5.431c6.312,11.6,13.947,17.47,22.023,17.47,11.012,0,19.525-8.073,19.525-17.911,0-11.6-10.862-18.205-34.794-37.585-4.992-3.965-8.955-12.332-8.955-20.26,0-14.534,11.3-24.665,25.544-24.665,12.919,0,20.7,7.782,27.6,17.178Z" fill="#4d4d4e"/>
+        </g>
+      </svg>
     </a>
+
     <div class="nav-tabs">
       <button class="nav-tab active" onclick="showPage('p1')" id="tab-p1"><span class="step-badge">1</span>The Opportunity</button>
-      <button class="nav-tab" onclick="showPage('p2')" id="tab-p2"><span class="step-badge">2</span>Why Join Us</button>
+      <button class="nav-tab" onclick="showPage('p2')" id="tab-p2"><span class="step-badge">2</span>Why CMG</button>
       <button class="nav-tab" onclick="showPage('p3')" id="tab-p3"><span class="step-badge">3</span>Hiring Process</button>
       <button class="nav-tab" onclick="showPage('p5')" id="tab-p5"><span class="step-badge">?</span>FAQ</button>
       <button class="nav-tab" onclick="showPage('p4')" id="tab-p4"><span class="step-badge">4</span>Apply Now</button>
     </div>
+
     <button class="nav-cta" onclick="showPage('p4')">Apply Now</button>
   </div>
 </nav>
 
-<!-- PAGE 1: OPPORTUNITY -->
+<!-- ============================================================ -->
+<!-- PAGE 1: OPPORTUNITY                                          -->
+<!-- ============================================================ -->
 <div id="p1" class="page active">
+
   <div class="hero">
     <div class="hero-content">
       <div>
-        <div class="hero-eyebrow"><span class="hero-eyebrow-line"></span>Now Hiring · {{LOCATION_DISPLAY}}</div>
+        <div class="hero-eyebrow">
+          <span class="hero-eyebrow-line"></span>
+          Now Hiring · {{LOCATION_DISPLAY}}
+        </div>
+
         <h1>{{HERO_HEADLINE}}</h1>
-        <p class="hero-sub">{{HERO_SUBHEADLINE}}</p>
+
+        <p class="hero-sub">No mortgage experience required. {{COMPANY_NAME}}'s {{LOCATION_DISPLAY}} team is recruiting driven, coachable people ready to earn what they're worth in one of America's most resilient industries.</p>
+
         <div class="hero-checks">
-          <div class="hero-check"><span class="check-icon">✓</span>No mortgage license required to start — we pay for it</div>
+          <div class="hero-check"><span class="check-icon">✓</span>No mortgage license required to start — CMG pays for it</div>
           <div class="hero-check"><span class="check-icon">✓</span>Warm, pre-qualified leads delivered to your pipeline daily</div>
           <div class="hero-check"><span class="check-icon">✓</span>Fully paid 8-week training program with live coaching</div>
-          <div class="hero-check"><span class="check-icon">✓</span>{{SIGNING_BONUS}} signing bonus for {{SIGNING_BONUS_MONTH}} hires</div>
+          <div class="hero-check"><span class="check-icon">✓</span>{{SIGNING_BONUS}}</div>
         </div>
+
         <div class="hero-btns">
           <button class="btn-red" onclick="showPage('p4')">Apply in 3 Minutes →</button>
           <button class="btn-outline" onclick="document.getElementById('vid-block').scrollIntoView({behavior:'smooth'})">▶ Watch Leadership Message</button>
         </div>
       </div>
+
       <div class="earnings-card">
         <div class="earnings-label">Year 1 On-Target Earnings</div>
         <div class="earnings-figure">{{YEAR1_RANGE}}</div>
         <div class="earnings-note">base salary + commission</div>
+
         <div class="earnings-rows">
-          <div class="earnings-row"><span class="earnings-row-label">Year 2 — Top Performer</span><span class="earnings-row-val">{{YEAR2_TOP}}</span></div>
-          <div class="earnings-row"><span class="earnings-row-label">Senior Loan Officer</span><span class="earnings-row-val">{{SENIOR_LO}}</span></div>
-          <div class="earnings-row"><span class="earnings-row-label">Team Lead / Branch Mgr</span><span class="earnings-row-val">{{TEAM_LEAD}}</span></div>
-          <div class="earnings-row"><span class="earnings-row-label">Signing Bonus ({{SIGNING_BONUS_MONTH}} hire)</span><span class="earnings-row-val" style="color:var(--cmg-red)">{{SIGNING_BONUS}}</span></div>
+          <div class="earnings-row">
+            <span class="earnings-row-label">Year 2 — Top Performer</span>
+            <span class="earnings-row-val">{{YEAR2_TOP}}</span>
+          </div>
+          <div class="earnings-row">
+            <span class="earnings-row-label">Senior Loan Officer</span>
+            <span class="earnings-row-val">{{SENIOR_LO}}</span>
+          </div>
+          <div class="earnings-row">
+            <span class="earnings-row-label">Team Lead / Branch Mgr</span>
+            <span class="earnings-row-val">{{TEAM_LEAD}}</span>
+          </div>
+          <div class="earnings-row">
+            <span class="earnings-row-label">Signing Bonus (July hire)</span>
+            <span class="earnings-row-val" style="color:var(--cmg-red)">{{SIGNING_BONUS_AMOUNT}}</span>
+          </div>
         </div>
       </div>
     </div>
+
     <div class="hero-stats">
       <div class="hero-stats-inner">
-        <div class="hero-stat"><div class="hero-stat-num">{{STAT_1_NUM}}</div><div class="hero-stat-label">{{STAT_1_LABEL}}</div></div>
-        <div class="hero-stat"><div class="hero-stat-num">{{STAT_2_NUM}}</div><div class="hero-stat-label">{{STAT_2_LABEL}}</div></div>
-        <div class="hero-stat"><div class="hero-stat-num">{{STAT_3_NUM}}</div><div class="hero-stat-label">{{STAT_3_LABEL}}</div></div>
-        <div class="hero-stat"><div class="hero-stat-num">{{STAT_4_NUM}}</div><div class="hero-stat-label">{{STAT_4_LABEL}}</div></div>
+        <div class="hero-stat">
+          <div class="hero-stat-num">{{STAT_1_NUM}}</div>
+          <div class="hero-stat-label">{{STAT_1_LABEL}}</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-num">{{STAT_2_NUM}}</div>
+          <div class="hero-stat-label">{{STAT_2_LABEL}}</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-num">{{STAT_3_NUM}}</div>
+          <div class="hero-stat-label">{{STAT_3_LABEL}}</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-num">{{STAT_4_NUM}}</div>
+          <div class="hero-stat-label">{{STAT_4_LABEL}}</div>
+        </div>
       </div>
     </div>
   </div>
 
+  <!-- Career Path -->
   <div class="section">
     <div class="section-eyebrow">Career Trajectory</div>
-    <h2 class="section-title">A real path forward — not just another job.</h2>
-    <p class="section-sub">Every loan officer starts at the same place. Where you go depends entirely on your drive and coachability.</p>
+    <h2 class="section-title">A real path forward —<br>not just another job.</h2>
+    <p class="section-sub">Every CMG loan officer in South Carolina starts at the same place. Where you go depends entirely on your drive and coachability.</p>
+
     <div class="path-track">
       <div class="path-connector"></div>
-      <div class="path-step"><div class="path-node">🎓</div><div class="path-timeline">Month 1–2</div><h3>Loan Officer Trainee</h3><p>Paid training. Learn products, systems, compliance, and market dynamics.</p><div class="path-salary">$45K base</div></div>
-      <div class="path-step"><div class="path-node">📞</div><div class="path-timeline">Month 3–12</div><h3>Junior Loan Officer</h3><p>Live warm leads. Building pipeline. Coached on every deal you work.</p><div class="path-salary">{{YEAR1_RANGE}} OTE</div></div>
-      <div class="path-step"><div class="path-node">🏆</div><div class="path-timeline">Year 2–3</div><h3>Senior Loan Officer</h3><p>Referral network. Complex purchase loans. Mentoring incoming hires.</p><div class="path-salary">{{SENIOR_LO}} OTE</div></div>
-      <div class="path-step"><div class="path-node">🚀</div><div class="path-timeline">Year 3+</div><h3>Team Lead / Branch Mgr</h3><p>Build and lead your own team. Override income. Equity in the platform.</p><div class="path-salary">{{TEAM_LEAD}}+ OTE</div></div>
+      <div class="path-step">
+        <div class="path-node">🎓</div>
+        <div class="path-timeline">Month 1–2</div>
+        <h3>Loan Officer Trainee</h3>
+        <p>Paid training. Learn products, systems, compliance, and SC market dynamics.</p>
+        <div class="path-salary">$45K base</div>
+      </div>
+      <div class="path-step">
+        <div class="path-node">📞</div>
+        <div class="path-timeline">Month 3–12</div>
+        <h3>Junior Loan Officer</h3>
+        <p>Live warm leads. Building pipeline. Coached on every deal you work.</p>
+        <div class="path-salary">$65–90K OTE</div>
+      </div>
+      <div class="path-step">
+        <div class="path-node">🏆</div>
+        <div class="path-timeline">Year 2–3</div>
+        <h3>Senior Loan Officer</h3>
+        <p>Referral network. Complex purchase loans. Mentoring incoming hires.</p>
+        <div class="path-salary">$120–180K OTE</div>
+      </div>
+      <div class="path-step">
+        <div class="path-node">🚀</div>
+        <div class="path-timeline">Year 3+</div>
+        <h3>Team Lead / Branch Mgr</h3>
+        <p>Build and lead your own team. Override income. Equity in the platform.</p>
+        <div class="path-salary">$250K+ OTE</div>
+      </div>
     </div>
   </div>
 
+  <!-- Training -->
   <div style="background: var(--gray-50); padding: 80px 0;">
     <div class="section" style="padding-top: 0; padding-bottom: 0;">
       <div class="section-eyebrow">Training Program</div>
-      <h2 class="section-title">Eight weeks that change your career trajectory.</h2>
-      <p class="section-sub">Our Mortgage Academy is nationally recognized. You'll be licensed, certified, and pipeline-ready before you take your first live borrower call.</p>
+      <h2 class="section-title">Eight weeks that change<br>your career trajectory.</h2>
+      <p class="section-sub">CMG's Mortgage Academy is nationally recognized. You'll be licensed, certified, and pipeline-ready before you take your first live borrower call.</p>
+
       <div class="training-grid">
-        <div class="training-card"><div class="training-week">Weeks 1–2</div><h3>Industry Foundations</h3><p>Understand mortgages end-to-end — loan types, rates, credit, and the local housing market.</p><div class="training-list"><div class="training-list-item">NMLS pre-licensing education (fully paid)</div><div class="training-list-item">Mortgage law and compliance overview</div><div class="training-list-item">Full product catalog deep dive</div><div class="training-list-item">Shadowing licensed LOs on live calls</div></div></div>
-        <div class="training-card"><div class="training-week">Weeks 3–4</div><h3>Sales Skills &amp; Scripts</h3><p>Build your frameworks. Practice until they feel natural. Our playbook is built from 10,000+ conversations.</p><div class="training-list"><div class="training-list-item">Call recording and live coaching feedback</div><div class="training-list-item">Complete objection handling library</div><div class="training-list-item">Pre-qualification scripting techniques</div><div class="training-list-item">Daily role-play with your cohort</div></div></div>
-        <div class="training-card"><div class="training-week">Weeks 5–6</div><h3>CRM &amp; Technology Mastery</h3><p>Learn every tool you'll use daily — so technology accelerates you instead of slowing you down.</p><div class="training-list"><div class="training-list-item">Encompass LOS certification</div><div class="training-list-item">Salesforce pipeline management</div><div class="training-list-item">Lead routing and prioritization</div><div class="training-list-item">Automated follow-up sequences</div></div></div>
-        <div class="training-card"><div class="training-week">Weeks 7–8</div><h3>Live Pipeline Launch</h3><p>You're licensed, trained, and ready. Work real leads with a senior coach in your corner.</p><div class="training-list"><div class="training-list-item">First live borrower conversations</div><div class="training-list-item">First closed loan milestone bonus</div><div class="training-list-item">90-day personalized coaching plan</div><div class="training-list-item">Full team integration and onboarding</div></div></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="section">
-    <div class="section-eyebrow">Real People. Real Results.</div>
-    <h2 class="section-title">From zero mortgage experience to top producers.</h2>
-    <div class="testimonials-row">
-      <div class="tcard"><div class="tcard-stars">★★★★★</div><div class="tcard-quote">I waited tables for six years before joining. The training alone was worth more than any course I ever took. I closed $97,000 in my first full year with zero finance background.</div><div class="tcard-author"><div class="tcard-avatar" style="background: var(--cmg-navy);">JM</div><div><div class="tcard-name">Jordan M.</div><div class="tcard-detail">Former server → Senior LO, Year 2</div></div></div></div>
-      <div class="tcard"><div class="tcard-stars">★★★★★</div><div class="tcard-quote">My DISC assessment placed me in purchase loans — exactly where my personality thrives. I'm now team lead at 26. The career path laid out is real and they actually hold up their end.</div><div class="tcard-author"><div class="tcard-avatar" style="background: var(--cmg-red);">AL</div><div><div class="tcard-name">Ashley L.</div><div class="tcard-detail">Team Lead, Charleston branch</div></div></div></div>
-      <div class="tcard"><div class="tcard-stars">★★★★★</div><div class="tcard-quote">I came from retail banking and thought I knew mortgages. The training showed me how much I didn't know — and how to close at twice the rate. Best career move I've made.</div><div class="tcard-author"><div class="tcard-avatar" style="background: var(--green);">RC</div><div><div class="tcard-name">Rafael C.</div><div class="tcard-detail">Former bank teller → $145K Year 3</div></div></div></div>
-    </div>
-  </div>
-
-  <div class="section" style="padding-top: 0;">
-    <div class="noexp">
-      <h2>No experience required.<br><span>Hunger is the only prerequisite.</span></h2>
-      <p>If you can hold a conversation, follow a proven system, and genuinely care about helping people into homes — we can teach you everything else. We've turned bartenders, teachers, veterans, and retail workers into top mortgage producers.</p>
-      <div class="noexp-grid">
-        <div class="noexp-card"><div class="noexp-card-icon">🍽️</div><h4>Hospitality</h4><p>Service-first people close more loans. Your empathy is your greatest edge.</p></div>
-        <div class="noexp-card"><div class="noexp-card-icon">🎖️</div><h4>Veterans</h4><p>Discipline, resilience, structure. You already have the mindset we build toward.</p></div>
-        <div class="noexp-card"><div class="noexp-card-icon">🏫</div><h4>Teachers</h4><p>Explaining complex things simply is a superpower in mortgage. Borrow it.</p></div>
-        <div class="noexp-card"><div class="noexp-card-icon">🛍️</div><h4>Retail &amp; Sales</h4><p>You already handle objections all day. Now earn real commission for it.</p></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="section" style="padding-top: 0;" id="vid-block">
-    <div class="video-block">
-      <div class="video-thumb"><div class="play-circle">▶</div><div class="video-thumb-label">3-minute message from our Branch Manager</div></div>
-      <div class="video-body">
-        <h3>"We built this team to create careers, not fill seats."</h3>
-        <p>When we opened this call center, the goal wasn't volume — it was building a team of mortgage professionals who'd still be here, and thriving, five years from now.</p>
-        <p>Watch this short message to hear what our top performers have in common and what your first 90 days will actually look like.</p>
-        <div class="leader-row">
-          <div class="leader-ava">{{MANAGER_INITIALS}}</div>
-          <div><div class="leader-name">{{MANAGER_NAME}}</div><div class="leader-title">{{MANAGER_TITLE}}</div></div>
+        <div class="training-card">
+          <div class="training-week">Weeks 1–2</div>
+          <h3>Industry Foundations</h3>
+          <p>Understand mortgages end-to-end — loan types, rates, credit, and the SC housing market.</p>
+          <div class="training-list">
+            <div class="training-list-item">NMLS pre-licensing education (fully paid by CMG)</div>
+            <div class="training-list-item">SC mortgage law and compliance overview</div>
+            <div class="training-list-item">Full product catalog deep dive</div>
+            <div class="training-list-item">Shadowing licensed LOs on live calls</div>
+          </div>
+        </div>
+        <div class="training-card">
+          <div class="training-week">Weeks 3–4</div>
+          <h3>Sales Skills &amp; Scripts</h3>
+          <p>Build your frameworks. Practice until they feel natural. CMG's playbook is built from 10,000+ SC conversations.</p>
+          <div class="training-list">
+            <div class="training-list-item">Call recording and live coaching feedback</div>
+            <div class="training-list-item">Complete objection handling library</div>
+            <div class="training-list-item">Pre-qualification scripting techniques</div>
+            <div class="training-list-item">Daily role-play with your cohort</div>
+          </div>
+        </div>
+        <div class="training-card">
+          <div class="training-week">Weeks 5–6</div>
+          <h3>CRM &amp; Technology Mastery</h3>
+          <p>Learn every tool you'll use daily — so technology accelerates you instead of slowing you down.</p>
+          <div class="training-list">
+            <div class="training-list-item">Encompass LOS certification</div>
+            <div class="training-list-item">Salesforce pipeline management</div>
+            <div class="training-list-item">Lead routing and prioritization</div>
+            <div class="training-list-item">Automated follow-up sequences</div>
+          </div>
+        </div>
+        <div class="training-card">
+          <div class="training-week">Weeks 7–8</div>
+          <h3>Live Pipeline Launch</h3>
+          <p>You're licensed, trained, and ready. Work real leads with a senior coach in your corner.</p>
+          <div class="training-list">
+            <div class="training-list-item">First live borrower conversations</div>
+            <div class="training-list-item">First closed loan milestone bonus</div>
+            <div class="training-list-item">90-day personalized coaching plan</div>
+            <div class="training-list-item">Full team integration and onboarding</div>
+          </div>
         </div>
       </div>
     </div>
   </div>
 
+  <!-- Testimonials -->
+  <div class="section">
+    <div class="section-eyebrow">Real People. Real Results.</div>
+    <h2 class="section-title">From zero mortgage experience<br>to top producers.</h2>
+
+    <div class="testimonials-row">
+      <div class="tcard">
+        <div class="tcard-stars">★★★★★</div>
+        <div class="tcard-quote">I waited tables for six years before CMG. The training alone was worth more than any course I ever took. I closed $97,000 in my first full year and I had zero finance background.</div>
+        <div class="tcard-author">
+          <div class="tcard-avatar" style="background: var(--cmg-navy);">JM</div>
+          <div>
+            <div class="tcard-name">Jordan M.</div>
+            <div class="tcard-detail">Former server → Senior LO, Year 2</div>
+          </div>
+        </div>
+      </div>
+      <div class="tcard">
+        <div class="tcard-stars">★★★★★</div>
+        <div class="tcard-quote">My DISC assessment placed me in purchase loans — exactly where my personality thrives. I'm now team lead at 26. The career path CMG lays out is real and they actually hold up their end.</div>
+        <div class="tcard-author">
+          <div class="tcard-avatar" style="background: var(--cmg-red);">AL</div>
+          <div>
+            <div class="tcard-name">Ashley L.</div>
+            <div class="tcard-detail">Team Lead, Charleston branch</div>
+          </div>
+        </div>
+      </div>
+      <div class="tcard">
+        <div class="tcard-stars">★★★★★</div>
+        <div class="tcard-quote">I came from retail banking and thought I knew mortgages. CMG's training showed me how much I didn't know — and how to close at twice the rate. Best career move I've made.</div>
+        <div class="tcard-author">
+          <div class="tcard-avatar" style="background: var(--green);">RC</div>
+          <div>
+            <div class="tcard-name">Rafael C.</div>
+            <div class="tcard-detail">Former bank teller → $145K Year 3</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- No Experience Required -->
+  <div class="section" style="padding-top: 0;">
+    <div class="noexp">
+      <h2>No experience required.<br><span>Hunger is the only prerequisite.</span></h2>
+      <p>If you can hold a conversation, follow a proven system, and genuinely care about helping people into homes — CMG can teach you everything else. We've turned bartenders, teachers, veterans, and retail workers into top mortgage producers.</p>
+
+      <div class="noexp-grid">
+        <div class="noexp-card">
+          <div class="noexp-card-icon">🍽️</div>
+          <h4>Hospitality</h4>
+          <p>Service-first people close more loans. Your empathy is your greatest edge.</p>
+        </div>
+        <div class="noexp-card">
+          <div class="noexp-card-icon">🎖️</div>
+          <h4>Veterans</h4>
+          <p>Discipline, resilience, structure. You already have the mindset we build toward.</p>
+        </div>
+        <div class="noexp-card">
+          <div class="noexp-card-icon">🏫</div>
+          <h4>Teachers</h4>
+          <p>Explaining complex things simply is a superpower in mortgage. Borrow it.</p>
+        </div>
+        <div class="noexp-card">
+          <div class="noexp-card-icon">��</div>
+          <h4>Retail &amp; Sales</h4>
+          <p>You already handle objections all day. Now earn real commission for it.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Video -->
+  <div class="section" style="padding-top: 0;" id="vid-block">
+    <div class="video-block">
+      <div class="video-thumb">
+        <div class="play-circle">▶</div>
+        <div class="video-thumb-label">3-minute message from our Regional Director</div>
+      </div>
+      <div class="video-body">
+        <h3>"We built this team to create careers, not fill seats."</h3>
+        <p>When we opened the South Carolina call center, the goal wasn't volume — it was building a team of mortgage professionals who'd still be here, and thriving, five years from now.</p>
+        <p>Watch this short message to hear what our top performers have in common and what your first 90 days will actually look like.</p>
+        <div class="leader-row">
+          <div class="leader-ava">{{MANAGER_INITIALS}}</div>
+          <div>
+            <div class="leader-name">{{MANAGER_NAME}}</div>
+            <div class="leader-title">{{MANAGER_TITLE}} · NMLS# {{MANAGER_NMLS}}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- CTA -->
   <div class="full-cta">
     <h2>Your application takes under 3 minutes.</h2>
     <p>No cover letter. No lengthy questionnaire. Just your name, phone, and a bit about yourself. A recruiter will be in touch within one business day.</p>
     <button class="btn-red" style="font-size: 15px; padding: 16px 36px;" onclick="showPage('p4')">Apply Now — It's Free →</button>
   </div>
+
 </div>
 
-<!-- PAGE 2: WHY JOIN -->
+<!-- ============================================================ -->
+<!-- PAGE 2: WHY CMG                                              -->
+<!-- ============================================================ -->
 <div id="p2" class="page">
+
   <div class="why-hero">
-    <div class="section-eyebrow" style="justify-content: center; margin-bottom: 16px;">Why Join Us</div>
+    <div class="section-eyebrow" style="justify-content: center; margin-bottom: 16px;">Why {{COMPANY_NAME}}</div>
     <h1>The platform that lets<br>great producers <span>win.</span></h1>
-    <p>Tools, leads, coaching, and culture. Here's why our loan officers outperform the market — and why they stay.</p>
+    <p>Tools, leads, coaching, and culture. Here's why CMG loan officers outperform the market — and why they stay.</p>
   </div>
+
   <div class="section">
     <div class="pillars-grid">
-      <div class="pillar"><div class="pillar-icon">⚡</div><h3>Technology that closes loans faster</h3><p>Our tech stack puts you three steps ahead of the borrower and ten steps ahead of the competition.</p><div class="pillar-list"><div class="pillar-item"><div class="pillar-dot"></div>Encompass LOS — the industry gold standard</div><div class="pillar-item"><div class="pillar-dot"></div>Salesforce CRM with AI-assisted lead scoring</div><div class="pillar-item"><div class="pillar-dot"></div>Digital mortgage application portal</div><div class="pillar-item"><div class="pillar-dot"></div>Real-time rate alerts for locked borrowers</div><div class="pillar-item"><div class="pillar-dot"></div>E-sign and document automation end-to-end</div></div></div>
-      <div class="pillar"><div class="pillar-icon">🎯</div><h3>Leads — not just a name and number</h3><p>We don't hand you a cold list. Every lead in our system is pre-qualified, categorized, and ready for a real conversation.</p><div class="pillar-list"><div class="pillar-item"><div class="pillar-dot"></div>30–50 warm inbound leads per LO monthly</div><div class="pillar-item"><div class="pillar-dot"></div>Pre-verified credit range and income band</div><div class="pillar-item"><div class="pillar-dot"></div>Segmented by purchase vs. refinance intent</div><div class="pillar-item"><div class="pillar-dot"></div>Automated nurture for long-cycle borrowers</div><div class="pillar-item"><div class="pillar-dot"></div>Realtor referral pipeline included at Year 2</div></div></div>
-      <div class="pillar"><div class="pillar-icon">🏋️</div><h3>Coaching that makes you measurably better</h3><p>Not a manager who checks in weekly. A dedicated performance coach who reviews your calls and tells you exactly what to fix.</p><div class="pillar-list"><div class="pillar-item"><div class="pillar-dot"></div>1:1 coaching 3× per week in Year 1</div><div class="pillar-item"><div class="pillar-dot"></div>Weekly call recording reviews with scored feedback</div><div class="pillar-item"><div class="pillar-dot"></div>Monthly pipeline strategy sessions</div><div class="pillar-item"><div class="pillar-dot"></div>Access to top-performer playbooks and scripts</div><div class="pillar-item"><div class="pillar-dot"></div>Quarterly DISC re-assessment and growth mapping</div></div></div>
+      <div class="pillar">
+        <div class="pillar-icon">⚡</div>
+        <h3>Technology that closes loans faster</h3>
+        <p>CMG's tech stack puts you three steps ahead of the borrower and ten steps ahead of the competition.</p>
+        <div class="pillar-list">
+          <div class="pillar-item"><div class="pillar-dot"></div>Encompass LOS — the industry gold standard</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Salesforce CRM with AI-assisted lead scoring</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Digital mortgage application portal</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Real-time rate alerts for locked borrowers</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>E-sign and document automation end-to-end</div>
+        </div>
+      </div>
+      <div class="pillar">
+        <div class="pillar-icon">🎯</div>
+        <h3>Leads — not just a name and number</h3>
+        <p>We don't hand you a cold list. Every lead in our system is pre-qualified, categorized, and ready for a real conversation.</p>
+        <div class="pillar-list">
+          <div class="pillar-item"><div class="pillar-dot"></div>30–50 warm inbound leads per LO monthly</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Pre-verified credit range and income band</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Segmented by purchase vs. refinance intent</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Automated nurture for long-cycle borrowers</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Realtor referral pipeline included at Year 2</div>
+        </div>
+      </div>
+      <div class="pillar">
+        <div class="pillar-icon">🏋️</div>
+        <h3>Coaching that makes you measurably better</h3>
+        <p>Not a manager who checks in weekly. A dedicated performance coach who reviews your calls and tells you exactly what to fix.</p>
+        <div class="pillar-list">
+          <div class="pillar-item"><div class="pillar-dot"></div>1:1 coaching 3× per week in Year 1</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Weekly call recording reviews with scored feedback</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Monthly pipeline strategy sessions</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Access to top-performer playbooks and scripts</div>
+          <div class="pillar-item"><div class="pillar-dot"></div>Quarterly DISC re-assessment and growth mapping</div>
+        </div>
+      </div>
     </div>
   </div>
+
+  <!-- Benefits -->
   <div style="background: var(--gray-50); padding: 80px 0;">
     <div class="section" style="padding-top: 0; padding-bottom: 0;">
       <div class="section-eyebrow">Compensation &amp; Benefits</div>
       <h2 class="section-title">We pay competitively.<br>Then we compete to keep you.</h2>
+      <p class="section-sub">Compensation is just the starting line. Here's the full picture of what CMG puts on the table.</p>
+
       <div class="benefits-grid">
-        <div class="benefit"><div class="benefit-icon">💵</div><div><h4>Base Salary + Uncapped Commission</h4><p>Guaranteed base while building your pipeline, plus competitive BPS on every closed loan. No ceiling, ever.</p></div></div>
-        <div class="benefit"><div class="benefit-icon">🏥</div><div><h4>Full Medical, Dental &amp; Vision</h4><p>We cover 80% of employee premiums from day 30. Dependent coverage available. HSA-compatible plan options.</p></div></div>
-        <div class="benefit"><div class="benefit-icon">🎓</div><div><h4>License &amp; Continuing Education Paid</h4><p>We fund your NMLS pre-licensing, state exam fees, and all annual CE requirements — not just year one.</p></div></div>
-        <div class="benefit"><div class="benefit-icon">📈</div><div><h4>401(k) with 4% Company Match</h4><p>Vesting starts at 90 days. We match dollar-for-dollar up to 4% of your contribution.</p></div></div>
-        <div class="benefit"><div class="benefit-icon">🏖️</div><div><h4>PTO + 11 Federal Holidays</h4><p>15 days PTO to start, all federal holidays, plus a paid birthday day. PTO increases at Year 3.</p></div></div>
-        <div class="benefit"><div class="benefit-icon">🏠</div><div><h4>Employee Mortgage Discount</h4><p>Employees receive preferred pricing on their own home loans. You're in the business — benefit from it.</p></div></div>
-        <div class="benefit"><div class="benefit-icon">🏆</div><div><h4>Performance Bonuses &amp; President's Club</h4><p>Quarterly bonuses, annual President's Club trip for top producers, and monthly team spiff competitions.</p></div></div>
-        <div class="benefit"><div class="benefit-icon">🔁</div><div><h4>Hybrid Work After Year 1</h4><p>Top performers work 2–3 days remote after completing their first full year. Earn the flexibility.</p></div></div>
+        <div class="benefit">
+          <div class="benefit-icon">💵</div>
+          <div>
+            <h4>Base Salary + Uncapped Commission</h4>
+            <p>Guaranteed base while building your pipeline, plus competitive BPS on every closed loan. No ceiling, ever.</p>
+          </div>
+        </div>
+        <div class="benefit">
+          <div class="benefit-icon">🏥</div>
+          <div>
+            <h4>Full Medical, Dental &amp; Vision</h4>
+            <p>CMG covers 80% of employee premiums from day 30. Dependent coverage available. HSA-compatible plan options.</p>
+          </div>
+        </div>
+        <div class="benefit">
+          <div class="benefit-icon">🎓</div>
+          <div>
+            <h4>License &amp; Continuing Education Paid</h4>
+            <p>CMG funds your NMLS pre-licensing, state exam fees, and all annual CE requirements — not just year one.</p>
+          </div>
+        </div>
+        <div class="benefit">
+          <div class="benefit-icon">📈</div>
+          <div>
+            <h4>401(k) with 4% Company Match</h4>
+            <p>Vesting starts at 90 days. CMG matches dollar-for-dollar up to 4% of your contribution.</p>
+          </div>
+        </div>
+        <div class="benefit">
+          <div class="benefit-icon">🏖️</div>
+          <div>
+            <h4>PTO + 11 Federal Holidays</h4>
+            <p>15 days PTO to start, all federal holidays, plus a paid birthday day. PTO increases at Year 3.</p>
+          </div>
+        </div>
+        <div class="benefit">
+          <div class="benefit-icon">🏠</div>
+          <div>
+            <h4>Employee Mortgage Discount</h4>
+            <p>CMG employees receive preferred pricing on their own home loans. You're in the business — benefit from it.</p>
+          </div>
+        </div>
+        <div class="benefit">
+          <div class="benefit-icon">🏆</div>
+          <div>
+            <h4>Performance Bonuses &amp; President's Club</h4>
+            <p>Quarterly bonuses, annual President's Club trip for top producers, and monthly team spiff competitions.</p>
+          </div>
+        </div>
+        <div class="benefit">
+          <div class="benefit-icon">🔁</div>
+          <div>
+            <h4>Hybrid Work After Year 1</h4>
+            <p>Top performers work 2–3 days remote after completing their first full year. Earn the flexibility.</p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
+
+  <!-- Culture -->
   <div class="section">
     <div class="section-eyebrow">Culture</div>
-    <h2 class="section-title">The environment you'll actually want to show up to.</h2>
+    <h2 class="section-title">The environment you'll<br>actually want to show up to.</h2>
+    <p class="section-sub">Culture isn't free snacks and a ping-pong table. It's the daily experience of working with people who challenge and sharpen you.</p>
+
     <div class="culture-grid">
-      <div class="culture-card"><div class="culture-card-icon">📊</div><h4>Transparent metrics</h4><p>Leaderboards, live comp calculators, and pipeline visibility. You always know exactly where you stand.</p></div>
-      <div class="culture-card"><div class="culture-card-icon">🤝</div><h4>Collaborative, not cutthroat</h4><p>LOs share scripts, referral sources, and wins. Rising tides lift every boat here.</p></div>
-      <div class="culture-card"><div class="culture-card-icon">🎙️</div><h4>Your voice matters</h4><p>Monthly town halls, open-door leadership, and quarterly culture surveys that actually get acted on.</p></div>
-      <div class="culture-card"><div class="culture-card-icon">🌎</div><h4>Diverse and community-rooted</h4><p>We hire from the communities we serve. Understanding our borrowers is competitive advantage.</p></div>
+      <div class="culture-card">
+        <div class="culture-card-icon">📊</div>
+        <h4>Transparent metrics</h4>
+        <p>Leaderboards, live comp calculators, and pipeline visibility. You always know exactly where you stand.</p>
+      </div>
+      <div class="culture-card">
+        <div class="culture-card-icon">🤝</div>
+        <h4>Collaborative, not cutthroat</h4>
+        <p>LOs share scripts, referral sources, and wins. Rising tides lift every boat here.</p>
+      </div>
+      <div class="culture-card">
+        <div class="culture-card-icon">🎙️</div>
+        <h4>Your voice matters</h4>
+        <p>Monthly town halls, open-door leadership, and quarterly culture surveys that actually get acted on.</p>
+      </div>
+      <div class="culture-card">
+        <div class="culture-card-icon">🌎</div>
+        <h4>Diverse and SC-rooted</h4>
+        <p>We hire from the communities we serve. Understanding our borrowers is competitive advantage.</p>
+      </div>
     </div>
   </div>
+
   <div class="full-cta">
-    <h2>Ready to see if we're right for you?</h2>
+    <h2>Ready to see if CMG is right for you?</h2>
     <p>Apply in under 3 minutes. No resume required to start. A recruiter will be in touch within one business day.</p>
     <button class="btn-red" style="font-size: 15px; padding: 16px 36px;" onclick="showPage('p4')">Start Your Application →</button>
   </div>
+
 </div>
 
-<!-- PAGE 3: HIRING PROCESS -->
+<!-- ============================================================ -->
+<!-- PAGE 3: HIRING PROCESS                                       -->
+<!-- ============================================================ -->
 <div id="p3" class="page">
+
   <div class="why-hero">
     <div class="section-eyebrow" style="justify-content: center; margin-bottom: 16px;">How We Hire</div>
-    <h1>From application to first day —<br><span>here's exactly what to expect.</span></h1>
+    <h1>From application to<br>first day — <span>here's exactly what to expect.</span></h1>
     <p>No black holes. No ghosting. Our process is designed to be fast, transparent, and respectful of your time. Most candidates go from application to offer in under two weeks.</p>
   </div>
+
+  <!-- Timeline -->
   <div class="section">
     <div class="section-eyebrow">The Process</div>
     <h2 class="section-title">Six steps. Two weeks.<br>A career that changes everything.</h2>
+    <p class="section-sub">Every candidate goes through the same clear path. Here's what happens after you hit submit.</p>
+
     <div class="process-timeline">
-      <div class="process-step"><div class="process-left"><div class="process-node"><div class="process-num">1</div></div><div class="process-line"></div></div><div class="process-body"><div class="process-timing">Day 1</div><h3>Submit Your Application</h3><p>Fill out the short form — name, phone, email, location, and career background. No cover letter. Under 3 minutes.</p><div class="process-detail-row"><div class="process-detail-item"><span>⏱️</span> Under 3 minutes</div><div class="process-detail-item"><span>📄</span> Resume optional</div><div class="process-detail-item"><span>🔒</span> Secure &amp; private</div></div></div></div>
-      <div class="process-step"><div class="process-left"><div class="process-node"><div class="process-num">2</div></div><div class="process-line"></div></div><div class="process-body"><div class="process-timing">Day 1 — Same day</div><h3>Schedule Your Intro Call</h3><p>Immediately after applying, pick a time for a 20-minute intro call right in the form. You'll receive SMS confirmation instantly.</p><div class="process-detail-row"><div class="process-detail-item"><span>📅</span> Pick any open slot</div><div class="process-detail-item"><span>💬</span> SMS reminders sent automatically</div><div class="process-detail-item"><span>🎥</span> Phone or Zoom</div></div></div></div>
-      <div class="process-step"><div class="process-left"><div class="process-node"><div class="process-num">3</div></div><div class="process-line"></div></div><div class="process-body"><div class="process-timing">Day 1–2 · After scheduling</div><h3>Complete Your Pre-Screen Assessment</h3><p>A DISC personality profile, a short sales aptitude quiz, and a few scenario-based questions. About 12 minutes. Sent to your email within 30 minutes of scheduling.</p><div class="process-callout"><div class="process-callout-icon">📧</div><div><div class="process-callout-title">Check your registered email</div><div class="process-callout-desc">Your assessment link arrives within 30 minutes of scheduling. Check your inbox — and spam just in case. Complete it before your intro call for the best experience.</div></div></div></div></div>
-      <div class="process-step"><div class="process-left"><div class="process-node"><div class="process-num">4</div></div><div class="process-line"></div></div><div class="process-body"><div class="process-timing">Day 2–5</div><h3>20-Minute Intro Call</h3><p>A recruiter will review your application and assessment before the call. This isn't an interrogation — it's a conversation. They'll walk through your background, answer every question you have, and give you a realistic picture of the first 90 days.</p><div class="process-detail-row"><div class="process-detail-item"><span>🎯</span> No trick questions</div><div class="process-detail-item"><span>💰</span> Comp discussed openly</div><div class="process-detail-item"><span>🙋</span> Ask us anything</div></div></div></div>
-      <div class="process-step"><div class="process-left"><div class="process-node"><div class="process-num">5</div></div><div class="process-line"></div></div><div class="process-body"><div class="process-timing">Day 5–10</div><h3>Final Interview with Hiring Manager</h3><p>Candidates who move forward will have a second conversation with the branch hiring manager. This is where we align on your specialty track, target earnings, and start timeline.</p><div class="process-detail-row"><div class="process-detail-item"><span>👤</span> 30–45 minutes</div><div class="process-detail-item"><span>🗺️</span> Career path mapped out</div><div class="process-detail-item"><span>📋</span> Start date discussed</div></div></div></div>
-      <div class="process-step process-step-last"><div class="process-left"><div class="process-node process-node-final"><div class="process-num">6</div></div></div><div class="process-body"><div class="process-timing">Day 10–14</div><h3>Offer Letter &amp; Onboarding</h3><p>Offer letters go out within 72 hours of your final interview. The next training class starts every two weeks — so you could be in your first paid training day within a month of applying today.</p><div class="process-detail-row"><div class="process-detail-item"><span>✅</span> Offer within 72 hrs of final interview</div><div class="process-detail-item"><span>🎓</span> Training starts within 2 weeks of acceptance</div></div></div></div>
+
+      <div class="process-step">
+        <div class="process-left">
+          <div class="process-node">
+            <div class="process-num">1</div>
+          </div>
+          <div class="process-line"></div>
+        </div>
+        <div class="process-body">
+          <div class="process-timing">Day 1</div>
+          <h3>Submit Your Application</h3>
+          <p>Fill out the short form — name, phone, email, location, and career background. No cover letter, no lengthy questionnaire. Resume is optional at this stage. Takes under 3 minutes.</p>
+          <div class="process-detail-row">
+            <div class="process-detail-item"><span class="pdi-icon">⏱️</span> Under 3 minutes</div>
+            <div class="process-detail-item"><span class="pdi-icon">📄</span> Resume optional</div>
+            <div class="process-detail-item"><span class="pdi-icon">🔒</span> Secure &amp; private</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="process-step">
+        <div class="process-left">
+          <div class="process-node">
+            <div class="process-num">2</div>
+          </div>
+          <div class="process-line"></div>
+        </div>
+        <div class="process-body">
+          <div class="process-timing">Day 1 — Same day</div>
+          <h3>Schedule Your Intro Call</h3>
+          <p>Immediately after applying, you'll choose a time for a 20-minute intro call right in the application form. Pick a date and time that works for you — phone or Zoom, your choice. You'll receive an SMS confirmation instantly and automated reminders before your call.</p>
+          <div class="process-detail-row">
+            <div class="process-detail-item"><span class="pdi-icon">📅</span> Pick any open slot</div>
+            <div class="process-detail-item"><span class="pdi-icon">💬</span> SMS reminders sent automatically</div>
+            <div class="process-detail-item"><span class="pdi-icon">🎥</span> Phone or Zoom</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="process-step">
+        <div class="process-left">
+          <div class="process-node">
+            <div class="process-num">3</div>
+          </div>
+          <div class="process-line"></div>
+        </div>
+        <div class="process-body">
+          <div class="process-timing">Day 1–2 · After scheduling</div>
+          <h3>Complete Your Pre-Screen Assessment</h3>
+          <p>Once your interview is booked, you'll receive an email to your registered address with a link to complete a brief pre-screen assessment. This includes a DISC personality profile, a short sales aptitude quiz, and a few scenario-based questions. It takes about 12 minutes and helps us tailor your training path and coaching plan from day one.</p>
+          <div class="process-callout">
+            <div class="process-callout-icon">📧</div>
+            <div>
+              <div class="process-callout-title">Check your registered email</div>
+              <div class="process-callout-desc">Your assessment link will arrive within 30 minutes of scheduling your interview. Check your inbox — and your spam folder just in case. Complete it before your intro call for the best experience.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="process-step">
+        <div class="process-left">
+          <div class="process-node">
+            <div class="process-num">4</div>
+          </div>
+          <div class="process-line"></div>
+        </div>
+        <div class="process-body">
+          <div class="process-timing">Day 2–5</div>
+          <h3>20-Minute Intro Call</h3>
+          <p>A CMG recruiter will review your application and assessment results before your call. This isn't an interrogation — it's a conversation. They'll walk through your background, answer every question you have about the role, compensation, and training, and give you a realistic picture of the first 90 days.</p>
+          <div class="process-detail-row">
+            <div class="process-detail-item"><span class="pdi-icon">🎯</span> No trick questions</div>
+            <div class="process-detail-item"><span class="pdi-icon">💰</span> Comp discussed openly</div>
+            <div class="process-detail-item"><span class="pdi-icon">🙋</span> Ask us anything</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="process-step">
+        <div class="process-left">
+          <div class="process-node">
+            <div class="process-num">5</div>
+          </div>
+          <div class="process-line"></div>
+        </div>
+        <div class="process-body">
+          <div class="process-timing">Day 5–10</div>
+          <h3>Final Interview with Hiring Manager</h3>
+          <p>Candidates who move forward will have a second, slightly deeper conversation with the branch hiring manager. This is where we align on your specialty track, target earnings, and start timeline. Most candidates complete this within a week of their intro call.</p>
+          <div class="process-detail-row">
+            <div class="process-detail-item"><span class="pdi-icon">👤</span> 30–45 minutes</div>
+            <div class="process-detail-item"><span class="pdi-icon">🗺️</span> Career path mapped out</div>
+            <div class="process-detail-item"><span class="pdi-icon">📋</span> Start date discussed</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="process-step process-step-last">
+        <div class="process-left">
+          <div class="process-node process-node-final">
+            <div class="process-num">6</div>
+          </div>
+        </div>
+        <div class="process-body">
+          <div class="process-timing">Day 10–14</div>
+          <h3>Offer Letter &amp; Onboarding</h3>
+          <p>Offer letters go out within 72 hours of your final interview. Once accepted, you'll receive your onboarding packet, training schedule, and cohort assignment. The next training class starts every two weeks — so you could be in your first paid training day within a month of applying today.</p>
+          <div class="process-detail-row">
+            <div class="process-detail-item"><span class="pdi-icon">✅</span> Offer within 72 hrs of final interview</div>
+            <div class="process-detail-item"><span class="pdi-icon">🎓</span> Training starts within 2 weeks of acceptance</div>
+          </div>
+        </div>
+      </div>
+
     </div>
   </div>
+
+  <!-- FAQ -->
   <div style="background: var(--gray-50); padding: 80px 0;">
     <div class="section" style="padding-top: 0; padding-bottom: 0;">
       <div class="section-eyebrow">Common Questions</div>
-      <h2 class="section-title">Things candidates ask us all the time.</h2>
+      <h2 class="section-title">Things candidates<br>ask us all the time.</h2>
+
       <div class="faq-grid">
-        <div class="faq-item"><h4>Do I need a mortgage license to apply?</h4><p>No. We fully fund your NMLS pre-licensing education and state exam fees. You'll complete licensing during the first two weeks of paid training.</p></div>
-        <div class="faq-item"><h4>How long does the whole process take?</h4><p>Most candidates receive an offer within 10–14 days of submitting their application.</p></div>
-        <div class="faq-item"><h4>What if I've never worked in finance?</h4><p>That's fine — and honestly, common. Our best performers often come from hospitality, retail, teaching, and the military. We hire for drive and coachability, not résumé.</p></div>
-        <div class="faq-item"><h4>What does the assessment measure?</h4><p>DISC personality profile, basic sales aptitude, and a few scenario questions. There are no wrong answers — it's used to place you in the right specialty and build your coaching plan.</p></div>
-        <div class="faq-item"><h4>Is training really paid?</h4><p>Yes. You'll receive your full base salary during the entire 8-week training program.</p></div>
-        <div class="faq-item"><h4>What if I don't pass my NMLS exam?</h4><p>We provide full exam prep support and allow re-takes. We've helped hundreds of trainees pass on their first attempt.</p></div>
+        <div class="faq-item">
+          <h4>Do I need a mortgage license to apply?</h4>
+          <p>No. CMG fully funds your NMLS pre-licensing education and state exam fees. You'll complete licensing during the first two weeks of paid training.</p>
+        </div>
+        <div class="faq-item">
+          <h4>How long does the whole process take?</h4>
+          <p>Most candidates receive an offer within 10–14 days of submitting their application. The timeline depends on your availability for interviews.</p>
+        </div>
+        <div class="faq-item">
+          <h4>What if I've never worked in finance?</h4>
+          <p>That's fine — and honestly, common. Our best performers often come from hospitality, retail, teaching, and the military. We hire for drive and coachability, not résumé.</p>
+        </div>
+        <div class="faq-item">
+          <h4>What does the assessment measure?</h4>
+          <p>The pre-screen covers DISC personality profile, basic sales aptitude, and a few scenario questions. There are no wrong answers — it's used to place you in the right specialty and build your coaching plan.</p>
+        </div>
+        <div class="faq-item">
+          <h4>Is training really paid?</h4>
+          <p>Yes. You'll receive your full base salary during the entire 8-week training program, including the weeks you're studying for your NMLS exam.</p>
+        </div>
+        <div class="faq-item">
+          <h4>What happens if I don't pass my NMLS exam?</h4>
+          <p>CMG provides full exam prep support and allows re-takes. We've helped hundreds of trainees pass on their first attempt — and we're invested in your success.</p>
+        </div>
       </div>
     </div>
   </div>
+
   <div class="full-cta">
     <h2>Ready to get started?</h2>
     <p>The application takes under 3 minutes. Your intro call can be scheduled for as soon as tomorrow.</p>
     <button class="btn-red" style="font-size: 15px; padding: 16px 36px;" onclick="showPage('p4')">Apply Now →</button>
   </div>
+
 </div>
 
-<!-- PAGE 4: APPLY -->
+<!-- ============================================================ -->
+<!-- PAGE 4: APPLY (with inline calendar)                         -->
+<!-- ============================================================ -->
 <div id="p4" class="page">
   <div class="apply-wrap">
     <div class="apply-sidebar">
       <div class="section-eyebrow" style="margin-bottom: 20px;">Apply Now</div>
       <h2>Tell us about <span>yourself.</span></h2>
       <p>Your application takes under 3 minutes. No resume required to start. A recruiter will contact you within one business day — and you'll schedule your intro call right here.</p>
+
       <div class="apply-points">
-        <div class="apply-point"><div class="apply-point-icon">⏱️</div><div><h4>3-minute application</h4><p>No essays. No cover letters. Just your contact info and a few quick questions.</p></div></div>
-        <div class="apply-point"><div class="apply-point-icon">📅</div><div><h4>Schedule your intro call in the same form</h4><p>Pick your preferred time right after submitting. No waiting for a callback to book.</p></div></div>
-        <div class="apply-point"><div class="apply-point-icon">📧</div><div><h4>Assessment sent to your email</h4><p>Once scheduled, your pre-screen assessment link arrives within 30 minutes. Complete it before your call.</p></div></div>
-        <div class="apply-point"><div class="apply-point-icon">🔒</div><div><h4>Your data stays private</h4><p>We never sell or share your information. Used only for your application.</p></div></div>
-      </div>
-      <div class="bonus-banner">
-        <div class="bonus-banner-title">🎁 Limited-Time Signing Bonus</div>
-        <div class="bonus-banner-body">Apply before {{SIGNING_BONUS_DEADLINE}} and receive a {{SIGNING_BONUS}} signing bonus upon completing training and your first funded loan.</div>
-      </div>
-    </div>
-    <div class="apply-main">
-      <div class="apply-steps-indicator">
-        <div class="asi-step asi-active" id="asi-1"><div class="asi-num">1</div><div class="asi-label">Your Info</div></div>
-        <div class="asi-line" id="asi-line-1"></div>
-        <div class="asi-step" id="asi-2"><div class="asi-num">2</div><div class="asi-label">Schedule Call</div></div>
-        <div class="asi-line" id="asi-line-2"></div>
-        <div class="asi-step" id="asi-3"><div class="asi-num">3</div><div class="asi-label">Confirmation</div></div>
+        <div class="apply-point">
+          <div class="apply-point-icon">⏱️</div>
+          <div>
+            <h4>3-minute application</h4>
+            <p>No essays. No cover letters. Just your contact info and a few quick questions.</p>
+          </div>
+        </div>
+        <div class="apply-point">
+          <div class="apply-point-icon">📅</div>
+          <div>
+            <h4>Schedule your intro call in the same form</h4>
+            <p>Pick your preferred time right after submitting. No waiting for a callback to book.</p>
+          </div>
+        </div>
+        <div class="apply-point">
+          <div class="apply-point-icon">📧</div>
+          <div>
+            <h4>Assessment sent to your email</h4>
+            <p>Once scheduled, your pre-screen assessment link arrives within 30 minutes. Complete it before your call.</p>
+          </div>
+        </div>
+        <div class="apply-point">
+          <div class="apply-point-icon">🔒</div>
+          <div>
+            <h4>Your data stays private</h4>
+            <p>We never sell or share your information. Used only for your CMG application.</p>
+          </div>
+        </div>
       </div>
 
+      <div class="bonus-banner">
+        <div class="bonus-banner-title">🎁 Limited-Time Signing Bonus</div>
+        <div class="bonus-banner-body">Apply before July 31st and receive a $2,500 signing bonus upon completing training and your first funded loan.</div>
+      </div>
+    </div>
+
+    <div class="apply-main">
+
+      <!-- Step indicator -->
+      <div class="apply-steps-indicator">
+        <div class="asi-step asi-active" id="asi-1">
+          <div class="asi-num">1</div>
+          <div class="asi-label">Your Info</div>
+        </div>
+        <div class="asi-line" id="asi-line-1"></div>
+        <div class="asi-step" id="asi-2">
+          <div class="asi-num">2</div>
+          <div class="asi-label">Schedule Call</div>
+        </div>
+        <div class="asi-line" id="asi-line-2"></div>
+        <div class="asi-step" id="asi-3">
+          <div class="asi-num">3</div>
+          <div class="asi-label">Confirmation</div>
+        </div>
+      </div>
+
+      <!-- STEP 1: Application form -->
       <div id="apply-step-1">
         <h2 class="apply-form-title">Start your application</h2>
         <div class="apply-main-sub">All fields marked with * are required</div>
+
         <div class="form-row">
-          <div class="form-group"><label class="form-label">First Name <span class="req">*</span></label><input type="text" class="form-input" placeholder="Jordan"></div>
-          <div class="form-group"><label class="form-label">Last Name <span class="req">*</span></label><input type="text" class="form-input" placeholder="Smith"></div>
+          <div class="form-group">
+            <label class="form-label">First Name <span class="req">*</span></label>
+            <input type="text" class="form-input" placeholder="Jordan">
+          </div>
+          <div class="form-group">
+            <label class="form-label">Last Name <span class="req">*</span></label>
+            <input type="text" class="form-input" placeholder="Smith">
+          </div>
         </div>
-        <div class="form-group"><label class="form-label">Mobile Phone <span class="req">*</span></label><input type="tel" class="form-input" placeholder="(843) 555-0100"></div>
-        <div class="form-group"><label class="form-label">Email Address <span class="req">*</span></label><input type="email" class="form-input" placeholder="jordan@email.com"></div>
-        <div class="form-group"><label class="form-label">City / Area <span class="req">*</span></label><select class="form-input"><option value="">Select your area</option><option>{{LOCATION_DISPLAY}}</option><option>Other location</option></select></div>
-        <div class="form-group"><label class="form-label">Current or Most Recent Career Field</label><select class="form-input"><option value="">Select one</option><option>Mortgage / Lending</option><option>Finance / Banking</option><option>Sales / Business Development</option><option>Real Estate</option><option>Hospitality / Food Service</option><option>Military / Veterans</option><option>Retail / Customer Service</option><option>Healthcare</option><option>Education</option><option>Other</option></select></div>
-        <div class="form-group"><label class="form-label">LinkedIn Profile URL</label><input type="url" class="form-input" placeholder="https://linkedin.com/in/yourname"></div>
-        <div class="form-group"><label class="form-label">Resume (optional)</label><div class="upload-zone" onclick="this.querySelector('input').click()"><div class="upload-zone-icon">📄</div><div class="upload-zone-title">Drop your resume here, or click to browse</div><div class="upload-zone-sub">PDF or Word document · Max 5MB</div><input type="file" style="display:none" accept=".pdf,.doc,.docx"></div></div>
-        <div class="form-group"><label style="display: flex; align-items: flex-start; gap: 10px; cursor: pointer; font-size: 13px; color: var(--gray-600); font-weight: 400;"><input type="checkbox" style="margin-top: 2px; accent-color: var(--cmg-red); width:15px; height:15px; flex-shrink:0;">I agree to receive SMS text messages and calls regarding my application. Standard message rates apply.</label></div>
+
+        <div class="form-group">
+          <label class="form-label">Mobile Phone <span class="req">*</span></label>
+          <input type="tel" class="form-input" placeholder="(843) 555-0100">
+        </div>
+
+        <div class="form-group">
+          <label class="form-label">Email Address <span class="req">*</span></label>
+          <input type="email" class="form-input" placeholder="jordan@email.com">
+        </div>
+
+        <div class="form-group">
+          <label class="form-label">City / Area in SC <span class="req">*</span></label>
+          <select class="form-input">
+            <option value="">Select your area</option>
+            <option>Charleston / North Charleston / Mt. Pleasant</option>
+            <option>Columbia / Midlands</option>
+            <option>Greenville / Spartanburg</option>
+            <option>Myrtle Beach / Grand Strand</option>
+            <option>Other SC location</option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label class="form-label">Current or Most Recent Career Field</label>
+          <select class="form-input">
+            <option value="">Select one</option>
+            <option>Mortgage / Lending</option>
+            <option>Finance / Banking</option>
+            <option>Sales / Business Development</option>
+            <option>Real Estate</option>
+            <option>Hospitality / Food Service</option>
+            <option>Military / Veterans</option>
+            <option>Retail / Customer Service</option>
+            <option>Healthcare</option>
+            <option>Education</option>
+            <option>Other</option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label class="form-label">LinkedIn Profile URL</label>
+          <input type="url" class="form-input" placeholder="https://linkedin.com/in/yourname">
+        </div>
+
+        <div class="form-group">
+          <label class="form-label">Resume (optional)</label>
+          <div class="upload-zone" onclick="this.querySelector('input').click()">
+            <div class="upload-zone-icon">📄</div>
+            <div class="upload-zone-title">Drop your resume here, or click to browse</div>
+            <div class="upload-zone-sub">PDF or Word document · Max 5MB</div>
+            <input type="file" style="display:none" accept=".pdf,.doc,.docx">
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label style="display: flex; align-items: flex-start; gap: 10px; cursor: pointer; font-size: 13px; color: var(--gray-600); font-weight: 400;">
+            <input type="checkbox" style="margin-top: 2px; accent-color: var(--cmg-red); width:15px; height:15px; flex-shrink:0;">
+            I agree to receive SMS text messages and calls from {{COMPANY_NAME}} regarding my application. Standard message rates apply.
+          </label>
+        </div>
+
         <button class="form-submit-btn" onclick="goToSchedule()">Next: Schedule Your Intro Call →</button>
-        <div class="form-disclaimer">By submitting, you agree to our Privacy Policy and Terms of Use. We are an equal opportunity employer.</div>
+
+        <div class="form-disclaimer">
+          By submitting, you agree to {{COMPANY_NAME}}'s Privacy Policy and Terms of Use. {{COMPANY_NAME}} is an equal opportunity employer.
+        </div>
       </div>
 
+      <!-- STEP 2: Schedule -->
       <div id="apply-step-2" style="display:none;">
         <h2 class="apply-form-title">Schedule your intro call</h2>
         <div class="apply-main-sub">Pick a date and time — we'll send an SMS confirmation right away</div>
+
         <div class="cal-widget" style="max-width:100%; margin-bottom: 20px;">
-          <div class="cal-top"><div class="cal-top-ava">📞</div><div><div class="cal-top-title">Recruiting Team · Intro Call</div><div class="cal-top-sub">20 min · Phone or Zoom · Eastern Time</div></div></div>
+          <div class="cal-top">
+            <div class="cal-top-ava">CMG</div>
+            <div>
+              <div class="cal-top-title">CMG Recruiting Team · Intro Call</div>
+              <div class="cal-top-sub">20 min · Phone or Zoom · Eastern Time</div>
+            </div>
+          </div>
           <div class="cal-body">
-            <div class="cal-nav"><button class="cal-nav-btn" onclick="changeMonth(-1)">‹</button><div class="cal-month-label" id="cal-month-lbl"></div><button class="cal-nav-btn" onclick="changeMonth(1)">›</button></div>
+            <div class="cal-nav">
+              <button class="cal-nav-btn" onclick="changeMonth(-1)">‹</button>
+              <div class="cal-month-label" id="cal-month-lbl">July 2025</div>
+              <button class="cal-nav-btn" onclick="changeMonth(1)">›</button>
+            </div>
             <div class="cal-grid" id="cal-grid"></div>
-            <div id="cal-slots-wrap" style="display:none;"><div style="font-family:'Montserrat',sans-serif; font-size:13px; font-weight:700; color:var(--cmg-navy); margin-bottom:10px;" id="cal-slots-lbl">Available times</div><div class="cal-slots" id="cal-slots"></div></div>
+            <div id="cal-slots-wrap" style="display:none;">
+              <div style="font-family:'Montserrat',sans-serif; font-size:13px; font-weight:700; color:var(--cmg-navy); margin-bottom:10px;" id="cal-slots-lbl">Available times</div>
+              <div class="cal-slots" id="cal-slots"></div>
+            </div>
           </div>
         </div>
+
         <div style="display:flex; gap:12px;">
           <button style="flex:1; background:var(--gray-100); color:var(--cmg-navy); border:none; font-family:'Montserrat',sans-serif; font-size:13px; font-weight:700; padding:14px; border-radius:var(--radius-sm); cursor:pointer;" onclick="backToForm()">← Back</button>
           <button class="form-submit-btn" style="flex:2; margin-top:0;" onclick="goToConfirmation()">Confirm &amp; Submit →</button>
         </div>
       </div>
 
+      <!-- STEP 3: Confirmation -->
       <div id="apply-step-3" style="display:none; text-align:center; padding: 20px 0;">
         <div style="font-size:56px; margin-bottom:16px;">🎉</div>
         <h2 style="font-family:'Montserrat',sans-serif; font-size:28px; color:var(--cmg-navy); margin-bottom:12px;">You're all set!</h2>
         <p style="color:var(--gray-600); font-size:16px; line-height:1.65; max-width:480px; margin:0 auto 32px;">Your application is submitted and your intro call is scheduled. Here's what happens next.</p>
+
         <div class="next-steps-box" style="margin-bottom:28px;">
           <div class="next-steps-title">What to do right now</div>
           <div class="next-steps-items">
-            <div class="next-steps-item"><div class="next-steps-item-num">1</div><div><strong>Check your email inbox</strong> — your pre-screen assessment link will arrive within 30 minutes. Complete it before your intro call.</div></div>
-            <div class="next-steps-item"><div class="next-steps-item-num">2</div><div><strong>Watch for SMS reminders</strong> — you'll receive a confirmation text now, a 24-hour reminder, and a 30-minute heads-up before your call.</div></div>
-            <div class="next-steps-item"><div class="next-steps-item-num">3</div><div><strong>Come prepared with questions</strong> — your recruiter will have reviewed your background and assessment. This is your chance to interview us too.</div></div>
+            <div class="next-steps-item">
+              <div class="next-steps-item-num">1</div>
+              <div>
+                <strong>Check your email inbox</strong> — your pre-screen assessment link will arrive within 30 minutes. Complete it before your intro call.
+              </div>
+            </div>
+            <div class="next-steps-item">
+              <div class="next-steps-item-num">2</div>
+              <div>
+                <strong>Watch for SMS reminders</strong> — you'll receive a confirmation text now, a 24-hour reminder, and a 30-minute heads-up before your call.
+              </div>
+            </div>
+            <div class="next-steps-item">
+              <div class="next-steps-item-num">3</div>
+              <div>
+                <strong>Come prepared with questions</strong> — your recruiter will have reviewed your background and assessment. This is your chance to interview us too.
+              </div>
+            </div>
           </div>
         </div>
+
         <div style="padding:20px 24px; background:var(--cmg-red-pale); border:1px solid rgba(106,170,38,0.3); border-radius:var(--radius-lg); max-width:420px; margin:0 auto 28px; text-align:left;">
           <div style="font-family:'Montserrat',sans-serif; font-size:11px; font-weight:700; letter-spacing:1px; text-transform:uppercase; color:var(--cmg-red); margin-bottom:8px;">📧 Check your email now</div>
           <div style="font-size:13px; color:var(--gray-800); line-height:1.6;">Your pre-screen assessment has been sent to the email address you provided. It takes about 12 minutes and helps us personalize your training path. <strong>Complete it before your intro call.</strong></div>
         </div>
+
         <button class="btn-red" style="font-size:14px; padding:14px 28px;" onclick="showPage('p1')">← Back to Overview</button>
       </div>
+
     </div>
   </div>
 </div>
 
-<!-- PAGE 5: FAQ -->
+</div>
+
+<!-- ============================================================ -->
+<!-- PAGE 5: FAQ                                                  -->
+<!-- ============================================================ -->
 <div id="p5" class="page">
+
   <div class="why-hero">
     <div class="section-eyebrow" style="justify-content: center; margin-bottom: 16px;">Frequently Asked Questions</div>
     <h1>Everything you want to<br>know before you <span>apply.</span></h1>
-    <p>Straight answers to the questions candidates ask us most.</p>
+    <p>Straight answers to the questions candidates ask us most. If you don't see yours here, call or text us directly.</p>
   </div>
+
+  <!-- FAQ Categories -->
   <div class="section">
+
+    <!-- Category: The Role -->
     <div class="faq-category">
-      <div class="faq-cat-header"><div class="faq-cat-icon">💼</div><h2 class="faq-cat-title">The Role</h2></div>
+      <div class="faq-cat-header">
+        <div class="faq-cat-icon">💼</div>
+        <h2 class="faq-cat-title">The Role</h2>
+      </div>
       <div class="faq-accordion">
-        <div class="faq-acc-item"><button class="faq-acc-btn" onclick="toggleFaq(this)"><span>What does a loan officer actually do day-to-day?</span><span class="faq-chevron">›</span></button><div class="faq-acc-body"><p>You spend most of your day on the phone with borrowers who have already expressed interest in getting a mortgage — warm, pre-qualified leads, not cold calls. You'll guide them through the pre-qualification process, explain loan options, collect documentation, and hand off to processing once you've locked a loan.</p></div></div>
-        <div class="faq-acc-item"><button class="faq-acc-btn" onclick="toggleFaq(this)"><span>Is this a remote position or in-office?</span><span class="faq-chevron">›</span></button><div class="faq-acc-body"><p>The position is in-office during training and your first year. Top performers earn the option to work hybrid (2–3 days remote) after completing their first full year. This is by design — coaching and team energy accelerate your development significantly.</p></div></div>
-        <div class="faq-acc-item"><button class="faq-acc-btn" onclick="toggleFaq(this)"><span>What are the hours?</span><span class="faq-chevron">›</span></button><div class="faq-acc-body"><p>Core hours are Monday through Friday, 8:30 AM – 5:30 PM ET. Some loan officers choose to work occasional early evenings to reach borrowers who are unavailable during the day — this is voluntary. There is no required weekend work.</p></div></div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>What does a loan officer at the SC call center actually do day-to-day?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>You spend most of your day on the phone with borrowers who have already expressed interest in getting a mortgage — these are warm, pre-qualified leads, not cold calls. You'll guide them through the pre-qualification process, explain loan options, collect documentation, and hand off to processing once you've locked a loan. A typical day includes 20–40 outbound follow-up calls, 3–8 substantive borrower conversations, and pipeline management in Salesforce. In your first few months, you'll also have coaching sessions 3 times per week.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>Is this a remote position or in-office?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>The position is in-office during training and your first year. This is by design — the coaching, call shadowing, and team energy of being on-site accelerates your development significantly. Top performers earn the option to work hybrid (2–3 days remote) after completing their first full year. Our South Carolina offices are located in Charleston/Mt. Pleasant and Columbia.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>What are the hours? Is there evening or weekend work?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Core hours are Monday through Friday, 8:30 AM – 5:30 PM ET. Some loan officers choose to work occasional early evenings to reach borrowers who are unavailable during the day — this is voluntary and tends to be more common in your first year when you're building your pipeline. There is no required weekend work.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>How many loans am I expected to close per month?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>New loan officers typically close 2–4 loans per month in months 3–6, ramping to 5–8 per month by the end of year one. Senior loan officers consistently close 8–15 per month. Your coach will set realistic benchmarks with you based on your lead volume and specialty track — you're never held to targets that aren't calibrated to your pipeline.</p>
+          </div>
+        </div>
+
       </div>
     </div>
+
+    <!-- Category: Compensation -->
     <div class="faq-category">
-      <div class="faq-cat-header"><div class="faq-cat-icon">💰</div><h2 class="faq-cat-title">Compensation &amp; Benefits</h2></div>
+      <div class="faq-cat-header">
+        <div class="faq-cat-icon">💰</div>
+        <h2 class="faq-cat-title">Compensation &amp; Benefits</h2>
+      </div>
       <div class="faq-accordion">
-        <div class="faq-acc-item"><button class="faq-acc-btn" onclick="toggleFaq(this)"><span>How exactly does the pay structure work?</span><span class="faq-chevron">›</span></button><div class="faq-acc-body"><p>You receive a guaranteed base salary throughout training and into your first year. Once fully in production, your earnings are base plus commission — expressed in basis points (BPS) per loan closed. There is no cap on commission. Your recruiter will walk through the exact comp model on your intro call.</p></div></div>
-        <div class="faq-acc-item"><button class="faq-acc-btn" onclick="toggleFaq(this)"><span>What is the signing bonus and how do I qualify?</span><span class="faq-chevron">›</span></button><div class="faq-acc-body"><p>Candidates who apply before {{SIGNING_BONUS_DEADLINE}}, complete training, and close their first funded loan will receive a {{SIGNING_BONUS}} signing bonus. It is paid within 30 days of your first loan funding.</p></div></div>
-        <div class="faq-acc-item"><button class="faq-acc-btn" onclick="toggleFaq(this)"><span>Does the company really pay for my mortgage license?</span><span class="faq-chevron">›</span></button><div class="faq-acc-body"><p>Yes — completely. We cover your NMLS pre-licensing education, state exam fees, and first-year license fees. You also remain on full base salary while completing your licensing work during training weeks 1–2.</p></div></div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>How exactly does the pay structure work?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>You receive a guaranteed base salary throughout training and into your first year. Once you're fully in production, your earnings are base plus commission — expressed in basis points (BPS) per loan closed. The more loans you close, the higher your effective BPS rate climbs through tiered performance thresholds. There is no cap on commission. Your recruiter will walk through the exact comp model on your intro call, including what year-one, year-two, and senior LO earnings look like based on recent team data.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>What is the $2,500 signing bonus and how do I qualify?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Candidates who apply before July 31st, complete training, and close their first funded loan will receive a $2,500 signing bonus. It is paid within 30 days of your first loan funding. There is no clawback provision as long as you remain employed for 90 days after the bonus is paid.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>Does CMG really pay for my mortgage license?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Yes — completely. CMG covers your NMLS pre-licensing education (20 hours), the SC state-specific education hours, your exam registration fees, and your first-year license fees. You also remain on full base salary while completing your licensing work during training weeks 1–2. If you need to re-take the exam, CMG provides additional prep support and covers re-take fees on a case-by-case basis.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>When does health insurance start?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Medical, dental, and vision coverage becomes effective on day 30 of employment. CMG covers 80% of employee-only premiums. Dependent and family coverage is available at competitive group rates. You'll enroll during your onboarding week — benefits paperwork is completed before your first day of training.</p>
+          </div>
+        </div>
+
       </div>
     </div>
+
+    <!-- Category: Licensing & Qualifications -->
     <div class="faq-category">
-      <div class="faq-cat-header"><div class="faq-cat-icon">📋</div><h2 class="faq-cat-title">Licensing &amp; Qualifications</h2></div>
+      <div class="faq-cat-header">
+        <div class="faq-cat-icon">📋</div>
+        <h2 class="faq-cat-title">Licensing &amp; Qualifications</h2>
+      </div>
       <div class="faq-accordion">
-        <div class="faq-acc-item"><button class="faq-acc-btn" onclick="toggleFaq(this)"><span>Do I need a mortgage license before I apply?</span><span class="faq-chevron">›</span></button><div class="faq-acc-body"><p>No. You do not need an existing license to apply or to be hired. We fully fund your NMLS pre-licensing education and state exam, completed during the first two weeks of paid training.</p></div></div>
-        <div class="faq-acc-item"><button class="faq-acc-btn" onclick="toggleFaq(this)"><span>I have no finance background. Am I really a candidate?</span><span class="faq-chevron">›</span></button><div class="faq-acc-body"><p>Absolutely. Some of our best-performing loan officers came from hospitality, retail, teaching, and the military with zero finance experience. What we hire for is coachability, drive, communication skills, and the ability to build trust quickly with strangers.</p></div></div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>Do I need a mortgage license before I apply?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>No. You do not need an existing license to apply or to be hired. CMG fully funds your NMLS pre-licensing education and state exam, and you complete it during the first two weeks of paid training. If you already hold an active NMLS license, that's a plus — but it's not a requirement.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>Is there a background check or credit check involved?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Yes. NMLS licensing requires a background check and credit review as part of the application process — this is federally mandated for all mortgage loan originators, not just a CMG policy. Certain financial issues (recent bankruptcy, felony convictions) can affect licensability. If you have questions about your specific situation, your recruiter can discuss what typically affects licensing outcomes. A less-than-perfect credit history does not automatically disqualify you.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>What if I don't pass the NMLS exam on the first try?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>It happens, and it doesn't end your path at CMG. We provide comprehensive exam prep materials, practice tests, and one-on-one support from team members who have passed the exam. NMLS allows re-takes after a 30-day waiting period (and a 180-day waiting period after three consecutive failures). CMG will work with you on re-take scheduling and support you through the process.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>I have no finance or sales background. Am I really a candidate?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Absolutely. Some of our best-performing loan officers came from hospitality, retail, teaching, and the military — with zero finance experience. What we hire for is coachability, drive, communication skills, and the ability to build trust quickly with strangers. The technical knowledge is teachable. The right mindset is not. If you can hold a genuine conversation, handle rejection without it derailing you, and follow a proven system — we can make you a mortgage professional.</p>
+          </div>
+        </div>
+
       </div>
     </div>
+
+    <!-- Category: Training & Growth -->
+    <div class="faq-category">
+      <div class="faq-cat-header">
+        <div class="faq-cat-icon">🎓</div>
+        <h2 class="faq-cat-title">Training &amp; Career Growth</h2>
+      </div>
+      <div class="faq-accordion">
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>What does the 8-week training program actually look like?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Weeks 1–2 focus on industry foundations: NMLS pre-licensing education, SC mortgage law, loan products, and market fundamentals. Weeks 3–4 shift to sales skills — scripting, objection handling, call recording, and daily role-play with your cohort. Weeks 5–6 are technology and systems: Encompass LOS, Salesforce CRM, lead routing, and automated follow-up workflows. Weeks 7–8 are live pipeline launch — you'll work real leads with a senior coach monitoring and coaching in real time. You receive your full base salary throughout all 8 weeks.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>How quickly can I move into a leadership or management role?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>CMG promotes from within aggressively. Top performers have moved into team lead roles in as little as 18 months. The path typically looks like: Junior LO (months 1–12) → Senior LO (years 1–3) → Team Lead (year 2+ for top performers) → Branch Manager (year 3+). Promotion is performance-based, not tenure-based. If you're consistently hitting or exceeding targets, the conversation about next steps will come to you — you don't have to chase it.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>What does coaching look like after the 8-week training ends?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Coaching doesn't stop after training — it's ongoing throughout your career at CMG. In year one, you'll have 1:1 coaching sessions three times per week, weekly call recording reviews with scored feedback, and monthly pipeline strategy sessions. In year two, coaching frequency decreases as you develop independence, but the structure remains. Senior loan officers have access to advanced coaching tracks focused on referral development, team leadership, and revenue optimization.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Category: The Application -->
+    <div class="faq-category">
+      <div class="faq-cat-header">
+        <div class="faq-cat-icon">📝</div>
+        <h2 class="faq-cat-title">The Application Process</h2>
+      </div>
+      <div class="faq-accordion">
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>What is the pre-screen assessment and how long does it take?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>The assessment has three parts: a DISC personality profile (helps us understand your natural communication and decision-making style), a sales aptitude quiz (3 scenario-based questions), and a personality fit section (4 slider-based self-assessments). The whole thing takes about 12 minutes. There are no right or wrong answers — the results are used to place you in the right loan specialty and build your personalized coaching plan. You'll receive the assessment link via email within 30 minutes of scheduling your intro call.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>How long does the hiring process take from application to offer?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Most candidates receive an offer within 10–14 days of submitting their application. The timeline: application submitted (Day 1) → intro call scheduled same day → pre-screen assessment completed within 24–48 hours → intro call within 2–5 days → final interview within 5–10 days → offer letter within 72 hours of final interview. The biggest variable is your availability for interviews. Candidates who respond quickly and come prepared move through fastest.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>What happens if I'm not selected after my interview?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>Every candidate receives a response — we don't ghost applicants. If you're not selected after your intro call, a recruiter will let you know within 2 business days with honest feedback. In some cases, candidates who aren't the right fit for the current cohort are invited to reapply for a future one, particularly if timing or a specific experience gap was the factor rather than fit.</p>
+          </div>
+        </div>
+
+        <div class="faq-acc-item">
+          <button class="faq-acc-btn" onclick="toggleFaq(this)">
+            <span>When does the next training cohort start?</span>
+            <span class="faq-chevron">›</span>
+          </button>
+          <div class="faq-acc-body">
+            <p>New training cohorts launch every two weeks. If you apply today and move through the process quickly, you could be starting paid training within 3–4 weeks. Your recruiter will share the upcoming cohort start dates on your intro call and work with you to align your start timeline with your availability.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
   </div>
+
+  <!-- Still have questions CTA -->
   <div style="background: var(--gray-50); padding: 64px 48px; text-align: center; border-top: 1px solid var(--gray-200);">
     <div style="max-width: 560px; margin: 0 auto;">
       <div class="section-eyebrow" style="justify-content: center; margin-bottom: 14px;">Still have questions?</div>
       <h2 style="font-size: 28px; color: var(--cmg-navy); margin-bottom: 12px; line-height: 1.25;">Talk to a real person.</h2>
-      <p style="color: var(--gray-600); font-size: 16px; line-height: 1.65; margin-bottom: 32px;">Our recruiting team is available Monday–Friday, 9 AM – 5 PM ET.</p>
+      <p style="color: var(--gray-600); font-size: 16px; line-height: 1.65; margin-bottom: 32px;">Our recruiting team is available Monday–Friday, 9 AM – 5 PM ET. No bots, no forms — just a straightforward conversation.</p>
       <div style="display: flex; gap: 12px; justify-content: center; flex-wrap: wrap;">
-        <a href="tel:{{CONTACT_PHONE_TEL}}" class="btn-red" style="text-decoration:none; font-size:14px; padding:13px 24px;">📞 {{CONTACT_PHONE_DISPLAY}}</a>
+        <a href="tel:{{CONTACT_PHONE_TEL}}" class="btn-red" style="text-decoration:none; font-size:14px; padding:13px 24px;">📞 Call {{CONTACT_PHONE_DISPLAY}}</a>
         <button class="btn-red" style="background: var(--cmg-navy); font-size:14px; padding:13px 24px;" onclick="showPage('p4')">Apply Now →</button>
       </div>
     </div>
   </div>
+
 </div>
 
+<!-- Footer -->
 <footer>
   <div class="footer-inner">
     <div class="footer-top">
-      <div style="font-family:'Montserrat',sans-serif;font-size:18px;font-weight:800;color:white;opacity:0.85;">{{COMPANY_NAME}}</div>
+      <div class="footer-logo">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1643.342 222.139" style="height:30px;width:auto;display:block;opacity:0.75;" aria-label="{{COMPANY_NAME}}">
+          <defs><clipPath id="clip-path-f2"><rect width="1643.342" height="222.139" fill="none"/></clipPath></defs>
+          <g clip-path="url(#clip-path-f2)">
+            <path d="M204.427,44.072,187.938,56.728a90.083,90.083,0,0,0-32.771-26.94,95.86,95.86,0,0,0-42.008-9.169A92.856,92.856,0,0,0,66.815,32.63,86.211,86.211,0,0,0,33.763,64.9q-11.724,20.26-11.723,45.56,0,38.244,26.228,63.832t66.172,25.585q43.928,0,73.5-34.4l16.489,12.508a105.418,105.418,0,0,1-39.025,30.78q-23.379,10.879-52.243,10.872-54.873,0-86.575-36.531Q.007,152.254,0,108.615,0,62.7,32.2,31.35T112.878,0q29.286,0,52.879,11.59a102.663,102.663,0,0,1,38.67,32.482" fill="#92c13b"/>
+            <path d="M213.84,219.636,243.777,10.517h3.4l85.013,171.589L416.38,10.517h3.352l30.092,209.119h-20.5L408.668,70.086l-73.942,149.55H329.39L254.567,68.947,234.03,219.636Z" fill="#92c13b"/>
+            <path d="M669.628,40.376,653.42,55.733a123.721,123.721,0,0,0-38.307-26.088q-20.826-8.881-40.586-8.889a96.859,96.859,0,0,0-46.848,12.086,87.794,87.794,0,0,0-34.473,32.771,84.663,84.663,0,0,0-12.226,43.71,86.356,86.356,0,0,0,12.655,44.849A89.875,89.875,0,0,0,528.6,187.579a100.616,100.616,0,0,0,48.9,12.16q32.273,0,54.589-18.2t26.443-47.195H591.867v-20.19h90.128q-.277,48.48-28.79,76.977-28.5,28.507-76.266,28.508-58,0-91.83-39.521-26.021-30.417-26.021-70.367a107.928,107.928,0,0,1,14.927-55.3,106.26,106.26,0,0,1,40.942-40.023Q540.979.008,573.816,0A130.892,130.892,0,0,1,623.854,9.6q23.457,9.6,45.774,30.78" fill="#92c13b"/>
+            <path d="M711.547,114.083h10.571v44.19h53.736v-44.19h10.571V219.5H775.854V168.552H722.118V219.5H711.547Z" fill="white"/>
+            <path d="M918.392,166.791c0,30.976-24.226,55.348-55.5,55.348-32.445,0-55.642-25.4-55.642-54.909,0-31.418,24.371-55.79,54.763-55.79,32,0,56.377,23.93,56.377,55.351m-100.13.439a44.08,44.08,0,0,0,44.34,44.632c24.665,0,44.778-18.793,44.778-45.219,0-26.721-21.435-44.926-44.778-44.926-23.2,0-44.34,18.5-44.34,45.513" fill="white"/>
+            <path d="M934.664,219.5l14.973-105.413H951.4l42.869,86.473,42.431-86.473h1.762L1053.436,219.5h-10.277l-10.277-75.463L995.591,219.5h-2.643l-37.878-76.05L944.939,219.5Z" fill="white"/>
+            <path d="M1074.4,114.083H1134.6V124.36h-49.623V157.4H1134.6v10.274h-49.623v41.55H1134.6V219.5H1074.4Z" fill="white"/>
+            <path d="M1193.738,114.083h10.571v95.136h40.521V219.5h-51.092Z" fill="white"/>
+            <path d="M1359.031,166.791c0,30.976-24.223,55.348-55.493,55.348-32.447,0-55.644-25.4-55.644-54.909,0-31.418,24.371-55.79,54.761-55.79,32.007,0,56.376,23.93,56.376,55.351m-100.125.439a44.079,44.079,0,0,0,44.336,44.632c24.665,0,44.779-18.793,44.779-45.219,0-26.721-21.434-44.926-44.779-44.926-23.195,0-44.336,18.5-44.336,45.513" fill="white"/>
+            <path d="M1414.06,114.083,1463.241,219.5h-11.306l-16.589-34.648h-45.512L1373.391,219.5h-11.746l49.917-105.413Zm-1.323,22.316-18.205,38.172h36.116Z" fill="white"/>
+            <path d="M1479.81,219.5V114.083h2.2l69.884,80.748V114.083h10.571V219.5h-2.349l-69.736-79.719V219.5Z" fill="white"/>
+            <path d="M1633.213,135.225c-5.727-7.489-10.719-12.92-19.38-12.92-9.1,0-14.242,6.46-14.242,13.362,0,5.724,3.376,11.745,9.4,16.295,19.819,14.681,34.355,24.813,34.355,41.843,0,14.827-12.478,28.334-29.657,28.334-14.533,0-24.077-8.076-31.86-22.316l8.957-5.431c6.312,11.6,13.947,17.47,22.023,17.47,11.012,0,19.525-8.073,19.525-17.911,0-11.6-10.862-18.205-34.794-37.585-4.992-3.965-8.955-12.332-8.955-20.26,0-14.534,11.3-24.665,25.544-24.665,12.919,0,20.7,7.782,27.6,17.178Z" fill="white"/>
+          </g>
+        </svg>
+      </div>
       <div class="footer-links">
-        <a href="#">Privacy Policy</a>
-        <a href="#">Terms of Use</a>
-        <a href="#">Web Accessibility</a>
+        <a href="https://www.cmghomeloans.com/corporate/privacy-policy" target="_blank">Privacy Policy</a>
+        <a href="https://www.cmghomeloans.com/corporate/licensing" target="_blank">Licensing</a>
+        <a href="https://www.cmghomeloans.com/corporate/terms-of-use" target="_blank">Terms of Use</a>
+        <a href="https://www.cmghomeloans.com/corporate/web-accessibility" target="_blank">Web Accessibility</a>
       </div>
     </div>
     <div class="footer-legal">
-      {{COMPANY_NAME}} &nbsp;&middot;&nbsp; {{BRANCH_ADDRESS}} &nbsp;&middot;&nbsp; Branch NMLS# {{BRANCH_NMLS}} &nbsp;&middot;&nbsp; {{MANAGER_NAME}} NMLS# {{MANAGER_NMLS}}<br><br>
-      Equal Housing Opportunity. All rights reserved.
+      {{BRANCH_NAME}} &nbsp;&middot;&nbsp; {{BRANCH_ADDRESS}} &nbsp;&middot;&nbsp; Branch NMLS# {{BRANCH_NMLS}} &nbsp;&middot;&nbsp; {{MANAGER_NAME}} NMLS# {{MANAGER_NMLS}}<br><br>
+      {{COMPANY_NAME}}, NMLS ID# {{COMPANY_NMLS_ID}} (For licensing information, go to <a href="https://www.nmlsconsumeraccess.org" target="_blank" style="color:rgba(255,255,255,0.45);text-decoration:underline;">www.nmlsconsumeraccess.org</a>). Equal Housing Opportunity. Licensed by the Department of Financial Protection and Innovation (DFPI) under the California Residential Mortgage Lending Act No. 4150025.; AZ #0903132; Colorado regulated by the Division of Real Estate; Georgia Residential Mortgage Licensee #15438; Mortgage Servicer License No. MS068. Hawaii Mortgage Loan Originator Company License No. HI-1820. Massachusetts Mortgage Lender License #MC1820 and Mortgage Broker License #MC1820; Mississippi Licensed Mortgage Company Licensed by the Mississippi Department of Banking and Consumer Finance; Licensed by the New Hampshire Banking Department; Licensed by the NJ Department of Banking and Insurance; Licensed Mortgage Banker &ndash; NYS Department of Financial Services; Ohio Mortgage Broker Act Mortgage Banker Exemption #MBMB.850204.000; Rhode Island Licensed Lender #20142986LL; Registered Mortgage Banker with the Texas Department of Savings and Mortgage Lending, and Licensed by the Virginia State Corporation Commission #MC-5521. CMG Mortgage, Inc. is licensed in all 50 states, the District of Columbia, Guam, Puerto Rico, and the Virgin Islands (<a href="https://www.cmgfi.com/corporate/licensing" target="_blank" style="color:rgba(255,255,255,0.45);text-decoration:underline;">https://www.cmgfi.com/corporate/licensing</a>).
     </div>
   </div>
 </footer>
 
 <script>
+  // ── FAQ accordion ─────────────────────────────────────────────
   function toggleFaq(btn) {
     const body = btn.nextElementSibling;
     const isOpen = btn.classList.contains('open');
+    // Close all in same accordion
     const accordion = btn.closest('.faq-accordion');
-    accordion.querySelectorAll('.faq-acc-btn.open').forEach(b => { b.classList.remove('open'); b.nextElementSibling.classList.remove('open'); });
-    if (!isOpen) { btn.classList.add('open'); body.classList.add('open'); }
+    accordion.querySelectorAll('.faq-acc-btn.open').forEach(b => {
+      b.classList.remove('open');
+      b.nextElementSibling.classList.remove('open');
+    });
+    // Open clicked if it was closed
+    if (!isOpen) {
+      btn.classList.add('open');
+      body.classList.add('open');
+    }
   }
 
+  // ── Page navigation ──────────────────────────────────────────
   function showPage(id) {
     document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
     document.querySelectorAll('.nav-tab').forEach(t => t.classList.remove('active'));
     document.getElementById(id).classList.add('active');
     const tab = document.getElementById('tab-' + id);
     if (tab) tab.classList.add('active');
+    // Reset apply form to step 1 when navigating to p4
     if (id === 'p4') resetApplyForm();
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
-  function resetApplyForm() { showStep(1); }
+  // ── Multi-step apply form ────────────────────────────────────
+  function resetApplyForm() {
+    showStep(1);
+  }
 
   function showStep(n) {
     [1,2,3].forEach(i => {
@@ -697,73 +3294,35 @@
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
-  function backToForm() { showStep(1); }
-
-  async function goToSchedule() {
-    const btn = document.querySelector('#apply-step-1 .form-submit-btn');
-    const origText = btn.textContent;
-    btn.textContent = 'Submitting...';
-    btn.disabled = true;
-
-    const firstName = document.querySelector('#apply-step-1 input[placeholder="Jordan"]')?.value || '';
-    const lastName = document.querySelector('#apply-step-1 input[placeholder="Smith"]')?.value || '';
-    const phone = document.querySelector('#apply-step-1 input[type="tel"]')?.value || '';
-    const email = document.querySelector('#apply-step-1 input[type="email"]')?.value || '';
-    const locationEl = document.querySelector('#apply-step-1 select');
-    const location = locationEl?.value || '';
-    const selects = document.querySelectorAll('#apply-step-1 select');
-    const careerField = selects[1]?.value || '';
-    const linkedin = document.querySelector('#apply-step-1 input[type="url"]')?.value || '';
-
-    if (!firstName || !lastName || !phone || !email || !location) {
-      btn.textContent = origText;
-      btn.disabled = false;
-      alert('Please fill in all required fields.');
-      return;
-    }
-
-    try {
-      const resp = await fetch('{{API_BASE_URL}}/api/v1/recruit-platform/public/apply/{{ORG_SLUG}}', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({
-          first_name: firstName, last_name: lastName,
-          phone: phone, email: email, location: location,
-          career_background: careerField, linkedin_url: linkedin,
-          source: 'landing_page', landing_page_slug: '{{PAGE_SLUG}}'
-        })
-      });
-      if (!resp.ok) {
-        const err = await resp.json().catch(() => ({}));
-        if (err.duplicate) {
-          btn.textContent = origText; btn.disabled = false;
-          alert('We already have an application on file for this email. A recruiter will be in touch!');
-          return;
-        }
-        throw new Error('Submission failed');
-      }
-      const data = await resp.json();
-      window._applicationId = data.candidate_id || data.id;
-      showStep(2);
-    } catch(e) {
-      btn.textContent = origText; btn.disabled = false;
-      alert('Something went wrong. Please try again or call us directly.');
-    }
+  function goToSchedule() {
+    const form = {
+      first_name: document.querySelector('[name=first_name]')?.value || document.querySelectorAll('.form-input')[0]?.value || '',
+      last_name: document.querySelector('[name=last_name]')?.value || document.querySelectorAll('.form-input')[1]?.value || '',
+      email: document.querySelector('[name=email]')?.value || document.querySelectorAll('.form-input')[2]?.value || '',
+      phone: document.querySelector('[name=phone]')?.value || document.querySelectorAll('.form-input')[3]?.value || '',
+      experience: document.querySelector('[name=experience]')?.value || '',
+    };
+    fetch('{{API_BASE_URL}}/api/v1/recruit-platform/public/apply/{{ORG_SLUG}}', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...form, page_slug: '{{PAGE_SLUG}}' }),
+    }).catch(() => {});
+    showStep(2);
   }
-
-  async function goToConfirmation() {
-    const selectedSlot = document.querySelector('.cal-slot.sel')?.textContent || '';
-    const selectedDay = document.querySelector('.cal-d.sel')?.textContent || '';
-    if (window._applicationId && selectedSlot) {
-      fetch('{{API_BASE_URL}}/api/v1/recruit-platform/public/apply/{{ORG_SLUG}}/schedule', {
+  function backToForm()    { showStep(1); }
+  function goToConfirmation() {
+    const slot = window._selectedSlot;
+    if (slot) {
+      fetch('{{API_BASE_URL}}/api/v1/recruit-platform/public/schedule/{{ORG_SLUG}}', {
         method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ candidate_id: window._applicationId, selected_time: selectedSlot, selected_day: selectedDay })
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slot, page_slug: '{{PAGE_SLUG}}' }),
       }).catch(() => {});
     }
     showStep(3);
   }
 
+  // ── Calendar ─────────────────────────────────────────────────
   let cy = new Date().getFullYear(), cm = new Date().getMonth();
   const DN = ['Su','Mo','Tu','We','Th','Fr','Sa'];
   const MN = ['January','February','March','April','May','June','July','August','September','October','November','December'];
@@ -776,16 +3335,24 @@
     DN.forEach(d => { const el = document.createElement('div'); el.className = 'cal-dh'; el.textContent = d; grid.appendChild(el); });
     document.getElementById('cal-month-lbl').textContent = MN[cm] + ' ' + cy;
     const first = new Date(cy, cm, 1).getDay();
-    const days = new Date(cy, cm + 1, 0).getDate();
+    const days  = new Date(cy, cm + 1, 0).getDate();
     const today = new Date();
     for (let i = 0; i < first; i++) { const el = document.createElement('div'); el.className = 'cal-d'; grid.appendChild(el); }
     for (let d = 1; d <= days; d++) {
-      const dt = new Date(cy, cm, d);
+      const dt  = new Date(cy, cm, d);
       const dow = dt.getDay();
       const past = dt < new Date(today.getFullYear(), today.getMonth(), today.getDate());
       const el = document.createElement('div');
-      if (past || dow === 0 || dow === 6) { el.className = 'cal-d na'; }
-      else { el.className = 'cal-d avail'; el.onclick = () => { document.querySelectorAll('.cal-d').forEach(x => x.classList.remove('sel')); el.classList.add('sel'); showSlots(d, dow); }; }
+      if (past || dow === 0 || dow === 6) {
+        el.className = 'cal-d na';
+      } else {
+        el.className = 'cal-d avail';
+        el.onclick = () => {
+          document.querySelectorAll('.cal-d').forEach(x => x.classList.remove('sel'));
+          el.classList.add('sel');
+          showSlots(d, dow);
+        };
+      }
       el.textContent = d;
       grid.appendChild(el);
     }
@@ -796,7 +3363,7 @@
   function changeMonth(dir) {
     cm += dir;
     if (cm > 11) { cm = 0; cy++; }
-    if (cm < 0) { cm = 11; cy--; }
+    if (cm < 0)  { cm = 11; cy--; }
     renderCal();
   }
 
@@ -809,16 +3376,14 @@
       const el = document.createElement('div');
       el.className = 'cal-slot';
       el.textContent = t;
-      el.onclick = () => { document.querySelectorAll('.cal-slot').forEach(s => s.classList.remove('sel')); el.classList.add('sel'); };
+      el.onclick = () => {
+        document.querySelectorAll('.cal-slot').forEach(s => s.classList.remove('sel'));
+        el.classList.add('sel');
+      };
       sl.appendChild(el);
     });
     wrap.style.display = 'block';
   }
-
-  // Track page view
-  (function() {
-    fetch('{{API_BASE_URL}}/api/v1/recruit-platform/p/{{PAGE_SLUG}}/view', { method: 'POST' }).catch(() => {});
-  })();
 </script>
 </body>
 </html>

--- a/frontend/src/pages/RecruitPlatform/RecruitLayout.jsx
+++ b/frontend/src/pages/RecruitPlatform/RecruitLayout.jsx
@@ -54,6 +54,21 @@ function NavIcon({ path }) {
         <polyline points="9 22 9 12 15 12 15 22"/>
       </svg>
     ),
+    knowledgebase: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/>
+      </svg>
+    ),
+    embed: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>
+      </svg>
+    ),
+    websitebuilder: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/>
+      </svg>
+    ),
   };
   return icons[path] || null;
 }
@@ -87,6 +102,10 @@ export default function RecruitLayout() {
             <NavIcon path="jobs" />
             Jobs
           </NavLink>
+          <NavLink to="/recruit/knowledge-base" className={({ isActive }) => `rp-nav-item${isActive ? ' active' : ''}`}>
+            <NavIcon path="knowledgebase" />
+            Knowledge Base
+          </NavLink>
           <a href="/recruiting/interviews" className="rp-nav-item">
             <NavIcon path="interviews" />
             Interviews
@@ -111,6 +130,14 @@ export default function RecruitLayout() {
             <NavIcon path="settings" />
             Settings
           </a>
+          <NavLink to="/recruit/embed-settings" className={({ isActive }) => `rp-nav-item${isActive ? ' active' : ''}`}>
+            <NavIcon path="embed" />
+            Embed &amp; Share
+          </NavLink>
+          <NavLink to="/recruit/website-builder" className={({ isActive }) => `rp-nav-item${isActive ? ' active' : ''}`}>
+            <NavIcon path="websitebuilder" />
+            Website Builder
+          </NavLink>
           {isPlatformAdmin && (
             <NavLink to="/recruit/license-manager" className={({ isActive }) => `rp-nav-item${isActive ? ' active' : ''}`}>
               <NavIcon path="license" />

--- a/frontend/src/pages/RecruitPlatform/RecruitingPlatform.css
+++ b/frontend/src/pages/RecruitPlatform/RecruitingPlatform.css
@@ -1,0 +1,130 @@
+/* Shared layout for the RecruitPlatform authenticated shell */
+
+.rp-layout {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+/* ── Sidebar ── */
+.rp-sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  background: #0f172a;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.rp-sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 16px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.rp-logo-mark {
+  width: 32px;
+  height: 32px;
+  background: #3b82f6;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.rp-sidebar-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.2;
+}
+
+.rp-sidebar-sub {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.45);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 140px;
+}
+
+/* ── Nav ── */
+.rp-nav {
+  flex: 1;
+  padding: 12px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow-y: auto;
+}
+
+.rp-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: 8px;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.65);
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
+  cursor: pointer;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}
+
+.rp-nav-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+.rp-nav-item.active {
+  background: rgba(59, 130, 246, 0.2);
+  color: #60a5fa;
+}
+
+/* ── Sidebar footer ── */
+.rp-sidebar-footer {
+  padding: 12px 16px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.rp-user-email {
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.45);
+  margin-bottom: 8px;
+  word-break: break-all;
+}
+
+.rp-logout-btn {
+  width: 100%;
+  padding: 7px 0;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 7px;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.rp-logout-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+/* ── Main content area ── */
+.rp-main {
+  flex: 1;
+  overflow: hidden;
+  background: #f1f5f9;
+  display: flex;
+  flex-direction: column;
+}

--- a/frontend/src/pages/RecruitPlatform/WebsiteBuilder/WebsiteBuilder.css
+++ b/frontend/src/pages/RecruitPlatform/WebsiteBuilder/WebsiteBuilder.css
@@ -1,636 +1,383 @@
-/* ── Website Builder ─────────────────────────────────────────── */
-
-.wb-shell {
+.wb-container {
   display: flex;
   height: calc(100vh - 0px);
+  background: #f4f5f7;
   overflow: hidden;
-  background: #f7f8fa;
 }
 
-/* Sidebar — page list */
+/* ─── Sidebar ─────────────────────────────────────────────────────────────── */
 .wb-sidebar {
-  width: 380px;
-  min-width: 340px;
+  width: 280px;
+  flex-shrink: 0;
   background: #fff;
-  border-right: 1px solid #e2e8f0;
+  border-right: 1px solid #e2e5ec;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .wb-sidebar-header {
-  padding: 20px 20px 16px;
-  border-bottom: 1px solid #e2e8f0;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  padding: 16px;
+  border-bottom: 1px solid #e2e5ec;
 }
 
 .wb-sidebar-title {
-  font-family: 'Montserrat', sans-serif;
+  font-weight: 600;
   font-size: 14px;
-  font-weight: 700;
-  color: #1b2a4a;
+  color: #1a202c;
 }
 
-.wb-sidebar-subtitle {
-  font-size: 12px;
-  color: #718096;
-  margin-top: 1px;
-}
-
-.wb-create-btn {
-  background: #6aaa26;
+.wb-new-btn {
+  background: #1b2a4a;
   color: #fff;
   border: none;
   border-radius: 6px;
-  padding: 8px 14px;
-  font-family: 'Montserrat', sans-serif;
+  padding: 5px 12px;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
-  white-space: nowrap;
-  transition: background 0.18s;
 }
+.wb-new-btn:hover { background: #2d4470; }
 
-.wb-create-btn:hover {
-  background: #578f1e;
-}
-
-.wb-page-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 10px 0;
-}
-
-.wb-empty-list {
-  padding: 40px 20px;
-  text-align: center;
-  color: #a0aec0;
+.wb-empty {
+  padding: 24px 16px;
   font-size: 13px;
-  line-height: 1.6;
+  color: #8892a4;
+  line-height: 1.5;
 }
 
-.wb-empty-list-icon {
-  font-size: 32px;
-  margin-bottom: 10px;
-}
-
-/* Page list item */
 .wb-page-item {
-  padding: 14px 16px;
-  cursor: pointer;
-  border-left: 3px solid transparent;
-  transition: background 0.12s, border-color 0.12s;
+  padding: 12px 16px;
   border-bottom: 1px solid #f0f2f5;
+  cursor: pointer;
+  transition: background 0.12s;
 }
-
-.wb-page-item:hover {
-  background: #f7f8fa;
-}
-
-.wb-page-item.selected {
-  background: #eff7e1;
-  border-left-color: #6aaa26;
-}
-
-.wb-page-item-top {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 6px;
-}
+.wb-page-item:hover { background: #f8fafc; }
+.wb-page-item.active { background: #eff3ff; border-left: 3px solid #1b2a4a; }
 
 .wb-page-item-title {
-  font-family: 'Montserrat', sans-serif;
   font-size: 13px;
-  font-weight: 700;
-  color: #1b2a4a;
-  line-height: 1.3;
-}
-
-.wb-page-item-slug {
-  font-size: 11px;
-  color: #718096;
-  margin-bottom: 6px;
-  font-family: monospace;
+  font-weight: 600;
+  color: #1a202c;
+  margin-bottom: 4px;
 }
 
 .wb-page-item-meta {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-top: 8px;
+  gap: 8px;
+  margin-bottom: 3px;
 }
 
-.wb-page-item-stat {
-  font-size: 11px;
-  color: #a0aec0;
-}
-
-.wb-page-item-actions {
-  display: flex;
-  gap: 6px;
-  margin-top: 8px;
-}
-
-.wb-page-item-action {
-  padding: 4px 10px;
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  font-family: 'Montserrat', sans-serif;
-  cursor: pointer;
-  border: 1px solid;
-  transition: all 0.15s;
-}
-
-.wb-page-item-action.edit {
-  background: #fff;
-  color: #1b2a4a;
-  border-color: #d2d6dc;
-}
-
-.wb-page-item-action.edit:hover {
-  background: #1b2a4a;
-  color: #fff;
-  border-color: #1b2a4a;
-}
-
-.wb-page-item-action.copy {
-  background: #fff;
-  color: #6aaa26;
-  border-color: #b8e08a;
-}
-
-.wb-page-item-action.copy:hover {
-  background: #eff7e1;
-}
-
-/* Status badge */
-.wb-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  border-radius: 100px;
+.wb-status-badge {
   font-size: 10px;
   font-weight: 700;
-  font-family: 'Montserrat', sans-serif;
-  letter-spacing: 0.5px;
+  padding: 2px 6px;
+  border-radius: 3px;
   text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.wb-status-badge.published { background: #d1fae5; color: #065f46; }
+.wb-status-badge.draft     { background: #f3f4f6; color: #6b7280; }
+
+.wb-page-stats {
+  font-size: 11px;
+  color: #8892a4;
+}
+
+.wb-page-slug {
+  font-size: 11px;
+  color: #8892a4;
+  font-family: 'Courier New', monospace;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.wb-badge.published {
-  background: #e6f4d9;
-  color: #3a7a10;
-}
-
-.wb-badge.draft {
-  background: #edf2f7;
-  color: #718096;
-}
-
-/* Main editor area */
-.wb-main {
+/* ─── Editor ──────────────────────────────────────────────────────────────── */
+.wb-editor {
   flex: 1;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
-.wb-main-header {
-  padding: 16px 24px;
-  border-bottom: 1px solid #e2e8f0;
-  background: #fff;
+.wb-no-selection {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #8892a4;
+  font-size: 14px;
+}
+
+/* ─── Action bar ─────────────────────────────────────────────────────────── */
+.wb-action-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding: 10px 20px;
+  background: #fff;
+  border-bottom: 1px solid #e2e5ec;
+  flex-shrink: 0;
+}
+
+.wb-action-left {
+  display: flex;
+  align-items: center;
   gap: 12px;
 }
 
-.wb-main-header-title {
-  font-family: 'Montserrat', sans-serif;
-  font-size: 16px;
-  font-weight: 800;
+.wb-editing-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a202c;
+}
+
+.wb-save-msg {
+  font-size: 12px;
+  color: #059669;
+  font-weight: 600;
+}
+
+.wb-error-msg {
+  font-size: 12px;
+  color: #dc2626;
+  font-weight: 500;
+}
+
+.wb-action-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wb-btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.12s;
+}
+.wb-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.wb-btn-ghost {
+  background: transparent;
+  color: #4a5568;
+  border: 1px solid #d5d9e3;
+}
+.wb-btn-ghost:hover { background: #f0f2f5; }
+
+.wb-btn-secondary {
+  background: #e8ecf5;
   color: #1b2a4a;
 }
+.wb-btn-secondary:hover { background: #d5ddf0; }
 
-.wb-main-header-slug {
-  font-size: 12px;
-  color: #718096;
-  font-family: monospace;
-  margin-top: 2px;
+.wb-btn-primary {
+  background: #1b2a4a;
+  color: #fff;
 }
+.wb-btn-primary:hover { background: #2d4470; }
 
-/* Empty state */
-.wb-empty-state {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  color: #a0aec0;
-  padding: 40px;
+.wb-btn-warning {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fcd34d;
 }
+.wb-btn-warning:hover { background: #fde68a; }
 
-.wb-empty-state-icon {
-  font-size: 56px;
-  opacity: 0.5;
+.wb-btn-danger {
+  background: #fee2e2;
+  color: #dc2626;
+  border: 1px solid #fca5a5;
 }
+.wb-btn-danger:hover { background: #fecaca; }
 
-.wb-empty-state h3 {
-  font-family: 'Montserrat', sans-serif;
-  font-size: 18px;
-  color: #4a5568;
-  margin: 0;
-}
-
-.wb-empty-state p {
-  font-size: 14px;
-  color: #a0aec0;
-  text-align: center;
-  max-width: 320px;
-  margin: 0;
-  line-height: 1.6;
-}
-
-/* Tabs */
+/* ─── Tabs ───────────────────────────────────────────────────────────────── */
 .wb-tabs {
   display: flex;
   gap: 0;
-  border-bottom: 1px solid #e2e8f0;
+  padding: 0 20px;
   background: #fff;
-  padding: 0 24px;
+  border-bottom: 1px solid #e2e5ec;
+  flex-shrink: 0;
 }
 
 .wb-tab {
-  background: none;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #6b7280;
+  background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  padding: 12px 16px 10px;
-  font-family: 'Montserrat', sans-serif;
-  font-size: 12px;
-  font-weight: 700;
-  color: #718096;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
-  letter-spacing: 0.4px;
-  white-space: nowrap;
+  transition: color 0.12s, border-color 0.12s;
 }
-
-.wb-tab:hover {
-  color: #1b2a4a;
-}
-
+.wb-tab:hover { color: #1b2a4a; }
 .wb-tab.active {
   color: #1b2a4a;
-  border-bottom-color: #6aaa26;
+  border-bottom-color: #1b2a4a;
+  font-weight: 600;
 }
 
-/* Tab content / form */
+/* ─── Tab content ─────────────────────────────────────────────────────────── */
 .wb-tab-content {
   flex: 1;
   overflow-y: auto;
   padding: 24px;
-  padding-bottom: 80px;
 }
 
-.wb-section-label {
-  font-family: 'Montserrat', sans-serif;
-  font-size: 10px;
+.wb-tab-section h4 {
+  font-size: 13px;
   font-weight: 700;
-  letter-spacing: 1.2px;
+  color: #1a202c;
   text-transform: uppercase;
-  color: #6aaa26;
-  margin-bottom: 14px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid #e2e8f0;
+  letter-spacing: 0.5px;
+  margin: 20px 0 12px;
 }
+.wb-tab-section h4:first-child { margin-top: 0; }
 
 .wb-form-group {
   margin-bottom: 16px;
 }
 
-.wb-form-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-}
-
-.wb-label {
+.wb-form-group label {
   display: block;
-  font-family: 'Montserrat', sans-serif;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.6px;
-  text-transform: uppercase;
-  color: #1b2a4a;
+  font-size: 12px;
+  font-weight: 600;
+  color: #4a5568;
   margin-bottom: 5px;
-}
-
-.wb-label-hint {
-  font-weight: 400;
-  text-transform: none;
-  letter-spacing: 0;
-  color: #a0aec0;
-  font-size: 10px;
-  display: block;
-  margin-top: 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
 }
 
 .wb-input {
   width: 100%;
-  padding: 9px 12px;
-  border: 1.5px solid #e2e8f0;
+  padding: 8px 12px;
+  border: 1.5px solid #d5d9e3;
   border-radius: 6px;
-  font-family: 'Open Sans', sans-serif;
   font-size: 13px;
   color: #1a202c;
   background: #fff;
-  outline: none;
-  transition: border-color 0.15s;
+  transition: border-color 0.12s;
+  box-sizing: border-box;
 }
-
 .wb-input:focus {
+  outline: none;
   border-color: #1b2a4a;
+}
+.wb-input[readonly] {
+  background: #f9fafb;
+  color: #6b7280;
 }
 
 .wb-textarea {
-  width: 100%;
-  padding: 9px 12px;
-  border: 1.5px solid #e2e8f0;
-  border-radius: 6px;
-  font-family: 'Open Sans', sans-serif;
-  font-size: 13px;
-  color: #1a202c;
-  background: #fff;
-  outline: none;
-  transition: border-color 0.15s;
   resize: vertical;
   min-height: 70px;
+  font-family: inherit;
 }
 
-.wb-textarea:focus {
-  border-color: #1b2a4a;
+.wb-hint {
+  font-size: 11px;
+  color: #8892a4;
+  margin-top: 4px;
 }
 
-/* Color row */
+/* ─── Color inputs ────────────────────────────────────────────────────────── */
 .wb-color-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 16px;
+}
+
+.wb-color-input-wrap {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
-.wb-color-swatch {
+.wb-color-picker {
   width: 36px;
-  height: 36px;
-  border-radius: 6px;
-  border: 1.5px solid #e2e8f0;
+  height: 32px;
+  border: none;
   padding: 0;
   cursor: pointer;
+  border-radius: 4px;
   flex-shrink: 0;
 }
 
-.wb-color-hex {
+.wb-color-text {
   flex: 1;
 }
 
-/* Stat rows */
-.wb-stat-row {
-  display: grid;
-  grid-template-columns: 120px 1fr;
-  gap: 10px;
-  align-items: end;
-  margin-bottom: 12px;
-}
-
-.wb-stat-row-label {
-  font-family: 'Montserrat', sans-serif;
-  font-size: 10px;
-  font-weight: 700;
-  color: #a0aec0;
-  margin-bottom: 5px;
-}
-
-/* Action bar */
-.wb-action-bar {
-  position: sticky;
-  bottom: 0;
-  background: #fff;
-  border-top: 1px solid #e2e8f0;
-  padding: 12px 24px;
+.wb-color-preview {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  box-shadow: 0 -2px 8px rgba(27,42,74,0.07);
-  z-index: 10;
+  gap: 8px;
+  margin: 12px 0 20px;
 }
 
-.wb-action-bar .spacer {
-  flex: 1;
-}
-
-.wb-btn {
-  padding: 9px 18px;
+.wb-swatch {
+  padding: 8px 16px;
   border-radius: 6px;
-  font-family: 'Montserrat', sans-serif;
   font-size: 12px;
-  font-weight: 700;
-  cursor: pointer;
-  transition: all 0.15s;
-  border: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  white-space: nowrap;
-}
-
-.wb-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.wb-btn.draft {
-  background: #edf2f7;
-  color: #4a5568;
-}
-
-.wb-btn.draft:hover:not(:disabled) {
-  background: #e2e8f0;
-}
-
-.wb-btn.publish {
-  background: #6aaa26;
+  font-weight: 600;
   color: #fff;
 }
 
-.wb-btn.publish:hover:not(:disabled) {
-  background: #578f1e;
+/* ─── Stat rows ───────────────────────────────────────────────────────────── */
+.wb-stat-row {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 12px;
+  align-items: start;
 }
 
-.wb-btn.unpublish {
-  background: #fff;
-  color: #c53030;
-  border: 1.5px solid #fc8181;
-}
-
-.wb-btn.unpublish:hover:not(:disabled) {
-  background: #fff5f5;
-}
-
-.wb-btn.preview {
-  background: #fff;
-  color: #1b2a4a;
-  border: 1.5px solid #e2e8f0;
-}
-
-.wb-btn.preview:hover:not(:disabled) {
-  border-color: #1b2a4a;
-}
-
-.wb-btn.copy-url {
-  background: #fff;
-  color: #6aaa26;
-  border: 1.5px solid #b8e08a;
-}
-
-.wb-btn.copy-url:hover:not(:disabled) {
-  background: #eff7e1;
-}
-
-.wb-btn.danger {
-  background: #fff;
-  color: #c53030;
-  border: 1.5px solid #fc8181;
-  padding: 9px 12px;
-}
-
-.wb-btn.danger:hover:not(:disabled) {
-  background: #fff5f5;
-}
-
-/* Modal */
+/* ─── Modal ───────────────────────────────────────────────────────────────── */
 .wb-modal-overlay {
   position: fixed;
   inset: 0;
   background: rgba(0,0,0,0.4);
-  z-index: 200;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  z-index: 1000;
 }
 
 .wb-modal {
   background: #fff;
-  border-radius: 12px;
-  padding: 28px 28px 24px;
-  width: 100%;
-  max-width: 480px;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.18);
+  border-radius: 10px;
+  padding: 28px;
+  width: 420px;
+  max-width: 90vw;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.15);
 }
 
-.wb-modal-title {
-  font-family: 'Montserrat', sans-serif;
-  font-size: 18px;
-  font-weight: 800;
-  color: #1b2a4a;
-  margin-bottom: 6px;
+.wb-modal h3 {
+  margin: 0 0 20px;
+  font-size: 16px;
+  color: #1a202c;
 }
 
-.wb-modal-desc {
-  font-size: 13px;
-  color: #718096;
-  line-height: 1.55;
-  margin-bottom: 22px;
-}
-
-.wb-modal-template-note {
-  background: #eff7e1;
-  border: 1px solid #b8e08a;
-  border-radius: 6px;
-  padding: 12px 14px;
+.wb-slug-preview {
   font-size: 12px;
-  color: #3a7a10;
-  line-height: 1.55;
-  margin-bottom: 18px;
+  color: #4a5568;
+  font-family: 'Courier New', monospace;
+  padding: 6px 10px;
+  background: #f9fafb;
+  border-radius: 4px;
+  margin-bottom: 6px;
 }
 
 .wb-modal-actions {
   display: flex;
   gap: 10px;
   justify-content: flex-end;
-  margin-top: 22px;
-}
-
-.wb-modal-cancel {
-  padding: 9px 18px;
-  background: #edf2f7;
-  border: none;
-  border-radius: 6px;
-  font-family: 'Montserrat', sans-serif;
-  font-size: 12px;
-  font-weight: 700;
-  color: #4a5568;
-  cursor: pointer;
-}
-
-.wb-modal-create {
-  padding: 9px 20px;
-  background: #1b2a4a;
-  border: none;
-  border-radius: 6px;
-  font-family: 'Montserrat', sans-serif;
-  font-size: 12px;
-  font-weight: 700;
-  color: #fff;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.wb-modal-create:hover {
-  background: #223358;
-}
-
-.wb-modal-create:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-/* Loading */
-.wb-loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 60px;
-  color: #a0aec0;
-  font-size: 14px;
-  gap: 10px;
-}
-
-/* Notification toast */
-.wb-toast {
-  position: fixed;
-  bottom: 24px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #1b2a4a;
-  color: #fff;
-  padding: 10px 20px;
-  border-radius: 8px;
-  font-size: 13px;
-  font-weight: 600;
-  z-index: 300;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.2);
-  animation: wb-toast-in 0.2s ease;
-}
-
-@keyframes wb-toast-in {
-  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+  margin-top: 20px;
 }

--- a/frontend/src/pages/RecruitPlatform/WebsiteBuilder/index.jsx
+++ b/frontend/src/pages/RecruitPlatform/WebsiteBuilder/index.jsx
@@ -1,43 +1,42 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { useRecruitPlatform } from '../../../contexts/RecruitPlatformContext';
 import './WebsiteBuilder.css';
 
-const API = 'https://api.perenniaai.com';
+const API_BASE = import.meta.env.VITE_API_URL || 'https://api.perenniaai.com';
 
-function authHeaders() {
-  const token = localStorage.getItem('recruit_auth_token');
-  return {
-    Authorization: `Bearer ${token}`,
-    'Content-Type': 'application/json',
-  };
+function slugify(str) {
+  return str.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
 function deriveColors(hex) {
-  if (!hex || !/^#[0-9a-fA-F]{6}$/.test(hex)) return { dark: '', pale: '' };
+  // Darken by ~15%, lighten to pale (mix with white 85%)
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
   const b = parseInt(hex.slice(5, 7), 16);
-  const dark = '#' + [r, g, b].map(c => Math.max(0, Math.round(c * 0.82)).toString(16).padStart(2, '0')).join('');
-  const pale = '#' + [r, g, b].map(c => Math.min(255, Math.round(c * 0.08 + 255 * 0.92)).toString(16).padStart(2, '0')).join('');
-  return { dark, pale };
-}
-
-function toSlug(str) {
-  return str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  const toHex = (n) => Math.max(0, Math.min(255, n)).toString(16).padStart(2, '0');
+  const darkR = Math.round(r * 0.85);
+  const darkG = Math.round(g * 0.85);
+  const darkB = Math.round(b * 0.85);
+  const paleR = Math.round(r + (255 - r) * 0.85);
+  const paleG = Math.round(g + (255 - g) * 0.85);
+  const paleB = Math.round(b + (255 - b) * 0.85);
+  return {
+    dark: `#${toHex(darkR)}${toHex(darkG)}${toHex(darkB)}`,
+    pale: `#${toHex(paleR)}${toHex(paleG)}${toHex(paleB)}`,
+  };
 }
 
 const DEFAULT_CONFIG = {
-  page_title: 'Careers — Apply Now',
-  company_name: 'CMG Home Loans',
-  location_display: 'Charleston & Columbia, SC',
   primary_color: '#6AAA26',
   primary_color_dark: '#578F1E',
   primary_color_pale: '#EFF7E1',
-  logo_url: '',
+  company_name: 'CMG Home Loans',
+  company_nmls_id: '1820',
+  location_display: 'Charleston & Columbia, SC',
   hero_headline: 'Build a <span class="red">six-figure</span><br>mortgage career<br>from <span class="italic">day one.</span>',
-  hero_subheadline: "No mortgage experience required. We recruit driven, coachable people ready to earn what they're worth in one of America's most resilient industries.",
-  signing_bonus: '$2,500',
-  signing_bonus_month: 'July',
-  signing_bonus_deadline: 'July 31st',
+  hero_headline_plain: 'Build a six-figure mortgage career from day one.',
+  signing_bonus: '$2,500 signing bonus for July hires',
+  signing_bonus_amount: '$2,500',
   year1_range: '$65–90K',
   year2_top: '$120,000+',
   senior_lo: '$180,000+',
@@ -50,12 +49,13 @@ const DEFAULT_CONFIG = {
   stat_3_label: 'Team borrower rating',
   stat_4_num: '8 Weeks',
   stat_4_label: 'Fully paid training program',
-  manager_initials: 'TL',
   manager_name: 'Tim Loss',
-  manager_title: 'Branch Manager · CMG Home Loans, Mt. Pleasant SC · NMLS# 187037',
+  manager_initials: 'TL',
+  manager_title: 'Branch Manager · CMG Home Loans, Mt. Pleasant SC',
   manager_nmls: '187037',
   contact_phone_display: '(843) 834-4997',
   contact_phone_tel: '+18438344997',
+  branch_name: 'CMG Home Loans',
   branch_address: '975 Johnnie Dodds Blvd. Suite A, Mt. Pleasant, SC 29464',
   branch_nmls: '1594871',
 };
@@ -69,290 +69,247 @@ const TABS = [
 ];
 
 export default function WebsiteBuilder() {
+  const { recruitToken } = useRecruitPlatform();
   const [pages, setPages] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [selectedPage, setSelectedPage] = useState(null);
-  const [formConfig, setFormConfig] = useState({});
+  const [selectedId, setSelectedId] = useState(null);
+  const [config, setConfig] = useState(DEFAULT_CONFIG);
   const [activeTab, setActiveTab] = useState('branding');
   const [saving, setSaving] = useState(false);
-  const [showCreateModal, setShowCreateModal] = useState(false);
-  const [newTitle, setNewTitle] = useState('');
-  const [newSlug, setNewSlug] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [toast, setToast] = useState(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [createForm, setCreateForm] = useState({ title: '', slug: '' });
+  const [error, setError] = useState('');
+  const [saveMsg, setSaveMsg] = useState('');
 
-  const showToast = useCallback((msg) => {
-    setToast(msg);
-    setTimeout(() => setToast(null), 2400);
-  }, []);
+  const authHeaders = {
+    Authorization: `Bearer ${recruitToken}`,
+    'Content-Type': 'application/json',
+  };
 
   const loadPages = useCallback(async () => {
     try {
-      const res = await fetch(`${API}/api/v1/recruit-platform/landing-pages/`, {
-        headers: authHeaders(),
-      });
+      const res = await fetch(`${API_BASE}/api/v1/recruit-platform/landing-pages`, { headers: authHeaders });
       if (res.ok) {
         const data = await res.json();
-        setPages(Array.isArray(data) ? data : (data.pages || data.items || []));
+        setPages(data);
+        if (data.length > 0 && !selectedId) {
+          setSelectedId(data[0].id);
+          setConfig({ ...DEFAULT_CONFIG, ...(data[0].config || {}) });
+        }
       }
-    } catch {
-      // silently fail — pages stay empty
-    } finally {
-      setLoading(false);
+    } catch (e) {
+      setError('Failed to load pages');
     }
-  }, []);
+  }, [recruitToken, selectedId]);
 
-  useEffect(() => { loadPages(); }, [loadPages]);
+  useEffect(() => { loadPages(); }, []);
 
-  async function selectPage(page) {
-    setSelectedPage(page);
-    setActiveTab('branding');
-    try {
-      const res = await fetch(`${API}/api/v1/recruit-platform/landing-pages/${page.id}`, {
-        headers: authHeaders(),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setFormConfig(data.config || data || {});
-      } else {
-        setFormConfig(page.config || {});
+  const selectPage = (page) => {
+    setSelectedId(page.id);
+    setConfig({ ...DEFAULT_CONFIG, ...(page.config || {}) });
+    setSaveMsg('');
+    setError('');
+  };
+
+  const handleConfigChange = (field, value) => {
+    setConfig((prev) => {
+      const next = { ...prev, [field]: value };
+      if (field === 'primary_color' && /^#[0-9a-fA-F]{6}$/.test(value)) {
+        const { dark, pale } = deriveColors(value);
+        next.primary_color_dark = dark;
+        next.primary_color_pale = pale;
       }
-    } catch {
-      setFormConfig(page.config || {});
-    }
-  }
+      if (field === 'manager_name') {
+        const parts = value.trim().split(/\s+/);
+        next.manager_initials = parts.map((p) => p[0]?.toUpperCase() || '').slice(0, 2).join('');
+      }
+      return next;
+    });
+  };
 
-  function setField(key, value) {
-    setFormConfig(prev => ({ ...prev, [key]: value }));
-  }
-
-  function handleColorChange(hex) {
-    const derived = deriveColors(hex);
-    setFormConfig(prev => ({
-      ...prev,
-      primary_color: hex,
-      primary_color_dark: derived.dark,
-      primary_color_pale: derived.pale,
-    }));
-  }
-
-  async function saveDraft() {
-    if (!selectedPage) return;
+  const saveDraft = async () => {
+    if (!selectedId) return;
     setSaving(true);
+    setError('');
     try {
-      const res = await fetch(`${API}/api/v1/recruit-platform/landing-pages/${selectedPage.id}`, {
-        method: 'PATCH',
-        headers: authHeaders(),
-        body: JSON.stringify({ config: formConfig, status: 'draft' }),
+      const res = await fetch(`${API_BASE}/api/v1/recruit-platform/landing-pages/${selectedId}`, {
+        method: 'PUT',
+        headers: authHeaders,
+        body: JSON.stringify({ config }),
       });
-      if (res.ok) {
-        showToast('Draft saved');
-        await loadPages();
-      } else {
-        showToast('Save failed — check connection');
-      }
-    } catch {
-      showToast('Save failed — check connection');
+      if (!res.ok) throw new Error((await res.json()).detail || 'Save failed');
+      setSaveMsg('Saved');
+      setTimeout(() => setSaveMsg(''), 2000);
+      await loadPages();
+    } catch (e) {
+      setError(e.message);
     } finally {
       setSaving(false);
     }
-  }
+  };
 
-  async function togglePublish() {
-    if (!selectedPage) return;
-    const isPublished = selectedPage.status === 'published';
-    const endpoint = isPublished ? 'unpublish' : 'publish';
+  const publishPage = async () => {
+    if (!selectedId) return;
     setSaving(true);
     try {
-      const res = await fetch(`${API}/api/v1/recruit-platform/landing-pages/${selectedPage.id}/${endpoint}`, {
+      await saveDraft();
+      const res = await fetch(`${API_BASE}/api/v1/recruit-platform/landing-pages/${selectedId}/publish`, {
         method: 'POST',
-        headers: authHeaders(),
+        headers: authHeaders,
       });
-      if (res.ok) {
-        showToast(isPublished ? 'Page unpublished' : 'Page published!');
-        await loadPages();
-        setSelectedPage(prev => ({ ...prev, status: isPublished ? 'draft' : 'published' }));
-      } else {
-        showToast('Action failed');
-      }
-    } catch {
-      showToast('Action failed');
+      if (!res.ok) throw new Error((await res.json()).detail || 'Publish failed');
+      await loadPages();
+      setSaveMsg('Published');
+      setTimeout(() => setSaveMsg(''), 3000);
+    } catch (e) {
+      setError(e.message);
     } finally {
       setSaving(false);
     }
-  }
+  };
 
-  async function deletePage() {
-    if (!selectedPage) return;
-    if (!window.confirm(`Delete "${selectedPage.title}"? This cannot be undone.`)) return;
+  const unpublishPage = async () => {
+    if (!selectedId) return;
+    setSaving(true);
     try {
-      const res = await fetch(`${API}/api/v1/recruit-platform/landing-pages/${selectedPage.id}`, {
+      const res = await fetch(`${API_BASE}/api/v1/recruit-platform/landing-pages/${selectedId}/unpublish`, {
+        method: 'POST',
+        headers: authHeaders,
+      });
+      if (!res.ok) throw new Error((await res.json()).detail || 'Failed');
+      await loadPages();
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const previewPage = () => {
+    if (!selectedId) return;
+    window.open(`${API_BASE}/api/v1/recruit-platform/landing-pages/${selectedId}/preview`, '_blank');
+  };
+
+  const copyUrl = () => {
+    const page = pages.find((p) => p.id === selectedId);
+    if (!page) return;
+    const url = `https://recruit.perenniaai.com/${page.slug}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setSaveMsg('URL copied');
+      setTimeout(() => setSaveMsg(''), 2000);
+    });
+  };
+
+  const deletePage = async () => {
+    if (!selectedId) return;
+    if (!window.confirm('Delete this page?')) return;
+    try {
+      await fetch(`${API_BASE}/api/v1/recruit-platform/landing-pages/${selectedId}`, {
         method: 'DELETE',
-        headers: authHeaders(),
+        headers: authHeaders,
       });
-      if (res.ok) {
-        showToast('Page deleted');
-        setSelectedPage(null);
-        setFormConfig({});
-        await loadPages();
-      } else {
-        showToast('Delete failed');
-      }
-    } catch {
-      showToast('Delete failed');
+      setSelectedId(null);
+      setConfig(DEFAULT_CONFIG);
+      await loadPages();
+    } catch (e) {
+      setError(e.message);
     }
-  }
+  };
 
-  function copyPublicUrl() {
-    if (!selectedPage) return;
-    const url = `https://recruit.perenniaai.com/p/${selectedPage.slug}`;
-    navigator.clipboard.writeText(url).then(() => showToast('URL copied!')).catch(() => showToast(url));
-  }
-
-  function openPreview() {
-    if (!selectedPage) return;
-    window.open(`${API}/api/v1/recruit-platform/landing-pages/${selectedPage.id}/preview`, '_blank');
-  }
-
-  async function createPage() {
-    if (!newTitle.trim() || !newSlug.trim()) return;
-    setCreating(true);
+  const createPage = async () => {
+    if (!createForm.title || !createForm.slug) return;
     try {
-      const res = await fetch(`${API}/api/v1/recruit-platform/landing-pages/`, {
+      const res = await fetch(`${API_BASE}/api/v1/recruit-platform/landing-pages`, {
         method: 'POST',
-        headers: authHeaders(),
-        body: JSON.stringify({
-          title: newTitle.trim(),
-          slug: newSlug.trim(),
-          status: 'draft',
-          config: { ...DEFAULT_CONFIG, page_title: newTitle.trim() },
-        }),
+        headers: authHeaders,
+        body: JSON.stringify({ title: createForm.title, slug: createForm.slug, config: DEFAULT_CONFIG }),
       });
-      if (res.ok) {
-        const created = await res.json();
-        setShowCreateModal(false);
-        setNewTitle('');
-        setNewSlug('');
-        await loadPages();
-        selectPage(created);
-        showToast('Page created');
-      } else {
-        const err = await res.json().catch(() => ({}));
-        showToast(err.detail || 'Create failed');
-      }
-    } catch {
-      showToast('Create failed');
-    } finally {
-      setCreating(false);
+      if (!res.ok) throw new Error((await res.json()).detail || 'Create failed');
+      const created = await res.json();
+      setShowCreate(false);
+      setCreateForm({ title: '', slug: '' });
+      await loadPages();
+      setSelectedId(created.id);
+      setConfig({ ...DEFAULT_CONFIG, ...(created.config || {}) });
+    } catch (e) {
+      setError(e.message);
     }
-  }
+  };
 
-  function handleNewTitleChange(val) {
-    setNewTitle(val);
-    setNewSlug(toSlug(val));
-  }
-
+  const selectedPage = pages.find((p) => p.id === selectedId);
   const isPublished = selectedPage?.status === 'published';
 
   return (
-    <div className="wb-shell">
-      {/* ── Left sidebar: page list ── */}
+    <div className="wb-container">
+      {/* Left panel: page list */}
       <div className="wb-sidebar">
         <div className="wb-sidebar-header">
-          <div>
-            <div className="wb-sidebar-title">Landing Pages</div>
-            <div className="wb-sidebar-subtitle">{pages.length} page{pages.length !== 1 ? 's' : ''}</div>
-          </div>
-          <button className="wb-create-btn" onClick={() => { setShowCreateModal(true); setNewTitle(''); setNewSlug(''); }}>
-            + New Page
-          </button>
+          <span className="wb-sidebar-title">Landing Pages</span>
+          <button className="wb-new-btn" onClick={() => setShowCreate(true)}>+ New</button>
         </div>
 
-        <div className="wb-page-list">
-          {loading && (
-            <div className="wb-loading">
-              <span>Loading pages…</span>
+        {pages.length === 0 && (
+          <div className="wb-empty">No pages yet. Create your first landing page.</div>
+        )}
+
+        {pages.map((page) => (
+          <div
+            key={page.id}
+            className={`wb-page-item${page.id === selectedId ? ' active' : ''}`}
+            onClick={() => selectPage(page)}
+          >
+            <div className="wb-page-item-title">{page.title}</div>
+            <div className="wb-page-item-meta">
+              <span className={`wb-status-badge ${page.status}`}>{page.status}</span>
+              <span className="wb-page-stats">{page.view_count} views · {page.submission_count} leads</span>
             </div>
-          )}
-          {!loading && pages.length === 0 && (
-            <div className="wb-empty-list">
-              <div className="wb-empty-list-icon">🌐</div>
-              <div>No landing pages yet.</div>
-              <div>Create your first page to start capturing applicants.</div>
-            </div>
-          )}
-          {pages.map(page => (
-            <div
-              key={page.id}
-              className={`wb-page-item${selectedPage?.id === page.id ? ' selected' : ''}`}
-              onClick={() => selectPage(page)}
-            >
-              <div className="wb-page-item-top">
-                <div className="wb-page-item-title">{page.title}</div>
-                <span className={`wb-badge ${page.status === 'published' ? 'published' : 'draft'}`}>
-                  {page.status === 'published' ? '● Published' : '○ Draft'}
-                </span>
-              </div>
-              <div className="wb-page-item-slug">/p/{page.slug}</div>
-              <div className="wb-page-item-meta">
-                <span className="wb-page-item-stat">👁 {page.view_count ?? 0} views</span>
-                <span className="wb-page-item-stat">📝 {page.submission_count ?? 0} submissions</span>
-              </div>
-              <div className="wb-page-item-actions">
-                <button
-                  className="wb-page-item-action edit"
-                  onClick={e => { e.stopPropagation(); selectPage(page); }}
-                >
-                  Edit
-                </button>
-                <button
-                  className="wb-page-item-action copy"
-                  onClick={e => {
-                    e.stopPropagation();
-                    const url = `https://recruit.perenniaai.com/p/${page.slug}`;
-                    navigator.clipboard.writeText(url).then(() => showToast('URL copied!')).catch(() => showToast(url));
-                  }}
-                >
-                  Copy Link
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
+            <div className="wb-page-slug">recruit.perenniaai.com/{page.slug}</div>
+          </div>
+        ))}
       </div>
 
-      {/* ── Main editor ── */}
-      <div className="wb-main">
-        {!selectedPage ? (
-          <div className="wb-empty-state">
-            <div className="wb-empty-state-icon">🌐</div>
-            <h3>No page selected</h3>
-            <p>Select a landing page from the list to edit it, or create a new one.</p>
-            <button className="wb-create-btn" onClick={() => { setShowCreateModal(true); setNewTitle(''); setNewSlug(''); }}>
-              + Create First Page
-            </button>
+      {/* Right panel: editor */}
+      <div className="wb-editor">
+        {!selectedId ? (
+          <div className="wb-no-selection">
+            <p>Select a page to edit or create a new one.</p>
           </div>
         ) : (
           <>
-            <div className="wb-main-header">
-              <div>
-                <div className="wb-main-header-title">{selectedPage.title}</div>
-                <div className="wb-main-header-slug">/p/{selectedPage.slug}</div>
+            {/* Action bar */}
+            <div className="wb-action-bar">
+              <div className="wb-action-left">
+                <span className="wb-editing-title">{selectedPage?.title}</span>
+                {saveMsg && <span className="wb-save-msg">{saveMsg}</span>}
+                {error && <span className="wb-error-msg">{error}</span>}
               </div>
-              <span className={`wb-badge ${isPublished ? 'published' : 'draft'}`}>
-                {isPublished ? '● Published' : '○ Draft'}
-              </span>
+              <div className="wb-action-right">
+                <button className="wb-btn wb-btn-ghost" onClick={previewPage}>Preview</button>
+                <button className="wb-btn wb-btn-ghost" onClick={copyUrl}>Copy URL</button>
+                <button className="wb-btn wb-btn-secondary" onClick={saveDraft} disabled={saving}>
+                  Save Draft
+                </button>
+                {isPublished ? (
+                  <button className="wb-btn wb-btn-warning" onClick={unpublishPage} disabled={saving}>
+                    Unpublish
+                  </button>
+                ) : (
+                  <button className="wb-btn wb-btn-primary" onClick={publishPage} disabled={saving}>
+                    Publish
+                  </button>
+                )}
+                <button className="wb-btn wb-btn-danger" onClick={deletePage}>Delete</button>
+              </div>
             </div>
 
             {/* Tabs */}
             <div className="wb-tabs">
-              {TABS.map(t => (
+              {TABS.map((tab) => (
                 <button
-                  key={t.id}
-                  className={`wb-tab${activeTab === t.id ? ' active' : ''}`}
-                  onClick={() => setActiveTab(t.id)}
+                  key={tab.id}
+                  className={`wb-tab${activeTab === tab.id ? ' active' : ''}`}
+                  onClick={() => setActiveTab(tab.id)}
                 >
-                  {t.label}
+                  {tab.label}
                 </button>
               ))}
             </div>
@@ -360,273 +317,215 @@ export default function WebsiteBuilder() {
             {/* Tab content */}
             <div className="wb-tab-content">
               {activeTab === 'branding' && (
-                <BrandingTab config={formConfig} setField={setField} onColorChange={handleColorChange} />
+                <BrandingTab config={config} onChange={handleConfigChange} />
               )}
               {activeTab === 'copy' && (
-                <CopyTab config={formConfig} setField={setField} />
+                <CopyTab config={config} onChange={handleConfigChange} />
               )}
               {activeTab === 'earnings' && (
-                <EarningsTab config={formConfig} setField={setField} />
+                <EarningsTab config={config} onChange={handleConfigChange} />
               )}
               {activeTab === 'stats' && (
-                <StatsTab config={formConfig} setField={setField} />
+                <StatsTab config={config} onChange={handleConfigChange} />
               )}
               {activeTab === 'contact' && (
-                <ContactTab config={formConfig} setField={setField} />
+                <ContactTab config={config} onChange={handleConfigChange} />
               )}
-            </div>
-
-            {/* Action bar */}
-            <div className="wb-action-bar">
-              <button className="wb-btn danger" onClick={deletePage} disabled={saving} title="Delete page">
-                🗑
-              </button>
-              <div className="spacer" />
-              <button className="wb-btn draft" onClick={saveDraft} disabled={saving}>
-                {saving ? 'Saving…' : 'Save Draft'}
-              </button>
-              <button className={`wb-btn ${isPublished ? 'unpublish' : 'publish'}`} onClick={togglePublish} disabled={saving}>
-                {isPublished ? 'Unpublish' : 'Publish'}
-              </button>
-              <button className="wb-btn preview" onClick={openPreview}>
-                Preview ↗
-              </button>
-              <button className="wb-btn copy-url" onClick={copyPublicUrl}>
-                Copy URL
-              </button>
             </div>
           </>
         )}
       </div>
 
-      {/* ── Create Modal ── */}
-      {showCreateModal && (
-        <div className="wb-modal-overlay" onClick={() => setShowCreateModal(false)}>
-          <div className="wb-modal" onClick={e => e.stopPropagation()}>
-            <div className="wb-modal-title">New Landing Page</div>
-            <div className="wb-modal-desc">Create a new recruitment landing page to run ad campaigns to.</div>
-
-            <div className="wb-modal-template-note">
-              🌱 <strong>Default template:</strong> Uses the CMG careers template with placeholder values. Customize the copy after creating.
-            </div>
-
+      {/* Create modal */}
+      {showCreate && (
+        <div className="wb-modal-overlay" onClick={() => setShowCreate(false)}>
+          <div className="wb-modal" onClick={(e) => e.stopPropagation()}>
+            <h3>Create Landing Page</h3>
             <div className="wb-form-group">
-              <label className="wb-label">Page Title</label>
+              <label>Page Title</label>
               <input
                 className="wb-input"
-                placeholder="e.g. Charleston Careers — Summer Hiring"
-                value={newTitle}
-                onChange={e => handleNewTitleChange(e.target.value)}
-                autoFocus
+                placeholder="e.g. Call Center – Charleston"
+                value={createForm.title}
+                onChange={(e) => setCreateForm((f) => ({
+                  ...f,
+                  title: e.target.value,
+                  slug: slugify(e.target.value),
+                }))}
               />
             </div>
-
             <div className="wb-form-group">
-              <label className="wb-label">
-                URL Slug
-                <span className="wb-label-hint">recruit.perenniaai.com/p/<strong>{newSlug || 'your-slug'}</strong></span>
-              </label>
+              <label>URL Slug</label>
+              <div className="wb-slug-preview">recruit.perenniaai.com/<strong>{createForm.slug || 'your-slug'}</strong></div>
               <input
                 className="wb-input"
-                placeholder="charleston-careers-summer"
-                value={newSlug}
-                onChange={e => setNewSlug(toSlug(e.target.value))}
+                placeholder="e.g. callcenter"
+                value={createForm.slug}
+                onChange={(e) => setCreateForm((f) => ({ ...f, slug: slugify(e.target.value) }))}
               />
             </div>
-
+            {error && <div className="wb-error-msg">{error}</div>}
             <div className="wb-modal-actions">
-              <button className="wb-modal-cancel" onClick={() => setShowCreateModal(false)}>Cancel</button>
-              <button
-                className="wb-modal-create"
-                onClick={createPage}
-                disabled={creating || !newTitle.trim() || !newSlug.trim()}
-              >
-                {creating ? 'Creating…' : 'Create Page'}
+              <button className="wb-btn wb-btn-ghost" onClick={() => { setShowCreate(false); setError(''); }}>
+                Cancel
+              </button>
+              <button className="wb-btn wb-btn-primary" onClick={createPage}
+                disabled={!createForm.title || !createForm.slug}>
+                Create
               </button>
             </div>
           </div>
         </div>
       )}
-
-      {/* ── Toast ── */}
-      {toast && <div className="wb-toast">{toast}</div>}
     </div>
   );
 }
 
-/* ── Tab components ── */
+// ─── Tab components ──────────────────────────────────────────────────────────
 
-function Field({ label, hint, children }) {
+function Field({ label, value, onChange, type = 'text', hint }) {
   return (
     <div className="wb-form-group">
-      <label className="wb-label">
-        {label}
-        {hint && <span className="wb-label-hint">{hint}</span>}
-      </label>
-      {children}
+      <label>{label}</label>
+      <input
+        className="wb-input"
+        type={type}
+        value={value || ''}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {hint && <div className="wb-hint">{hint}</div>}
     </div>
   );
 }
 
-function BrandingTab({ config, setField, onColorChange }) {
+function BrandingTab({ config, onChange }) {
   return (
-    <>
-      <div className="wb-section-label">Identity</div>
-      <div className="wb-form-row">
-        <Field label="Page Title">
-          <input className="wb-input" value={config.page_title || ''} onChange={e => setField('page_title', e.target.value)} placeholder="Careers — Apply Now" />
-        </Field>
-        <Field label="Company Name">
-          <input className="wb-input" value={config.company_name || ''} onChange={e => setField('company_name', e.target.value)} placeholder="CMG Home Loans" />
-        </Field>
-      </div>
-
-      <Field label="Logo URL" hint="Leave blank to use the default CMG SVG logo">
-        <input className="wb-input" value={config.logo_url || ''} onChange={e => setField('logo_url', e.target.value)} placeholder="https://example.com/logo.svg" />
-      </Field>
-
-      <div className="wb-section-label" style={{ marginTop: 20 }}>Colors</div>
-
-      <Field label="Primary Color">
-        <div className="wb-color-row">
-          <input
-            type="color"
-            className="wb-color-swatch"
-            value={config.primary_color || '#6AAA26'}
-            onChange={e => onColorChange(e.target.value)}
-          />
-          <input
-            className="wb-input wb-color-hex"
-            value={config.primary_color || '#6AAA26'}
-            onChange={e => onColorChange(e.target.value)}
-            placeholder="#6AAA26"
-          />
-        </div>
-      </Field>
-
-      <div className="wb-form-row">
-        <Field label="Primary Dark" hint="Auto-derived, or override">
-          <input className="wb-input" value={config.primary_color_dark || ''} onChange={e => setField('primary_color_dark', e.target.value)} placeholder="#578F1E" />
-        </Field>
-        <Field label="Primary Pale" hint="Auto-derived, or override">
-          <input className="wb-input" value={config.primary_color_pale || ''} onChange={e => setField('primary_color_pale', e.target.value)} placeholder="#EFF7E1" />
-        </Field>
-      </div>
-    </>
-  );
-}
-
-function CopyTab({ config, setField }) {
-  return (
-    <>
-      <div className="wb-section-label">Location & Hero</div>
-      <Field label="Location Display">
-        <input className="wb-input" value={config.location_display || ''} onChange={e => setField('location_display', e.target.value)} placeholder="Charleston & Columbia, SC" />
-      </Field>
-
-      <Field label="Hero Headline" hint="HTML allowed: <span class='red'>text</span>, <span class='italic'>text</span>, <br>">
-        <textarea className="wb-textarea" rows={4} value={config.hero_headline || ''} onChange={e => setField('hero_headline', e.target.value)} placeholder='Build a <span class="red">six-figure</span><br>mortgage career' />
-      </Field>
-
-      <Field label="Hero Subheadline">
-        <textarea className="wb-textarea" rows={3} value={config.hero_subheadline || ''} onChange={e => setField('hero_subheadline', e.target.value)} placeholder="No mortgage experience required…" />
-      </Field>
-
-      <div className="wb-section-label" style={{ marginTop: 20 }}>Signing Bonus</div>
-      <div className="wb-form-row">
-        <Field label="Bonus Amount">
-          <input className="wb-input" value={config.signing_bonus || ''} onChange={e => setField('signing_bonus', e.target.value)} placeholder="$2,500" />
-        </Field>
-        <Field label="Bonus Month">
-          <input className="wb-input" value={config.signing_bonus_month || ''} onChange={e => setField('signing_bonus_month', e.target.value)} placeholder="July" />
-        </Field>
-      </div>
-      <Field label="Application Deadline">
-        <input className="wb-input" value={config.signing_bonus_deadline || ''} onChange={e => setField('signing_bonus_deadline', e.target.value)} placeholder="July 31st" />
-      </Field>
-    </>
-  );
-}
-
-function EarningsTab({ config, setField }) {
-  return (
-    <>
-      <div className="wb-section-label">On-Target Earnings</div>
-      <div className="wb-form-row">
-        <Field label="Year 1 Range">
-          <input className="wb-input" value={config.year1_range || ''} onChange={e => setField('year1_range', e.target.value)} placeholder="$65–90K" />
-        </Field>
-        <Field label="Year 2 Top Performer">
-          <input className="wb-input" value={config.year2_top || ''} onChange={e => setField('year2_top', e.target.value)} placeholder="$120,000+" />
-        </Field>
-      </div>
-      <div className="wb-form-row">
-        <Field label="Senior Loan Officer">
-          <input className="wb-input" value={config.senior_lo || ''} onChange={e => setField('senior_lo', e.target.value)} placeholder="$180,000+" />
-        </Field>
-        <Field label="Team Lead / Branch Mgr">
-          <input className="wb-input" value={config.team_lead || ''} onChange={e => setField('team_lead', e.target.value)} placeholder="$250,000+" />
-        </Field>
-      </div>
-    </>
-  );
-}
-
-function StatsTab({ config, setField }) {
-  const stats = [1, 2, 3, 4];
-  return (
-    <>
-      <div className="wb-section-label">Hero Stats Bar</div>
-      {stats.map(n => (
-        <div key={n} className="wb-stat-row">
-          <div>
-            <div className="wb-stat-row-label">Stat {n} — Number</div>
-            <input className="wb-input" value={config[`stat_${n}_num`] || ''} onChange={e => setField(`stat_${n}_num`, e.target.value)} placeholder={n === 1 ? '2,400+' : n === 2 ? '94%' : n === 3 ? '4.97 ★' : '8 Weeks'} />
+    <div className="wb-tab-section">
+      <h4>Brand Colors</h4>
+      <div className="wb-color-row">
+        <div className="wb-form-group">
+          <label>Primary Color</label>
+          <div className="wb-color-input-wrap">
+            <input type="color" className="wb-color-picker" value={config.primary_color || '#6AAA26'}
+              onChange={(e) => onChange('primary_color', e.target.value)} />
+            <input className="wb-input wb-color-text" value={config.primary_color || ''}
+              onChange={(e) => onChange('primary_color', e.target.value)} />
           </div>
-          <div>
-            <div className="wb-stat-row-label">Stat {n} — Label</div>
-            <input className="wb-input" value={config[`stat_${n}_label`] || ''} onChange={e => setField(`stat_${n}_label`, e.target.value)} placeholder={n === 1 ? 'Loans closed last year' : n === 2 ? 'Employees promoted within 18 months' : n === 3 ? 'Team borrower rating' : 'Fully paid training program'} />
-          </div>
+          <div className="wb-hint">Dark and pale variants auto-calculated</div>
         </div>
-      ))}
-    </>
+        <div className="wb-form-group">
+          <label>Dark Variant</label>
+          <input className="wb-input" value={config.primary_color_dark || ''} readOnly />
+        </div>
+        <div className="wb-form-group">
+          <label>Pale Variant</label>
+          <input className="wb-input" value={config.primary_color_pale || ''} readOnly />
+        </div>
+      </div>
+
+      <div className="wb-color-preview">
+        <div className="wb-swatch" style={{ background: config.primary_color }}>Primary</div>
+        <div className="wb-swatch" style={{ background: config.primary_color_dark }}>Dark</div>
+        <div className="wb-swatch" style={{ background: config.primary_color_pale, color: '#333' }}>Pale</div>
+      </div>
+
+      <h4>Company</h4>
+      <Field label="Company Name" value={config.company_name} onChange={(v) => onChange('company_name', v)} />
+      <Field label="Company NMLS ID" value={config.company_nmls_id} onChange={(v) => onChange('company_nmls_id', v)} />
+    </div>
   );
 }
 
-function ContactTab({ config, setField }) {
+function CopyTab({ config, onChange }) {
   return (
-    <>
-      <div className="wb-section-label">Manager / Leadership</div>
-      <div className="wb-form-row">
-        <Field label="Initials">
-          <input className="wb-input" value={config.manager_initials || ''} onChange={e => setField('manager_initials', e.target.value)} placeholder="TL" />
-        </Field>
-        <Field label="Full Name">
-          <input className="wb-input" value={config.manager_name || ''} onChange={e => setField('manager_name', e.target.value)} placeholder="Tim Loss" />
-        </Field>
+    <div className="wb-tab-section">
+      <Field label="Location Display" value={config.location_display}
+        onChange={(v) => onChange('location_display', v)}
+        hint="e.g. Charleston & Columbia, SC" />
+      <div className="wb-form-group">
+        <label>Hero Headline (HTML allowed)</label>
+        <textarea className="wb-input wb-textarea" value={config.hero_headline || ''}
+          onChange={(e) => onChange('hero_headline', e.target.value)} rows={3} />
+        <div className="wb-hint">Use &lt;span class="red"&gt;text&lt;/span&gt; for accent color</div>
       </div>
-      <Field label="Title Line">
-        <input className="wb-input" value={config.manager_title || ''} onChange={e => setField('manager_title', e.target.value)} placeholder="Branch Manager · CMG Home Loans · NMLS# 187037" />
-      </Field>
-      <Field label="NMLS #">
-        <input className="wb-input" value={config.manager_nmls || ''} onChange={e => setField('manager_nmls', e.target.value)} placeholder="187037" />
-      </Field>
+      <Field label="Hero Headline (plain text, for page title)"
+        value={config.hero_headline_plain}
+        onChange={(v) => onChange('hero_headline_plain', v)} />
+      <Field label="Signing Bonus Text" value={config.signing_bonus}
+        onChange={(v) => onChange('signing_bonus', v)}
+        hint="Shown as hero checklist item" />
+      <Field label="Signing Bonus Amount" value={config.signing_bonus_amount}
+        onChange={(v) => onChange('signing_bonus_amount', v)}
+        hint="e.g. $2,500 — shown in earnings table" />
+    </div>
+  );
+}
 
-      <div className="wb-section-label" style={{ marginTop: 20 }}>Branch Contact</div>
-      <div className="wb-form-row">
-        <Field label="Phone Display">
-          <input className="wb-input" value={config.contact_phone_display || ''} onChange={e => setField('contact_phone_display', e.target.value)} placeholder="(843) 834-4997" />
-        </Field>
-        <Field label="Phone (tel: href)">
-          <input className="wb-input" value={config.contact_phone_tel || ''} onChange={e => setField('contact_phone_tel', e.target.value)} placeholder="+18438344997" />
-        </Field>
+function EarningsTab({ config, onChange }) {
+  return (
+    <div className="wb-tab-section">
+      <h4>Earnings Figures</h4>
+      <Field label="Year 1 OTE" value={config.year1_range}
+        onChange={(v) => onChange('year1_range', v)} hint="e.g. $65–90K" />
+      <Field label="Year 2 Top Performer" value={config.year2_top}
+        onChange={(v) => onChange('year2_top', v)} hint="e.g. $120,000+" />
+      <Field label="Senior LO" value={config.senior_lo}
+        onChange={(v) => onChange('senior_lo', v)} hint="e.g. $180,000+" />
+      <Field label="Team Lead / Manager" value={config.team_lead}
+        onChange={(v) => onChange('team_lead', v)} hint="e.g. $250,000+" />
+    </div>
+  );
+}
+
+function StatsTab({ config, onChange }) {
+  return (
+    <div className="wb-tab-section">
+      <h4>Hero Stats (shown below the headline)</h4>
+      <div className="wb-stat-row">
+        <Field label="Stat 1 Number" value={config.stat_1_num} onChange={(v) => onChange('stat_1_num', v)} />
+        <Field label="Stat 1 Label" value={config.stat_1_label} onChange={(v) => onChange('stat_1_label', v)} />
       </div>
-      <Field label="Branch Address">
-        <input className="wb-input" value={config.branch_address || ''} onChange={e => setField('branch_address', e.target.value)} placeholder="975 Johnnie Dodds Blvd. Suite A, Mt. Pleasant, SC 29464" />
-      </Field>
-      <Field label="Branch NMLS #">
-        <input className="wb-input" value={config.branch_nmls || ''} onChange={e => setField('branch_nmls', e.target.value)} placeholder="1594871" />
-      </Field>
-    </>
+      <div className="wb-stat-row">
+        <Field label="Stat 2 Number" value={config.stat_2_num} onChange={(v) => onChange('stat_2_num', v)} />
+        <Field label="Stat 2 Label" value={config.stat_2_label} onChange={(v) => onChange('stat_2_label', v)} />
+      </div>
+      <div className="wb-stat-row">
+        <Field label="Stat 3 Number" value={config.stat_3_num} onChange={(v) => onChange('stat_3_num', v)} />
+        <Field label="Stat 3 Label" value={config.stat_3_label} onChange={(v) => onChange('stat_3_label', v)} />
+      </div>
+      <div className="wb-stat-row">
+        <Field label="Stat 4 Number" value={config.stat_4_num} onChange={(v) => onChange('stat_4_num', v)} />
+        <Field label="Stat 4 Label" value={config.stat_4_label} onChange={(v) => onChange('stat_4_label', v)} />
+      </div>
+    </div>
+  );
+}
+
+function ContactTab({ config, onChange }) {
+  return (
+    <div className="wb-tab-section">
+      <h4>Hiring Manager</h4>
+      <Field label="Manager Name" value={config.manager_name}
+        onChange={(v) => onChange('manager_name', v)} />
+      <Field label="Manager Initials" value={config.manager_initials}
+        onChange={(v) => onChange('manager_initials', v)}
+        hint="Auto-calculated from name, or override" />
+      <Field label="Manager Title" value={config.manager_title}
+        onChange={(v) => onChange('manager_title', v)} hint="e.g. Branch Manager · CMG, Mt. Pleasant SC" />
+      <Field label="Manager NMLS#" value={config.manager_nmls}
+        onChange={(v) => onChange('manager_nmls', v)} />
+
+      <h4>Branch Contact</h4>
+      <Field label="Phone Display" value={config.contact_phone_display}
+        onChange={(v) => onChange('contact_phone_display', v)} hint="e.g. (843) 834-4997" />
+      <Field label="Phone (tel: href)" value={config.contact_phone_tel}
+        onChange={(v) => onChange('contact_phone_tel', v)} hint="e.g. +18438344997" />
+      <Field label="Branch Name" value={config.branch_name}
+        onChange={(v) => onChange('branch_name', v)} />
+      <Field label="Branch Address" value={config.branch_address}
+        onChange={(v) => onChange('branch_address', v)} />
+      <Field label="Branch NMLS#" value={config.branch_nmls}
+        onChange={(v) => onChange('branch_nmls', v)} />
+    </div>
   );
 }

--- a/frontend/src/routes/index.jsx
+++ b/frontend/src/routes/index.jsx
@@ -911,13 +911,19 @@ export function getRoutes(layoutProps, options = {}) {
     }>
       <Route path="dashboard" element={<Suspense fallback={<PageLoader />}><RecruitDashboard /></Suspense>} />
       <Route path="jobs" element={<Suspense fallback={<PageLoader />}><RecruitJobs /></Suspense>} />
+      <Route path="knowledge-base" element={<Suspense fallback={<PageLoader />}><KnowledgeBase /></Suspense>} />
+      <Route path="embed-settings" element={<Suspense fallback={<PageLoader />}><EmbedSettings /></Suspense>} />
+      <Route path="website-builder" element={<Suspense fallback={<PageLoader />}><WebsiteBuilder /></Suspense>} />
       <Route path="license-manager" element={<Suspense fallback={<PageLoader />}><LicenseManager /></Suspense>} />
       <Route path="website-builder" element={<Suspense fallback={<PageLoader />}><RecruitWebsiteBuilder /></Suspense>} />
       <Route path="knowledge-base" element={<Suspense fallback={<PageLoader />}><RecruitKnowledgeBase /></Suspense>} />
       <Route path="chat-widget" element={<Suspense fallback={<PageLoader />}><RecruitChatWidget /></Suspense>} />
       <Route path="embed-settings" element={<Suspense fallback={<PageLoader />}><RecruitEmbedSettings /></Suspense>} />
     </Route>,
-    <Route key="/recruit/jobs/public/:orgSlug" path="/recruit/jobs/public/:orgSlug" element={
+    <Route key="/recruit/chat-widget/:tenantSlug" path="/recruit/chat-widget/:tenantSlug" element={
+      <Suspense fallback={<PageLoader />}><RecruitChatWidget /></Suspense>
+    } />,
+    <Route key="/recruit/jobs-public/:orgSlug" path="/recruit/jobs-public/:orgSlug" element={
       <Suspense fallback={<PageLoader />}><RecruitJobsPublic /></Suspense>
     } />,
     <Route key="/recruit/login" path="/recruit/login" element={

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -35,6 +35,10 @@
       "destination": "https://api.perenniaai.com/api/:path*"
     },
     {
+      "source": "/:slug([a-z0-9][a-z0-9-]*)",
+      "destination": "https://api.perenniaai.com/api/v1/recruit-platform/p/:slug"
+    },
+    {
       "source": "/((?!api|token|static|_next|favicon.ico|aria-test\\.html).*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary

- **Chatbot / Knowledge Base**: LangGraph 3-node orchestrator, pgvector RAG, PDF/DOCX/TXT upload, embed widget at `/recruit/chat-widget/:slug`
- **Website Builder**: two-panel editor with 5 tabs (Branding, Copy, Earnings, Stats, Contact); server-side HTML template rendering with 30 configurable variables
- **Landing pages**: full CRUD API + public `/p/{slug}` endpoint; form submissions sync as applicants into CRM
- **Clean URLs**: `recruit.perenniaai.com/callcenter` (no `/p/` prefix) via Vercel rewrite `/:slug → /api/v1/recruit-platform/p/:slug`
- **Nav**: Knowledge Base, Embed & Share, Website Builder added to RecruitLayout sidebar

## DNS step required (manual)
Add `recruit.perenniaai.com` as a domain alias in Vercel project settings, then add a CNAME DNS record `recruit` → Vercel's generated hostname.

## Test plan
- [ ] Create a landing page in Website Builder, publish it, visit `recruit.perenniaai.com/<slug>`
- [ ] Submit the application form — verify applicant appears in pipeline
- [ ] Upload a PDF to Knowledge Base, test chat widget response quality
- [ ] Verify embed code generates correctly in Embed & Share tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)